### PR TITLE
Add JsonConfig.compactOutput option

### DIFF
--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -430,14 +430,16 @@ public final class pbandk/internal/Util : pbandk/internal/AbstractUtil {
 public final class pbandk/json/JsonConfig {
 	public static final field Companion Lpbandk/json/JsonConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZZ)V
-	public synthetic fun <init> (ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZ)V
+	public synthetic fun <init> (ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
-	public final fun copy (ZZZ)Lpbandk/json/JsonConfig;
-	public static synthetic fun copy$default (Lpbandk/json/JsonConfig;ZZZILjava/lang/Object;)Lpbandk/json/JsonConfig;
+	public final fun component4 ()Z
+	public final fun copy (ZZZZ)Lpbandk/json/JsonConfig;
+	public static synthetic fun copy$default (Lpbandk/json/JsonConfig;ZZZZILjava/lang/Object;)Lpbandk/json/JsonConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompactOutput ()Z
 	public final fun getIgnoreUnknownFieldsInInput ()Z
 	public final fun getOutputDefaultValues ()Z
 	public final fun getOutputProtoFieldNames ()Z

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty1
 internal class JsonMessageEncoder(private val jsonConfig: JsonConfig) : MessageEncoder {
     private val json = Json(
         JsonConfiguration.Stable.copy(
-            prettyPrint = true
+            prettyPrint = !jsonConfig.compactOutput
         )
     )
     private val jsonValueEncoder = JsonValueEncoder(jsonConfig)

--- a/runtime/src/commonMain/kotlin/pbandk/json/JsonConfig.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/json/JsonConfig.kt
@@ -18,6 +18,11 @@ data class JsonConfig(
      */
     val outputDefaultValues: Boolean = false,
     /**
+     * By default the JSON output is formatted for readability: entries are indented, each entry is on a new line, etc.
+     * If this option is `true` then a more compact format will be used that omits extraneous spaces and newlines.
+     */
+    val compactOutput: Boolean = false,
+    /**
      * The JSON parser rejects unknown fields by default. If this option is `true` then unknown fields will instead be
      * ignored.
      */

--- a/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
@@ -174,4 +174,16 @@ class JsonTest {
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedMessage, testAllTypesProto3)
     }
+
+    @Test
+    fun testCompactOutput() {
+        val testAllTypesProto3 = TestAllTypesProto3(
+            optionalInt32 = 123,
+            optionalBool = true
+        )
+        val json = testAllTypesProto3.encodeToJsonString()
+        assertEquals(4, json.lines().size)
+        val compactJson = testAllTypesProto3.encodeToJsonString(JsonConfig.DEFAULT.copy(compactOutput = true))
+        assertEquals(1, compactJson.lines().size)
+    }
 }


### PR DESCRIPTION
After the JSON refactor, we now default to pretty-printed JSON output to match default behavior in the official Java protobuf library. Add a `compactOutput=true` option to skip the pretty-printing and instead output the entire JSON object on a single line.