### PR TITLE
Add JsonConfig.outputDefaultStringsAsNull

### DIFF
--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -430,17 +430,19 @@ public final class pbandk/internal/Util : pbandk/internal/AbstractUtil {
 public final class pbandk/json/JsonConfig {
 	public static final field Companion Lpbandk/json/JsonConfig$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZZZ)V
-	public synthetic fun <init> (ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZZ)V
+	public synthetic fun <init> (ZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
-	public final fun copy (ZZZZ)Lpbandk/json/JsonConfig;
-	public static synthetic fun copy$default (Lpbandk/json/JsonConfig;ZZZZILjava/lang/Object;)Lpbandk/json/JsonConfig;
+	public final fun component5 ()Z
+	public final fun copy (ZZZZZ)Lpbandk/json/JsonConfig;
+	public static synthetic fun copy$default (Lpbandk/json/JsonConfig;ZZZZZILjava/lang/Object;)Lpbandk/json/JsonConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCompactOutput ()Z
 	public final fun getIgnoreUnknownFieldsInInput ()Z
+	public final fun getOutputDefaultStringsAsNull ()Z
 	public final fun getOutputDefaultValues ()Z
 	public final fun getOutputProtoFieldNames ()Z
 	public fun hashCode ()I

--- a/runtime/src/commonMain/kotlin/pbandk/json/JsonConfig.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/json/JsonConfig.kt
@@ -14,9 +14,20 @@ data class JsonConfig(
     val outputProtoFieldNames: Boolean = false,
     /**
      * Fields with default values are omitted by default in proto3 JSON output. If this option is `true` then fields
-     * will be output with their default values.
+     * will be output with their default values. See https://developers.google.com/protocol-buffers/docs/proto3#default
+     * for the default value for each type. When producing JSON output, empty `bytes` fields will be output as empty
+     * strings, and unset message fields will be output as `null`.
      */
     val outputDefaultValues: Boolean = false,
+    /**
+     * WARNING: This option should not be used. It only exists for backwards-compatibility.
+     *
+     * When [outputDefaultValues] is `true`, `string` fields set to their default value will normally be  output as
+     * empty strings in JSON. If this option is also `true`, then these fields will instead be output as `null` values
+     * in JSON. This option has no effect when [outputDefaultValues] is `false`.
+     */
+    @Deprecated("This option only exists for backwards-compatibility reasons. It should not be used by new code and will eventually be removed.")
+    val outputDefaultStringsAsNull: Boolean = false,
     /**
      * By default the JSON output is formatted for readability: entries are indented, each entry is on a new line, etc.
      * If this option is `true` then a more compact format will be used that omits extraneous spaces and newlines.

--- a/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
@@ -186,4 +186,44 @@ class JsonTest {
         val compactJson = testAllTypesProto3.encodeToJsonString(JsonConfig.DEFAULT.copy(compactOutput = true))
         assertEquals(1, compactJson.lines().size)
     }
+
+    @Test
+    fun testOutputDefaultValues_false() {
+        val jsonString = TestAllTypesProto3().encodeToJsonString(JsonConfig.DEFAULT.copy(outputDefaultValues = false))
+        val parsedJson = Json(JsonConfiguration.Stable).parseJson(jsonString).jsonObject
+        assertEquals(JsonObject(emptyMap()), parsedJson)
+    }
+
+    @Test
+    fun testOutputDefaultValues_true() {
+        val jsonString = TestAllTypesProto3(
+            optionalBoolWrapper = false
+        ).encodeToJsonString(JsonConfig.DEFAULT.copy(outputDefaultValues = true))
+        val parsedJson = Json(JsonConfiguration.Stable).parseJson(jsonString).jsonObject
+
+        assertEquals(JsonPrimitive(false), parsedJson["optionalBool"])
+        assertEquals(JsonPrimitive(0), parsedJson["optionalInt32"])
+        assertEquals(JsonPrimitive(""), parsedJson["optionalString"])
+        assertEquals(JsonPrimitive(""), parsedJson["optionalBytes"])
+        assertEquals(JsonPrimitive(TestAllTypesProto3.NestedEnum.fromValue(0).name!!), parsedJson["optionalNestedEnum"])
+
+        assertEquals(JsonNull, parsedJson["optionalNestedMessage"])
+
+        assertEquals(JsonArray(emptyList()), parsedJson["repeatedString"])
+        assertEquals(JsonObject(emptyMap()), parsedJson["mapBoolBool"])
+
+        assertEquals(JsonNull, parsedJson["optionalStringWrapper"])
+        assertEquals(JsonPrimitive(false), parsedJson["optionalBoolWrapper"])
+    }
+
+    @Test
+    fun testDefaultStringsAsNull() {
+        val jsonString = TestAllTypesProto3(
+            optionalStringWrapper = ""
+        ).encodeToJsonString(JsonConfig.DEFAULT.copy(outputDefaultValues = true, outputDefaultStringsAsNull = true))
+        val parsedJson = Json(JsonConfiguration.Stable).parseJson(jsonString).jsonObject
+        assertEquals(JsonPrimitive(false), parsedJson["optionalBool"])
+        assertEquals(JsonNull, parsedJson["optionalString"])
+        assertEquals(JsonPrimitive(""), parsedJson["optionalStringWrapper"])
+    }
 }


### PR DESCRIPTION
This will output protobuf `string` fields that contain the default value as `null` in JSON instead of `""`. We need this to preserve
backwards-compatibility in Streem's REST API.

Once pbandk supports proto3 `optional` presence, this option can probably be removed.