### PR TITLE
Clarify how to run conformance tests on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,14 @@ Then, from the root directory:
 ./conformance/test-conformance.sh
 ```
 
+Note that by default, the `test-conformance.sh` script will run the conformance test for `jvm`, `js` and `linux`. This will fail when running them on `MacOS` due to missing linux binaries. So in that case, run the tests for each platform individually:
+
+```
+./conformance/test-conformance.sh jvm
+./conformance/test-conformance.sh js
+./conformance/test-conformance.sh macos
+```
+
 ## Releasing
 
 Releases are handled automatically via CI. To create a new release:


### PR DESCRIPTION
Following issue https://github.com/streem/pbandk/issues/106 , I've updated the instructions to run conformance tests to clarify how they can be run on MacOS.