### PR TITLE
Update to kotlin 1.4.21

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,6 @@ configure<ApiValidationExtension> {
 allprojects {
     repositories {
         jcenter()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
     }
 
     tasks.withType<AbstractTestTask> {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,8 +1,8 @@
 object Versions {
     const val binaryCompatibilityValidatorGradlePlugin = "0.2.3"
-    const val kotlin = "1.4.20-M2"
-    const val kotlinCoroutines = "1.3.9"
-    const val kotlinSerialization = "1.0.0"
+    const val kotlin = "1.4.21"
+    const val kotlinCoroutines = "1.4.1"
+    const val kotlinSerialization = "1.0.1"
     const val protobufJava = "3.11.1"
     const val protobufJs = "6.10.1"
     const val springBootGradlePlugin = "2.3.4.RELEASE"

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -11,6 +11,5 @@ subprojects {
             mavenLocal()
         }
         jcenter()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
     }
 }

--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -17,7 +17,6 @@ application {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
 }

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -13,7 +13,6 @@ subprojects {
             mavenLocal()
         }
         jcenter()
-        maven("https://dl.bintray.com/kotlin/kotlin-eap")
     }
 
     tasks.withType<KotlinCompile>().configureEach {

--- a/examples/custom-service-gen/generator/build.gradle.kts
+++ b/examples/custom-service-gen/generator/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 val pbandkVersion: String by rootProject.extra
 
 dependencies {
-    implementation(kotlin("stdlib"))
     compileOnly("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
     compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib-jvm:$pbandkVersion")
 }

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -23,7 +23,6 @@ application {
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
     implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
 }
 

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -15,7 +15,6 @@ repositories {
         mavenLocal()
     }
     jcenter()
-    maven("https://dl.bintray.com/kotlin/kotlin-eap")
 }
 
 application {

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,7 +9,6 @@ pluginManagement {
     repositories {
         jcenter()
         gradlePluginPortal()
-        maven { url "https://dl.bintray.com/kotlin/kotlin-eap" }
     }
 }
 


### PR DESCRIPTION
Updated the existing `kotlin-1.4` branch with:

- latest version of `Kotlin`, `Coroutines` and `Serialization`
- remove `EAP` repositories
- remove `Kotlin stdlib` definitions

I verified this PR by :

- running all conformance tests for jvm, js and macos
- building the code generator using the two gradle commands provided in the readme
- building the runtime library

I didn't publish a build to a local maven repository and run the sample apps using that.

Happy to receive feedback on whether I'm following the right procedures.