### PR TITLE
Make sure to fail the conformance test on the first failure

### DIFF
--- a/conformance/test-conformance.sh
+++ b/conformance/test-conformance.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 if [ -z "$CONF_TEST_PATH" ]; then
     echo "Need to set CONF_TEST_PATH to conformance-test-runner"
     exit 1


### PR DESCRIPTION
Without the `set -e`, the conformance script would only report failure
if the last test in the script failed. It ignored failures from all
earlier tests.