### PR TITLE
Publish pbandk on Bintray

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ executors:
       # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
       TERM: dumb
+      GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
 
   nodejs:
     docker:
@@ -19,6 +20,7 @@ executors:
   native:
     docker:
       - image: cimg/base:2020.01
+
 
 commands:
 
@@ -43,19 +45,9 @@ commands:
             export CONF_TEST_PATH=~/protobuf/conformance/conformance-test-runner
             ./conformance/test-conformance.sh << parameters.target >>
 
-jobs:
 
-  build:
-    executor:
-      name: jvm
-
+  restore_gradle_cache:
     steps:
-      - checkout
-
-      - run:
-          name: Install Kotlin/Native compiler dependencies
-          command: sudo apt update && sudo apt install libncurses5
-
       - run:
           name: Collect files for dependencies cache key
           command: |
@@ -70,6 +62,33 @@ jobs:
             - v2-dependencies-{{ checksum "/tmp/circleci_cache_key" }}
             # fallback to using the latest cache if no exact match is found
             - v2-dependencies-
+
+
+  save_gradle_cache:
+    steps:
+      - save_cache:
+          name: Save dependencies cache
+          paths:
+            - ~/.gradle
+            - ~/.konan
+          key: v2-dependencies-{{ checksum "/tmp/circleci_cache_key" }}
+          when: always
+
+
+jobs:
+
+  build:
+    executor:
+      name: jvm
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install Kotlin/Native compiler dependencies
+          command: sudo apt update && sudo apt install libncurses5
+
+      - restore_gradle_cache
 
       - run: ./gradlew build
 
@@ -105,8 +124,6 @@ jobs:
           name: Ensure bundled types are up-to-date
           command: |
             export PATH="$PATH:$HOME/protobuf/install/bin"
-            # need to stop the gradle daemon from the earlier step so it can pick up the new PATH value
-            ./gradlew --stop
             ./gradlew -Dprotoc.path=$HOME/protobuf/install \
               :runtime:generateWellKnownTypes \
               :runtime:generateTestTypes \
@@ -152,13 +169,7 @@ jobs:
             - conformance/native/build/bin/linux/conformanceReleaseExecutable/conformance.kexe
             - conformance/native/failing_tests.txt
 
-      - save_cache:
-          name: Save dependencies cache
-          paths:
-            - ~/.gradle
-            - ~/.konan
-          key: v2-dependencies-{{ checksum "/tmp/circleci_cache_key" }}
-          when: always
+      - save_gradle_cache
 
 
   conformance_jvm:
@@ -169,6 +180,7 @@ jobs:
       - conformance_test:
           target: jvm
 
+
   conformance_js:
     executor:
       name: nodejs
@@ -177,6 +189,7 @@ jobs:
       - conformance_test:
           target: js
 
+
   conformance_native:
     executor:
       name: native
@@ -184,6 +197,7 @@ jobs:
     steps:
       - conformance_test:
           target: linux
+
 
   build_examples:
     executor:
@@ -234,20 +248,58 @@ jobs:
           when: always
 
 
+  publish:
+    executor:
+      name: jvm
+
+    steps:
+      - checkout
+      - restore_gradle_cache
+      - run: ./gradlew clean publishToBintrayRepository
+      - save_gradle_cache
+
+
 workflows:
   version: 2.1
   build:
     jobs:
-      - build
+      - build:
+          filters:
+            tags:
+              only: /.*/
       - conformance_jvm:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
       - conformance_js:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
       - conformance_native:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
       - build_examples:
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
+      - publish:
+          requires:
+            - build
+            - conformance_jvm
+            - conformance_js
+            - conformance_native
+            - build_examples
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+(\.[0-9]+)+([-+].+)*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,8 @@
 *.iml
-/gradle.properties
 .gradle
 .idea
 build
 local.properties
-node_modules
-package-lock.json
-/examples/browser-js/src/main/kotlin/pbandk/examples/browserjs/pb
 /failing_tests.txt
 /nonexistent_tests.txt
 /succeeding_tests.txt

--- a/README.md
+++ b/README.md
@@ -305,39 +305,35 @@ protoc \
 ### Runtime Library
 
 Pbandk's runtime library is a thin layer over the preferred Protobuf library for each platform. The libraries are
-present on [JitPack](https://jitpack.io/#streem/pbandk). Using Gradle, add the JitPack repository:
+present on JCenter. Using Gradle:
 
 ```
 repositories {
-    maven { url 'https://jitpack.io' }
+    jcenter()
 }
-```
 
-Then the dependency can be added for JVM libraries:
-
-```
 dependencies {
-    implementation 'com.github.streem.pbandk:pbandk-runtime-jvm:0.9.0-SNAPSHOT'
+    // For the `common` sourceset in a Kotlin Multiplatform project:
+    implementation("pro.streem.pbandk:pbandk-runtime-common:0.9.0-SNAPSHOT")
+
+    // For Kotlin/JVM sourcesets/projects:
+    implementation("pro.streem.pbandk:pbandk-runtime-jvm:0.9.0-SNAPSHOT")
+
+    // For Kotlin/JS sourcesets/projects:
+    implementation("pro.streem.pbandk:pbandk-runtime-js:0.9.0-SNAPSHOT")
+
+    // For Kotlin/Native sourcesets/projects:
+    implementation("pro.streem.pbandk:pbandk-runtime-native:0.9.0-SNAPSHOT")
 }
 ```
 
-or for the Native libraries:
-
-```
-dependencies {
-    implementation "com.github.streem.pbandk:pbandk-runtime-native:0.9.0-SNAPSHOT
-}
-```
-
-It has a dependency on the Google Protobuf Java library. The code targets Java 1.6 to be Android friendly. For Kotlin
-JS, change `pbandk-runtime-jvm` to `pbandk-runtime-js` and for common multiplatform code, change `pbandk-runtime-jvm` to
-`pbandk-runtime-common`.
+It has a dependency on the Google Protobuf Java library. The code targets Java 1.6 to be Android friendly.
 
 In addition, support for [Kotlin's `@OptIn` annotation](https://kotlinlang.org/docs/reference/opt-in-requirements.html)
 should be enabled in order to avoid compiler warnings in the generated code:
 
 ```
-tasks.withType<KotlinCompile>().all {
+tasks.withType<KotlinCompile>().configureEach {
     kotlinOptions.freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
 }
 ```
@@ -353,7 +349,7 @@ runtime:
 
 ```
 dependencies {
-    compileOnly 'com.github.streem.pbandk:protoc-gen-kotlin-lib-jvm:0.9.0-SNAPSHOT'
+    compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib-jvm:0.9.0-SNAPSHOT")
 }
 ```
 
@@ -547,6 +543,19 @@ Then, from the root directory:
 ```
 ./conformance/test-conformance.sh
 ```
+
+## Releasing
+
+Releases are handled automatically via CI. To create a new release:
+
+1. Update the pbandk version number in `gradle.properties`, `README.md`, and `examples/*/build.gradle.kts` to remove the `SNAPSHOT` suffix. For example, if the current version is `0.9.0-SNAPSHOT`, then update it to be `0.9.0`.
+1. Commit the change. E.g.: `git commit -m "Bump to 0.9.0" -a`.
+1. Tag the new version. E.g.: `git tag -a v0.9.0`. Include the release notes for this version in the tag's description. See one of the previous tags for examples.
+1. Increment the pbandk version number in the files from step 1 to the next minor release and add the `SNAPSHOT` suffix. For example, if the tag was created for version `0.9.0`, then the new version should be `0.9.1-SNAPSHOT`.
+1. Commit the change. E.g.: `git commit -m "Bump to 0.9.1-SNAPSHOT" -a`.
+1. Push the changes to GitHub: `git push origin --follow-tags master`.
+1. Wait for CI to notice the new tag, build it, and upload it to Bintray.
+1. Create a new release on GitHub. Use the contents of the tag description as the release description. E.g.: `hub release create -F <(git tag -l --format='%(contents)' v0.9.0) v0.9.0`.
 
 ## Credits
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,9 +22,6 @@ configure<ApiValidationExtension> {
 }
 
 allprojects {
-    group = "com.github.streem.pbandk"
-    version = "0.9.0-SNAPSHOT"
-
     repositories {
         jcenter()
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -5,3 +5,7 @@ plugins {
 repositories {
     jcenter()
 }
+
+dependencies {
+    implementation("com.google.guava:guava:28.0-jre")
+}

--- a/buildSrc/src/main/kotlin/addBintrayRepository.kt
+++ b/buildSrc/src/main/kotlin/addBintrayRepository.kt
@@ -1,0 +1,55 @@
+import com.google.common.base.CaseFormat
+import org.gradle.api.Project
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.api.publish.maven.tasks.PublishToMavenRepository
+import org.gradle.kotlin.dsl.withType
+import java.net.URI
+
+fun PublishingExtension.addBintrayRepository(project: Project, publication: MavenPublication) {
+    val bintrayApiUser = project.providers.gradleProperty("bintrayApiUser")
+        .orElse(project.providers.environmentVariable("BINTRAY_API_USER"))
+    val bintrayApiKey = project.providers.gradleProperty("bintrayApiKey")
+        .orElse(project.providers.environmentVariable("BINTRAY_API_KEY"))
+    if (!bintrayApiUser.isPresent || !bintrayApiKey.isPresent) {
+        project.logger.info("Bintray API key not defined, skipping configuration of Bintray maven publishing repository")
+        return
+    }
+
+    val camelCaseArtifactId = CaseFormat.LOWER_HYPHEN.to(CaseFormat.UPPER_CAMEL, publication.artifactId)
+
+    val mavenRepo = repositories.maven {
+        name = "bintray$camelCaseArtifactId"
+
+        val bintrayUser = "streem"
+        val bintrayRepo = "pbandk"
+        val bintrayPackage = "${publication.groupId}:${publication.artifactId}"
+        url = URI("https://api.bintray.com/maven/$bintrayUser/$bintrayRepo/$bintrayPackage/;publish=1")
+
+        credentials {
+            username = bintrayApiUser.get()
+            password = bintrayApiKey.get()
+        }
+    }
+
+    val publishToBintrayRepository = project.tasks.maybeCreate("publishToBintrayRepository").apply {
+        group = "publishing"
+        description = "Publishes all Maven publications to the Bintray Maven repositories."
+    }
+
+    project.tasks.withType<PublishToMavenRepository>()
+        .matching { it.repository == mavenRepo }
+        .all {
+            // Bintray does not support publishing snapshot versions
+            if (this.publication.version.contains("SNAPSHOT")
+                // Each Bintray "repository" will only contain a single package
+                || this.publication.artifactId != publication.artifactId
+            ) {
+                enabled = false
+                // Blank out the task group so that this task doesn't show up in the `gradlew tasks` list by default
+                group = ""
+            } else {
+                publishToBintrayRepository.dependsOn(this)
+            }
+        }
+}

--- a/examples/browser-js/app/build.gradle.kts
+++ b/examples/browser-js/app/build.gradle.kts
@@ -7,7 +7,7 @@ val protobufjsVersion = "^6.8.8"
 
 dependencies {
     implementation(kotlin("stdlib-js"))
-    implementation("com.github.streem.pbandk:pbandk-runtime-js:$pbandkVersion")
+    implementation("pro.streem.pbandk:pbandk-runtime-js:$pbandkVersion")
     implementation(npm("protobufjs", protobufjsVersion))
 }
 

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -7,10 +7,9 @@ val pbandkVersion by extra("0.9.0-SNAPSHOT")
 
 subprojects {
     repositories {
-        jcenter()
         if (System.getenv("CI") == "true") {
             mavenLocal()
         }
-        maven("https://jitpack.io")
+        jcenter()
     }
 }

--- a/examples/browser-js/lib-proto/build.gradle.kts
+++ b/examples/browser-js/lib-proto/build.gradle.kts
@@ -19,7 +19,7 @@ protobuf {
     }
     plugins {
         id("kotlin") {
-            artifact = "com.github.streem.pbandk:protoc-gen-kotlin-jvm:$pbandkVersion:jvm8@jar"
+            artifact = "pro.streem.pbandk:protoc-gen-kotlin-jvm:$pbandkVersion:jvm8@jar"
         }
     }
     generateProtoTasks {

--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -19,7 +19,7 @@ application {
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    implementation("com.github.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
+    implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
 }
 
 protobuf {
@@ -29,7 +29,7 @@ protobuf {
     }
     plugins {
         id("kotlin") {
-            artifact = "com.github.streem.pbandk:protoc-gen-kotlin-jvm:$pbandkVersion:jvm8@jar"
+            artifact = "pro.streem.pbandk:protoc-gen-kotlin-jvm:$pbandkVersion:jvm8@jar"
         }
     }
     generateProtoTasks {

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -9,11 +9,10 @@ val pbandkVersion by extra("0.9.0-SNAPSHOT")
 
 subprojects {
     repositories {
-        jcenter()
         if (System.getenv("CI") == "true") {
             mavenLocal()
         }
-        maven("https://jitpack.io")
+        jcenter()
     }
 
     tasks.withType<KotlinCompile>().configureEach {

--- a/examples/custom-service-gen/generator/build.gradle.kts
+++ b/examples/custom-service-gen/generator/build.gradle.kts
@@ -6,6 +6,6 @@ val pbandkVersion: String by rootProject.extra
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    compileOnly("com.github.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
-    compileOnly("com.github.streem.pbandk:protoc-gen-kotlin-lib-jvm:$pbandkVersion")
+    compileOnly("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
+    compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib-jvm:$pbandkVersion")
 }

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -11,11 +11,10 @@ val protobufVersion by extra("3.11.1")
 val pbandkVersion by extra("0.9.0-SNAPSHOT")
 
 repositories {
-    jcenter()
     if (System.getenv("CI") == "true") {
         mavenLocal()
     }
-    maven("https://jitpack.io")
+    jcenter()
 }
 
 application {
@@ -25,7 +24,7 @@ application {
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation("com.github.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
+    implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
 }
 
 protobuf {
@@ -35,7 +34,7 @@ protobuf {
     }
     plugins {
         id("kotlin") {
-            artifact = "com.github.streem.pbandk:protoc-gen-kotlin-jvm:$pbandkVersion:jvm8@jar"
+            artifact = "pro.streem.pbandk:protoc-gen-kotlin-jvm:$pbandkVersion:jvm8@jar"
         }
     }
     generateProtoTasks {
@@ -46,7 +45,6 @@ protobuf {
             task.plugins {
                 id("kotlin") {
                     option("kotlin_package=pbandk.examples.addressbook.pb")
-//                    option("json_support=false")
                 }
             }
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,9 @@
+group=pro.streem.pbandk
+version=0.9.0-SNAPSHOT
+
+kotlin.code.style=official
+org.gradle.caching=true
+
+# Workaround because Bintray doesn't support *.sha256 and *.sha512 checksum
+# files yet. See https://github.com/gradle/gradle/issues/11412 for details.
+systemProp.org.gradle.internal.publish.checksums.insecure=true

--- a/protoc-gen-kotlin/jvm/build.gradle.kts
+++ b/protoc-gen-kotlin/jvm/build.gradle.kts
@@ -35,6 +35,8 @@ publishing {
             pom {
                 configureForPbandk()
             }
+
+            addBintrayRepository(project, this)
         }
     }
 }

--- a/protoc-gen-kotlin/lib/build.gradle.kts
+++ b/protoc-gen-kotlin/lib/build.gradle.kts
@@ -62,5 +62,6 @@ publishing {
         pom {
             configureForPbandk()
         }
+        addBintrayRepository(project, this)
     }
 }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -143,5 +143,6 @@ publishing {
         pom {
             configureForPbandk()
         }
+        addBintrayRepository(project, this)
     }
 }


### PR DESCRIPTION
- Builds are configured to be published automatically by CI whenever a git tag is created. They can also be published manually from the command line as long as the `BINTRAY_API_USER` and `BINTRAY_API_KEY` environment variaables are defined.

- The maven group name has been updated to `pro.streem.pbandk` now that we're not using Jitpack and don't need it to be tied to GitHub anymore.

- Because the Bintray gradle plugin hasn't been updated in a while and does not work correctly with Kotlin Multiplatform projects, this PR just uses the `maven-publish` gradle plugin directly.

- Also optimize build times in CI by disabling the gradle daemon and enabling the build cache.

Fixes #13 