### PR TITLE
add json encoding tests for float and double values

### DIFF
--- a/conformance/js/failing_tests.txt
+++ b/conformance/js/failing_tests.txt
@@ -63,12 +63,6 @@ Recommended.FieldMaskPathsDontRoundTrip.JsonOutput
 Recommended.FieldMaskTooManyUnderscore.JsonOutput
 Recommended.Proto3.JsonInput.BytesFieldBase64Url.JsonOutput
 Recommended.Proto3.JsonInput.BytesFieldBase64Url.ProtobufOutput
-Recommended.Proto3.JsonInput.DoubleFieldInfinityNotQuoted
-Recommended.Proto3.JsonInput.DoubleFieldNanNotQuoted
-Recommended.Proto3.JsonInput.DoubleFieldNegativeInfinityNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldInfinityNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldNanNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldNegativeInfinityNotQuoted
 Recommended.Proto3.JsonInput.StringFieldSurrogateInWrongOrder
 Recommended.Proto3.JsonInput.StringFieldUnpairedHighSurrogate
 Recommended.Proto3.JsonInput.StringFieldUnpairedLowSurrogate
@@ -92,25 +86,11 @@ Required.Proto3.JsonInput.AnyWithValueForInteger.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForInteger.ProtobufOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.ProtobufOutput
-Required.Proto3.JsonInput.DoubleFieldTooLarge
-Required.Proto3.JsonInput.DoubleFieldTooSmall
 Required.Proto3.JsonInput.EmptyFieldMask.JsonOutput
 Required.Proto3.JsonInput.EmptyFieldMask.ProtobufOutput
 Required.Proto3.JsonInput.FieldMask.JsonOutput
 Required.Proto3.JsonInput.FieldMask.ProtobufOutput
-Required.Proto3.JsonInput.FloatFieldTooLarge
-Required.Proto3.JsonInput.FloatFieldTooSmall
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.JsonOutput
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.JsonOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.ProtobufOutput
 Required.Proto3.JsonInput.OneofFieldDuplicate
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.ProtobufOutput
 ##
 ## These failures need to be investigated
 ## See https://github.com/streem/pbandk/issues/22

--- a/conformance/jvm/failing_tests.txt
+++ b/conformance/jvm/failing_tests.txt
@@ -44,17 +44,7 @@ Required.Proto3.JsonInput.FieldMask.JsonOutput
 Required.Proto3.JsonInput.FieldMask.ProtobufOutput
 Required.Proto3.JsonInput.FloatFieldTooLarge
 Required.Proto3.JsonInput.FloatFieldTooSmall
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.JsonOutput
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.JsonOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.ProtobufOutput
 Required.Proto3.JsonInput.OneofFieldDuplicate
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.ProtobufOutput
 ##
 ## These failures need to be investigated
 ## See https://github.com/streem/pbandk/issues/22

--- a/conformance/jvm/failing_tests.txt
+++ b/conformance/jvm/failing_tests.txt
@@ -7,12 +7,6 @@ Recommended.FieldMaskPathsDontRoundTrip.JsonOutput
 Recommended.FieldMaskTooManyUnderscore.JsonOutput
 Recommended.Proto3.JsonInput.BytesFieldBase64Url.JsonOutput
 Recommended.Proto3.JsonInput.BytesFieldBase64Url.ProtobufOutput
-Recommended.Proto3.JsonInput.DoubleFieldInfinityNotQuoted
-Recommended.Proto3.JsonInput.DoubleFieldNanNotQuoted
-Recommended.Proto3.JsonInput.DoubleFieldNegativeInfinityNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldInfinityNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldNanNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldNegativeInfinityNotQuoted
 Recommended.Proto3.JsonInput.StringFieldSurrogateInWrongOrder
 Recommended.Proto3.JsonInput.StringFieldUnpairedHighSurrogate
 Recommended.Proto3.JsonInput.StringFieldUnpairedLowSurrogate
@@ -36,14 +30,10 @@ Required.Proto3.JsonInput.AnyWithValueForInteger.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForInteger.ProtobufOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.ProtobufOutput
-Required.Proto3.JsonInput.DoubleFieldTooLarge
-Required.Proto3.JsonInput.DoubleFieldTooSmall
 Required.Proto3.JsonInput.EmptyFieldMask.JsonOutput
 Required.Proto3.JsonInput.EmptyFieldMask.ProtobufOutput
 Required.Proto3.JsonInput.FieldMask.JsonOutput
 Required.Proto3.JsonInput.FieldMask.ProtobufOutput
-Required.Proto3.JsonInput.FloatFieldTooLarge
-Required.Proto3.JsonInput.FloatFieldTooSmall
 Required.Proto3.JsonInput.OneofFieldDuplicate
 ##
 ## These failures need to be investigated

--- a/conformance/native/failing_tests.txt
+++ b/conformance/native/failing_tests.txt
@@ -5,12 +5,6 @@
 Recommended.FieldMaskNumbersDontRoundTrip.JsonOutput
 Recommended.FieldMaskPathsDontRoundTrip.JsonOutput
 Recommended.FieldMaskTooManyUnderscore.JsonOutput
-Recommended.Proto3.JsonInput.DoubleFieldInfinityNotQuoted
-Recommended.Proto3.JsonInput.DoubleFieldNanNotQuoted
-Recommended.Proto3.JsonInput.DoubleFieldNegativeInfinityNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldInfinityNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldNanNotQuoted
-Recommended.Proto3.JsonInput.FloatFieldNegativeInfinityNotQuoted
 Recommended.Proto3.JsonInput.StringFieldSurrogateInWrongOrder
 Recommended.Proto3.JsonInput.StringFieldUnpairedHighSurrogate
 Recommended.Proto3.JsonInput.StringFieldUnpairedLowSurrogate
@@ -34,25 +28,11 @@ Required.Proto3.JsonInput.AnyWithValueForInteger.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForInteger.ProtobufOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.ProtobufOutput
-Required.Proto3.JsonInput.DoubleFieldTooLarge
-Required.Proto3.JsonInput.DoubleFieldTooSmall
 Required.Proto3.JsonInput.EmptyFieldMask.JsonOutput
 Required.Proto3.JsonInput.EmptyFieldMask.ProtobufOutput
 Required.Proto3.JsonInput.FieldMask.JsonOutput
 Required.Proto3.JsonInput.FieldMask.ProtobufOutput
-Required.Proto3.JsonInput.FloatFieldTooLarge
-Required.Proto3.JsonInput.FloatFieldTooSmall
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.JsonOutput
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.JsonOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.ProtobufOutput
 Required.Proto3.JsonInput.OneofFieldDuplicate
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.ProtobufOutput
 ##
 ## These failures need to be investigated
 ## See https://github.com/streem/pbandk/issues/22

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -146,7 +146,7 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
                 floatValue
             }
             (value as JsonLiteral).isString -> {
-                value.float
+                floatValue
             }
             else -> {
                 throw IllegalArgumentException("non finite values must be quoted")
@@ -163,7 +163,7 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
                 doubleValue
             }
             (value as JsonLiteral).isString -> {
-                value.double
+                doubleValue
             }
             else -> {
                 throw IllegalArgumentException("non finite values must be quoted")

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -11,6 +11,10 @@ import kotlin.Any
 internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
     private val FLOAT_MIN = -3.4028235E38F
     private val FLOAT_MAX = 3.4028235E38F
+    private val DOUBLE_MIN_POSITIVE = 2.22507e-308
+    private val DOUBLE_MAX_POSITIVE = 1.79769e+308
+    private val DOUBLE_MIN_NEGATIVE = -1.79769e+308
+    private val DOUBLE_MAX_NEGATIVE = -2.22507e-308
 
     private val numberTrailingZeroes = """\.0+$""".toRegex()
     private val numberScientificNotation = """-?(?:\d+)(\.\d+?)?0*[eE](\d+)$""".toRegex()
@@ -174,7 +178,10 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
         val doubleValue = value.double
         when {
             doubleValue.isFinite() -> {
-                if (doubleValue < Double.MIN_VALUE || doubleValue > Double.MAX_VALUE) {
+                if (doubleValue > 0.0 && (doubleValue < DOUBLE_MIN_POSITIVE|| doubleValue > DOUBLE_MAX_POSITIVE)) {
+                    throw NumberFormatException("value out of bounds")
+                }
+                if (doubleValue < 0.0 && (doubleValue < DOUBLE_MIN_NEGATIVE || doubleValue > DOUBLE_MAX_NEGATIVE)) {
                     throw NumberFormatException("value out of bounds")
                 }
 

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -9,6 +9,10 @@ import kotlin.Any
 
 @OptIn(ExperimentalUnsignedTypes::class)
 internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
+
+    val FLOAT_MIN = -3.4028235E38F
+    val FLOAT_MAX = 3.4028235E38F
+
     /**
      * Returns `null` if the value was parseable but is invalid. This currently only happens for enum fields with
      * unknown values.
@@ -143,6 +147,10 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
         val floatValue = value.float
         when {
             floatValue.isFinite() -> {
+                if (floatValue < FLOAT_MIN || floatValue > FLOAT_MAX) {
+                    throw NumberFormatException("value out of bounds")
+                }
+
                 floatValue
             }
             (value as JsonLiteral).isString -> {

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -98,7 +98,7 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
 
         body(contentWithoutTrailingZero)
     } catch (e: Exception) {
-        throw InvalidProtocolBufferException("field did not contain a number in JSON ${e.message}", e)
+        throw InvalidProtocolBufferException("field did not contain a number in JSON", e)
     }
 
     fun readInteger32(value: JsonElement, isMapKey: Boolean = false): Int =

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -140,15 +140,35 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
     }
 
     fun readFloat(value: JsonElement): Float = try {
-        // TODO handle Inf and NaN
-        value.float
+        val floatValue = value.float
+        when {
+            floatValue.isFinite() -> {
+                floatValue
+            }
+            (value as JsonLiteral).isString -> {
+                value.float
+            }
+            else -> {
+                throw IllegalArgumentException("non finite values must be quoted")
+            }
+        }
     } catch (e: Exception) {
         throw InvalidProtocolBufferException("float field did not contain a float value in JSON", e)
     }
 
     fun readDouble(value: JsonElement): Double = try {
-        // TODO handle Inf and NaN
-        value.double
+        val doubleValue = value.double
+        when {
+            doubleValue.isFinite() -> {
+                doubleValue
+            }
+            (value as JsonLiteral).isString -> {
+                value.double
+            }
+            else -> {
+                throw IllegalArgumentException("non finite values must be quoted")
+            }
+        }
     } catch (e: Exception) {
         throw InvalidProtocolBufferException("double field did not contain a double value in JSON", e)
     }

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -92,13 +92,15 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
 
         try {
             body(content)
-        } catch (e: Exception) {
+        } catch (e: NumberFormatException) {
             var contentWithoutTrailingZero = content.replace(numberTrailingZeroes, "")
             numberScientificNotation.find(contentWithoutTrailingZero)?.let {
                 val mantissaFraction = it.groupValues[1].trimStart('.')
                 val mantissaDigits = mantissaFraction.length
+                val isMantissaFractionZero = mantissaFraction.isEmpty() || mantissaFraction.toULong() == 0UL
                 val decade = it.groupValues[2].toLong()
-                if (mantissaFraction.toULong() == 0UL || decade >= mantissaDigits) {
+
+                if (isMantissaFractionZero || decade >= mantissaDigits) {
                     contentWithoutTrailingZero = contentWithoutTrailingZero.toDouble().toLong().toString()
                 }
             }

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueDecoder.kt
@@ -88,8 +88,8 @@ internal class JsonValueDecoder(private val jsonConfig: JsonConfig) {
             )
         }
 
-        val numberTrailingZeroes = "\\.0+$".toRegex()
-        val numberScientificNotation = "-?(?:\\d+)(\\.\\d+)?[eE](\\d+)$".toRegex()
+        val numberTrailingZeroes = """\.0+$""".toRegex()
+        val numberScientificNotation = """-?(?:\d+)(\.\d+)?[eE](\d+)$""".toRegex()
 
         var contentWithoutTrailingZero = content.replace(numberTrailingZeroes, "")
         numberScientificNotation.find(contentWithoutTrailingZero)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
@@ -2,12 +2,14 @@ package pbandk.json
 
 import kotlinx.serialization.json.json
 import kotlinx.serialization.json.jsonArray
+import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.TestAllTypesProto3
 import pbandk.wkt.Duration
 import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class DoubleTest {
 
@@ -106,5 +108,19 @@ class DoubleTest {
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+
+    @Test
+    fun testDoubleField_DecodeAboveMaximum() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalDouble":1.89769e+308}""")
+        }
+    }
+
+    @Test
+    fun testDoubleField_DecodeBelowMinimum() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalDouble":-1.89769e+308}""")
+        }
     }
 }

--- a/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
@@ -1,0 +1,110 @@
+package pbandk.json
+
+import kotlinx.serialization.json.json
+import kotlinx.serialization.json.jsonArray
+import pbandk.testpb.TestAllTypesProto3
+import pbandk.wkt.Duration
+import pbandk.wkt.Timestamp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class DoubleTest {
+
+    private val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
+
+    @Test
+    fun testDoubleField_EncodeFinite() {
+        val input = TestAllTypesProto3(optionalDouble = 1.1)
+
+        val expected = json { "optionalDouble" to 1.1 }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDoubleField_DecodeFinite() {
+        val json = json { "optionalDouble" to "1.1" }.toString()
+        val expectedDouble = 1.1
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+
+    @Test
+    fun testDoubleField_EncodeNaN() {
+        val input = TestAllTypesProto3(optionalDouble = Double.NaN)
+
+        val expected = json { "optionalDouble" to "NaN" }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDoubleField_DecodeNaN() {
+        val json = json { "optionalDouble" to "NaN" }.toString()
+        val expectedDouble = Double.NaN
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+
+    @Test
+    fun testDoubleField_EncodePositiveInfinity() {
+        val input = TestAllTypesProto3(optionalDouble = Double.POSITIVE_INFINITY)
+
+        val expected = json { "optionalDouble" to "Infinity" }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDoubleField_DecodePositiveInfinity() {
+        val json = json { "optionalDouble" to "Infinity" }.toString()
+        val expectedDouble = Double.POSITIVE_INFINITY
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+
+    @Test
+    fun testDoubleField_EncodeNegativeInfinity() {
+        val input = TestAllTypesProto3(optionalDouble = Double.NEGATIVE_INFINITY)
+
+        val expected = json { "optionalDouble" to "-Infinity" }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDoubleField_DecodeNegativeInfinity() {
+        val json = json { "optionalDouble" to "-Infinity" }.toString()
+        val expectedDouble = Double.NEGATIVE_INFINITY
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+
+    @Test
+    fun testDoubleField_EncodeExponentialNotation() {
+        val input = TestAllTypesProto3(optionalDouble = 2e-12)
+
+        val expected = json { "optionalDouble" to 2e-12 }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testDoubleField_DecodeExponentialNotation() {
+        val json = json { "optionalDouble" to "2e-12" }.toString()
+        val expectedDouble = 2e-12
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+}

--- a/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
@@ -35,6 +35,24 @@ class DoubleTest {
     }
 
     @Test
+    fun testDoubleField_DecodeMinNegative() {
+        val json = json { "optionalDouble" to "-2.22507e-308" }.toString()
+        val expectedDouble = -2.22507e-308
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.optionalDouble)
+    }
+
+    @Test
+    fun testOneOfDoubleField_Zero() {
+        val json = json { "oneofDouble" to 0.0 }.toString()
+        val expectedDouble = 0.0
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedDouble, testAllTypesProto3.oneofDouble)
+    }
+
+    @Test
     fun testDoubleField_EncodeNaN() {
         val input = TestAllTypesProto3(optionalDouble = Double.NaN)
 

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -130,4 +130,32 @@ class FloatTest {
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
     }
+
+    @Test
+    fun testFloatField_DecodeAboveMaximum() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":3.502823e+38}""")
+        }
+    }
+
+    @Test
+    fun testFloatField_DecodeBelowMinimum() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":-3.502823e+38}""")
+        }
+    }
+
+    @Test
+    fun testDoubleField_DecodeAboveMaximum() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalDouble":1.89769e+308}""")
+        }
+    }
+
+    @Test
+    fun testDoubleField_DecodeBelowMinimum() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalDouble":-1.89769e+308}""")
+        }
+    }
 }

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -1,0 +1,110 @@
+package pbandk.json
+
+import kotlinx.serialization.json.json
+import kotlinx.serialization.json.jsonArray
+import pbandk.testpb.TestAllTypesProto3
+import pbandk.wkt.Duration
+import pbandk.wkt.Timestamp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+class FloatTest {
+
+    private val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
+
+    @Test
+    fun testFloatField_EncodeFinite() {
+        val input = TestAllTypesProto3(optionalFloat = 1.1F)
+
+        val expected = json { "optionalFloat" to 1.1F }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testFloatField_DecodeFinite() {
+        val json = json { "optionalFloat" to "1.1" }.toString()
+        val expectedFloat = 1.1F
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
+    }
+
+    @Test
+    fun testFloatField_EncodeNaN() {
+        val input = TestAllTypesProto3(optionalFloat = Float.NaN)
+
+        val expected = json { "optionalFloat" to "NaN" }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testFloatField_DecodeNaN() {
+        val json = json { "optionalFloat" to "NaN" }.toString()
+        val expectedFloat = Float.NaN
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
+    }
+
+    @Test
+    fun testFloatField_EncodePositiveInfinity() {
+        val input = TestAllTypesProto3(optionalFloat = Float.POSITIVE_INFINITY)
+
+        val expected = json { "optionalFloat" to "Infinity" }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testFloatField_DecodePositiveInfinity() {
+        val json = json { "optionalFloat" to "Infinity" }.toString()
+        val expectedFloat = Float.POSITIVE_INFINITY
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
+    }
+
+    @Test
+    fun testFloatField_EncodeNegativeInfinity() {
+        val input = TestAllTypesProto3(optionalFloat = Float.NEGATIVE_INFINITY)
+
+        val expected = json { "optionalFloat" to "-Infinity" }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testFloatField_DecodeNegativeInfinity() {
+        val json = json { "optionalFloat" to "-Infinity" }.toString()
+        val expectedFloat = Float.NEGATIVE_INFINITY
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
+    }
+
+    @Test
+    fun testFloatField_EncodeExponentialNotation() {
+        val input = TestAllTypesProto3(optionalFloat = 2e-12F)
+
+        val expected = json { "optionalFloat" to 2e-12F }.toString()
+        val actual = input.encodeToJsonString(jsonConfig)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun testFloatField_DecodeExponentialNotation() {
+        val json = json { "optionalFloat" to "2e-12" }.toString()
+        val expectedFloat = 2e-12F
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
+    }
+}

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -139,6 +139,13 @@ class FloatTest {
     }
 
     @Test
+    fun testFloatField_DecodeAboveMaximumString() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":"3.502823e+38"}""")
+        }
+    }
+
+    @Test
     fun testFloatField_DecodeBelowMinimum() {
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":-3.502823e+38}""")

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -144,18 +144,4 @@ class FloatTest {
             TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":-3.502823e+38}""")
         }
     }
-
-    @Test
-    fun testDoubleField_DecodeAboveMaximum() {
-        assertFailsWith<InvalidProtocolBufferException> {
-            TestAllTypesProto3.decodeFromJsonString("""{"optionalDouble":1.89769e+308}""")
-        }
-    }
-
-    @Test
-    fun testDoubleField_DecodeBelowMinimum() {
-        assertFailsWith<InvalidProtocolBufferException> {
-            TestAllTypesProto3.decodeFromJsonString("""{"optionalDouble":-1.89769e+308}""")
-        }
-    }
 }

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -113,7 +113,7 @@ class FloatTest {
     }
 
     @Test
-    fun testFloatField_EncodeExponentialNotation() {
+    fun testFloatField_EncodeExponentNotation() {
         val input = TestAllTypesProto3(optionalFloat = 2e-12F)
 
         val expected = json { "optionalFloat" to 2e-12F }.toString()
@@ -123,7 +123,7 @@ class FloatTest {
     }
 
     @Test
-    fun testFloatField_DecodeExponentialNotation() {
+    fun testFloatField_DecodeExponentNotation() {
         val json = json { "optionalFloat" to "2e-12" }.toString()
         val expectedFloat = 2e-12F
 

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -2,12 +2,14 @@ package pbandk.json
 
 import kotlinx.serialization.json.json
 import kotlinx.serialization.json.jsonArray
+import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.TestAllTypesProto3
 import pbandk.wkt.Duration
 import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
 
 class FloatTest {
 
@@ -52,6 +54,13 @@ class FloatTest {
     }
 
     @Test
+    fun testFloatField_DecodeNaNUnquoted() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":NaN}""")
+        }
+    }
+
+    @Test
     fun testFloatField_EncodePositiveInfinity() {
         val input = TestAllTypesProto3(optionalFloat = Float.POSITIVE_INFINITY)
 
@@ -71,6 +80,13 @@ class FloatTest {
     }
 
     @Test
+    fun testFloatField_DecodePositiveInfinityUnquoted() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":Infinity}""")
+        }
+    }
+
+    @Test
     fun testFloatField_EncodeNegativeInfinity() {
         val input = TestAllTypesProto3(optionalFloat = Float.NEGATIVE_INFINITY)
 
@@ -87,6 +103,13 @@ class FloatTest {
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedFloat, testAllTypesProto3.optionalFloat)
+    }
+
+    @Test
+    fun testFloatField_DecodeNegativeInfinityUnquoted() {
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString("""{"optionalFloat":-Infinity}""")
+        }
     }
 
     @Test

--- a/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
@@ -65,8 +65,17 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_PassesOnValidFloatTrailingZero() {
-        val json = json { "optionalInt32" to "-1.200e1" }.toString()
-        val expectedInt = -12
+        val json = json { "optionalInt32" to "-1.200e2" }.toString()
+        val expectedInt = -120
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
+    fun testInt32Field_DecodeExponentNotation_PassesOnValidIntTrailingZero() {
+        val json = json { "optionalInt32" to "-1.000e0" }.toString()
+        val expectedInt = -1
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedInt, testAllTypesProto3.optionalInt32)

--- a/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
@@ -1,19 +1,13 @@
 package pbandk.json
 
 import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
 import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.TestAllTypesProto3
-import pbandk.wkt.Duration
-import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class IntTest {
-
-    private val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
 
     @Test
     fun testInt32Field_DecodeTrailingZero_PassesOnValidNumber() {
@@ -70,8 +64,44 @@ class IntTest {
     }
 
     @Test
+    fun testInt32Field_DecodeExponentNotation_PassesOnValidFloatTrailingZero() {
+        val json = json { "optionalInt32" to "-1.200e1" }.toString()
+        val expectedInt = -12
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
     fun testInt32Field_DecodeExponentNotation_FailsOnInvalidNumber() {
         val json = json { "optionalInt32" to "1e2e2" }.toString()
+
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString(json)
+        }
+    }
+
+    @Test
+    fun testInt32Field_DecodeMinFloatValue_Success() {
+        val json = json { "optionalInt32" to "-2.147483648e9" }.toString()
+        val expectedInt = -2147483648
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
+    fun testInt64Field_DecodeFieldTooLarge_Fails() {
+        val json = json { "optionalInt64" to "9223372036854775808" }.toString()
+
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString(json)
+        }
+    }
+
+    @Test
+    fun testUInt64Field_DecodeFieldTooLarge_Fails() {
+        val json = json { "optionalUint64" to "18446744073709551616" }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString(json)

--- a/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
-class IntegerTest {
+class IntTest {
 
     private val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
 
@@ -43,7 +43,7 @@ class IntegerTest {
     }
 
     @Test
-    fun testInt32Field_DecodeScientificNotation_PassesOnValidNumber() {
+    fun testInt32Field_DecodeExponentNotation_PassesOnValidNumber() {
         val json = json { "optionalInt32" to "1e0" }.toString()
         val expectedInt = 1
 
@@ -52,7 +52,7 @@ class IntegerTest {
     }
 
     @Test
-    fun testInt32Field_DecodeScientificNotation_PassesOnValidNumberCapitalized() {
+    fun testInt32Field_DecodeExponentNotation_PassesOnValidNumberCapitalized() {
         val json = json { "optionalInt32" to "1E2" }.toString()
         val expectedInt = 100
 
@@ -61,7 +61,7 @@ class IntegerTest {
     }
 
     @Test
-    fun testInt32Field_DecodeScientificNotation_PassesOnValidFloat() {
+    fun testInt32Field_DecodeExponentNotation_PassesOnValidFloat() {
         val json = json { "optionalInt32" to "-1.2e1" }.toString()
         val expectedInt = -12
 
@@ -70,7 +70,7 @@ class IntegerTest {
     }
 
     @Test
-    fun testInt32Field_DecodeScientificNotation_FailsOnInvalidNumber() {
+    fun testInt32Field_DecodeExponentNotation_FailsOnInvalidNumber() {
         val json = json { "optionalInt32" to "1e2e2" }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {

--- a/runtime/src/commonTest/kotlin/pbandk/json/IntegerTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/IntegerTest.kt
@@ -1,0 +1,80 @@
+package pbandk.json
+
+import kotlinx.serialization.json.json
+import kotlinx.serialization.json.jsonArray
+import pbandk.InvalidProtocolBufferException
+import pbandk.testpb.TestAllTypesProto3
+import pbandk.wkt.Duration
+import pbandk.wkt.Timestamp
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+import kotlin.test.assertFailsWith
+
+class IntegerTest {
+
+    private val jsonConfig = JsonConfig.DEFAULT.copy(compactOutput = true)
+
+    @Test
+    fun testInt32Field_DecodeTrailingZero_PassesOnValidNumber() {
+        val json = json { "optionalInt32" to "1.00" }.toString()
+        val expectedInt = 1
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
+    fun testInt32Field_DecodeTrailingZero_FailsOnFloat() {
+        val json = json { "optionalInt32" to "1.10" }.toString()
+
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString(json)
+        }
+    }
+
+    @Test
+    fun testInt32Field_DecodeTrailingZero_FailsOnInvalidNumber() {
+        val json = json { "optionalInt32" to "1.00.00" }.toString()
+
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString(json)
+        }
+    }
+
+    @Test
+    fun testInt32Field_DecodeScientificNotation_PassesOnValidNumber() {
+        val json = json { "optionalInt32" to "1e0" }.toString()
+        val expectedInt = 1
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
+    fun testInt32Field_DecodeScientificNotation_PassesOnValidNumberCapitalized() {
+        val json = json { "optionalInt32" to "1E2" }.toString()
+        val expectedInt = 100
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
+    fun testInt32Field_DecodeScientificNotation_PassesOnValidFloat() {
+        val json = json { "optionalInt32" to "-1.2e1" }.toString()
+        val expectedInt = -12
+
+        val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
+        assertEquals(expectedInt, testAllTypesProto3.optionalInt32)
+    }
+
+    @Test
+    fun testInt32Field_DecodeScientificNotation_FailsOnInvalidNumber() {
+        val json = json { "optionalInt32" to "1e2e2" }.toString()
+
+        assertFailsWith<InvalidProtocolBufferException> {
+            TestAllTypesProto3.decodeFromJsonString(json)
+        }
+    }
+}


### PR DESCRIPTION
As per #72 and https://developers.google.com/protocol-buffers/docs/proto3#json

float/double values are already able to be parsed from/to `NaN`, `Infinity` and `-Infinity` through current serialization

>  exponent notation and floating-point numbers for unmarshalling numeric types: 1e5, 100000.000, 2.147483647e9, -2.147483648e9, 4.294967295e9