### PR TITLE
Update to Kotlin 1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+* Updated to Kotlin 1.4. Projects that are still on Kotlin 1.3 should be able to continue using pbandk, but this configuration is only supported on a best-effort basis (please file a GitHub issue with any problems). Projects are encouraged to update to Kotlin 1.4. (PR [#114], fixes [#86])
 * **[BREAKING CHANGE]** The API and implementation of `UnknownField` changed significantly. If you access the contents of unknown fields in your code, you will need to update to the new API. The unknown field no longer provides access to a decoded version of the field's wire type. Instead it only provides access to the raw binary encoding of the field. (PR [#103])
 
 ### Fixed
@@ -28,7 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Binary decoding of 64-bit numbers under Kotlin/JS with certain inputs that would previously cause a crash. (PR [#103])
 
 [#65]: https://github.com/streem/pbandk/issues/65
+[#86]: https://github.com/streem/pbandk/issues/86
 [#103]: https://github.com/streem/pbandk/pull/103
+[#114]: https://github.com/streem/pbandk/pull/114
 
 
 ## [0.9.1] - Unreleased

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,9 +1,9 @@
 object Versions {
     const val binaryCompatibilityValidatorGradlePlugin = "0.2.3"
-    const val kotlin = "1.3.72"
-    const val kotlinCoroutines = "1.3.5"
-    const val kotlinSerialization = "0.20.0"
+    const val kotlin = "1.4.21"
+    const val kotlinCoroutines = "1.4.2"
+    const val kotlinSerialization = "1.0.1"
     const val protobufJava = "3.11.1"
-    const val protobufJs = "6.8.8"
-    const val springBootGradlePlugin = "2.2.6.RELEASE"
+    const val protobufJs = "6.10.2"
+    const val springBootGradlePlugin = "2.3.7.RELEASE"
 }

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -24,18 +24,6 @@ kotlin {
     // Uncomment to enable Windows
     // mingwX64("windows")
 
-    targets.withType<KotlinNativeTarget> {
-        val main by compilations.getting {
-            defaultSourceSet {
-                kotlin.srcDir("src/nativeMain/kotlin")
-            }
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-native:${Versions.kotlinCoroutines}")
-            }
-        }
-    }
-
     sourceSets {
         all {
             languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
@@ -43,9 +31,8 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
                 implementation(project(":runtime"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-common:${Versions.kotlinCoroutines}")
+                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
             }
         }
 
@@ -53,13 +40,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-            }
-        }
-
-        val jvmMain by getting {
-            dependencies {
-                implementation(kotlin("stdlib-jdk8"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
             }
         }
 
@@ -71,16 +51,22 @@ kotlin {
             }
         }
 
-        val jsMain by getting {
-            dependencies {
-                implementation(kotlin("stdlib-js"))
-                implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core-js:${Versions.kotlinCoroutines}")
-            }
-        }
-
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))
+            }
+        }
+
+        val nativeMain by creating {
+            dependsOn(commonMain)
+        }
+    }
+
+    targets.withType<KotlinNativeTarget> {
+        val main by compilations.getting {
+            defaultSourceSet {
+                val nativeMain by sourceSets.getting
+                dependsOn(nativeMain)
             }
         }
     }
@@ -94,7 +80,7 @@ tasks {
         logLevel.set("debug")
     }
 
-    // DCE is now enable by default in Kotlin 1.3.7x
+    // DCE is now enabled by default in Kotlin 1.3.7x
     // and it doesn't work well with commonJS modules
     // Use of commonJs could be removed since default module is now UMD
     // but would require some code change

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/Main.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/Main.kt
@@ -16,7 +16,7 @@ inline fun debug(fn: () -> String) {
     if (logDebug) Platform.stderrPrintln(fn())
 }
 
-fun main(args: Array<String>) = runBlockingMain {
+fun main() = runBlockingMain {
     debug { "Starting conformance test" }
     while (true) {
         val res = doTestIo().also { debug { "Result: $it" } } ?: return@runBlockingMain

--- a/conformance/native/build.gradle.kts
+++ b/conformance/native/build.gradle.kts
@@ -11,13 +11,16 @@ kotlin {
     targets.withType<KotlinNativeTarget> {
         binaries {
             executable("conformance")
+            configureEach {
+                // See https://youtrack.jetbrains.com/issue/KT-44148
+                freeCompilerArgs += "-Xdisable-phases=EscapeAnalysis"
+            }
         }
     }
 
     sourceSets {
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
                 api(project(":conformance:conformance-lib"))
             }
         }

--- a/conformance/native/src/commonMain/kotlin/Main.kt
+++ b/conformance/native/src/commonMain/kotlin/Main.kt
@@ -1,1 +1,1 @@
-fun main() = pbandk.conformance.main(emptyArray())
+fun main() = pbandk.conformance.main()

--- a/examples/browser-js/app/build.gradle.kts
+++ b/examples/browser-js/app/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 val pbandkVersion: String by rootProject.extra
-val protobufjsVersion = "^6.8.8"
+val protobufjsVersion = "^6.10.2"
 
 dependencies {
     implementation(kotlin("stdlib-js"))
@@ -34,4 +34,17 @@ tasks {
     project(":lib-proto").tasks
         .matching { it.name == "generateProto" }
         .all { compileKotlinJs.get().dependsOn(this) }
+}
+
+// This is required for consuming a Kotlin/JS library compiled with Kotlin 1.4
+// from a Kotlin 1.3 project. See https://youtrack.jetbrains.com/issue/KT-40226
+// for details.
+private class KotlinJsCompilerDisambiguationRule : AttributeDisambiguationRule<String> {
+    override fun execute(details: MultipleCandidatesDetails<String>) {
+        details.closestMatch("legacy")
+    }
+}
+val jsCompilerAttr = Attribute.of("org.jetbrains.kotlin.js.compiler", String::class.java)
+project.dependencies.attributesSchema.attribute(jsCompilerAttr) {
+    disambiguationRules.add(KotlinJsCompilerDisambiguationRule::class.java)
 }

--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -17,7 +17,6 @@ application {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
 }

--- a/examples/custom-service-gen/application/src/main/kotlin/pbandk/examples/greeter/pb/helloworld.kt
+++ b/examples/custom-service-gen/application/src/main/kotlin/pbandk/examples/greeter/pb/helloworld.kt
@@ -9,12 +9,13 @@ data class HelloRequest(
     override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
     override val descriptor get() = Companion.descriptor
     override val protoSize by lazy { super.protoSize }
-    companion object : pbandk.Message.Companion<HelloRequest> {
-        val defaultInstance by lazy { HelloRequest() }
-        override fun decodeWith(u: pbandk.MessageDecoder) = HelloRequest.decodeWithImpl(u)
+    companion object : pbandk.Message.Companion<pbandk.examples.greeter.pb.HelloRequest> {
+        val defaultInstance by lazy { pbandk.examples.greeter.pb.HelloRequest() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = pbandk.examples.greeter.pb.HelloRequest.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<HelloRequest> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<HelloRequest, *>>(1).apply {
+        override val descriptor: pbandk.MessageDescriptor<pbandk.examples.greeter.pb.HelloRequest> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.examples.greeter.pb.HelloRequest, *>>(1)
+            fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -22,12 +23,12 @@ data class HelloRequest(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "name",
-                        value = HelloRequest::name
+                        value = pbandk.examples.greeter.pb.HelloRequest::name
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                messageClass = HelloRequest::class,
+                messageClass = pbandk.examples.greeter.pb.HelloRequest::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -42,12 +43,13 @@ data class HelloReply(
     override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
     override val descriptor get() = Companion.descriptor
     override val protoSize by lazy { super.protoSize }
-    companion object : pbandk.Message.Companion<HelloReply> {
-        val defaultInstance by lazy { HelloReply() }
-        override fun decodeWith(u: pbandk.MessageDecoder) = HelloReply.decodeWithImpl(u)
+    companion object : pbandk.Message.Companion<pbandk.examples.greeter.pb.HelloReply> {
+        val defaultInstance by lazy { pbandk.examples.greeter.pb.HelloReply() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = pbandk.examples.greeter.pb.HelloReply.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<HelloReply> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<HelloReply, *>>(1).apply {
+        override val descriptor: pbandk.MessageDescriptor<pbandk.examples.greeter.pb.HelloReply> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.examples.greeter.pb.HelloReply, *>>(1)
+            fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -55,12 +57,12 @@ data class HelloReply(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "message",
-                        value = HelloReply::message
+                        value = pbandk.examples.greeter.pb.HelloReply::message
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                messageClass = HelloReply::class,
+                messageClass = pbandk.examples.greeter.pb.HelloReply::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -70,9 +72,11 @@ data class HelloReply(
 
 fun HelloRequest?.orDefault() = this ?: HelloRequest.defaultInstance
 
-private fun HelloRequest.protoMergeImpl(plus: pbandk.Message?): HelloRequest = (plus as? HelloRequest)?.copy(
-    unknownFields = unknownFields + plus.unknownFields
-) ?: this
+private fun HelloRequest.protoMergeImpl(plus: pbandk.Message?): HelloRequest = (plus as? HelloRequest)?.let {
+    it.copy(
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
 
 @Suppress("UNCHECKED_CAST")
 private fun HelloRequest.Companion.decodeWithImpl(u: pbandk.MessageDecoder): HelloRequest {
@@ -88,9 +92,11 @@ private fun HelloRequest.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Hel
 
 fun HelloReply?.orDefault() = this ?: HelloReply.defaultInstance
 
-private fun HelloReply.protoMergeImpl(plus: pbandk.Message?): HelloReply = (plus as? HelloReply)?.copy(
-    unknownFields = unknownFields + plus.unknownFields
-) ?: this
+private fun HelloReply.protoMergeImpl(plus: pbandk.Message?): HelloReply = (plus as? HelloReply)?.let {
+    it.copy(
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
 
 @Suppress("UNCHECKED_CAST")
 private fun HelloReply.Companion.decodeWithImpl(u: pbandk.MessageDecoder): HelloReply {

--- a/examples/custom-service-gen/generator/build.gradle.kts
+++ b/examples/custom-service-gen/generator/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 val pbandkVersion: String by rootProject.extra
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     compileOnly("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
     compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib-jvm:$pbandkVersion")
 }

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -23,7 +23,6 @@ application {
 }
 
 dependencies {
-    implementation(kotlin("stdlib-jdk8"))
     implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
 }
 

--- a/examples/gradle-and-jvm/src/main/kotlin/pbandk/examples/addressbook/pb/addressbook.kt
+++ b/examples/gradle-and-jvm/src/main/kotlin/pbandk/examples/addressbook/pb/addressbook.kt
@@ -13,12 +13,13 @@ data class Person(
     override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
     override val descriptor get() = Companion.descriptor
     override val protoSize by lazy { super.protoSize }
-    companion object : pbandk.Message.Companion<Person> {
-        val defaultInstance by lazy { Person() }
-        override fun decodeWith(u: pbandk.MessageDecoder) = Person.decodeWithImpl(u)
+    companion object : pbandk.Message.Companion<pbandk.examples.addressbook.pb.Person> {
+        val defaultInstance by lazy { pbandk.examples.addressbook.pb.Person() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = pbandk.examples.addressbook.pb.Person.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<Person> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<Person, *>>(5).apply {
+        override val descriptor: pbandk.MessageDescriptor<pbandk.examples.addressbook.pb.Person> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.examples.addressbook.pb.Person, *>>(5)
+            fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -26,7 +27,7 @@ data class Person(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "name",
-                        value = Person::name
+                        value = pbandk.examples.addressbook.pb.Person::name
                     )
                 )
                 add(
@@ -36,7 +37,7 @@ data class Person(
                         number = 2,
                         type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
                         jsonName = "id",
-                        value = Person::id
+                        value = pbandk.examples.addressbook.pb.Person::id
                     )
                 )
                 add(
@@ -46,7 +47,7 @@ data class Person(
                         number = 3,
                         type = pbandk.FieldDescriptor.Type.Primitive.String(),
                         jsonName = "email",
-                        value = Person::email
+                        value = pbandk.examples.addressbook.pb.Person::email
                     )
                 )
                 add(
@@ -56,7 +57,7 @@ data class Person(
                         number = 4,
                         type = pbandk.FieldDescriptor.Type.Repeated<pbandk.examples.addressbook.pb.Person.PhoneNumber>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.examples.addressbook.pb.Person.PhoneNumber.Companion)),
                         jsonName = "phones",
-                        value = Person::phones
+                        value = pbandk.examples.addressbook.pb.Person::phones
                     )
                 )
                 add(
@@ -66,12 +67,12 @@ data class Person(
                         number = 5,
                         type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion),
                         jsonName = "lastUpdated",
-                        value = Person::lastUpdated
+                        value = pbandk.examples.addressbook.pb.Person::lastUpdated
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                messageClass = Person::class,
+                messageClass = pbandk.examples.addressbook.pb.Person::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -79,17 +80,17 @@ data class Person(
     }
 
     sealed class PhoneType(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is Person.PhoneType && other.value == value
+        override fun equals(other: kotlin.Any?) = other is pbandk.examples.addressbook.pb.Person.PhoneType && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "Person.PhoneType.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "pbandk.examples.addressbook.pb.Person.PhoneType.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object MOBILE : PhoneType(0, "MOBILE")
         object HOME : PhoneType(1, "HOME")
         object WORK : PhoneType(2, "WORK")
-        class UNRECOGNIZED(value: Int) : Person.PhoneType(value)
+        class UNRECOGNIZED(value: Int) : pbandk.examples.addressbook.pb.Person.PhoneType(value)
 
-        companion object : pbandk.Message.Enum.Companion<Person.PhoneType> {
-            val values: List<Person.PhoneType> by lazy { listOf(MOBILE, HOME, WORK) }
+        companion object : pbandk.Message.Enum.Companion<pbandk.examples.addressbook.pb.Person.PhoneType> {
+            val values: List<pbandk.examples.addressbook.pb.Person.PhoneType> by lazy { listOf(MOBILE, HOME, WORK) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No PhoneType with name: $name")
         }
@@ -103,12 +104,13 @@ data class Person(
         override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
         override val descriptor get() = Companion.descriptor
         override val protoSize by lazy { super.protoSize }
-        companion object : pbandk.Message.Companion<Person.PhoneNumber> {
-            val defaultInstance by lazy { Person.PhoneNumber() }
-            override fun decodeWith(u: pbandk.MessageDecoder) = Person.PhoneNumber.decodeWithImpl(u)
+        companion object : pbandk.Message.Companion<pbandk.examples.addressbook.pb.Person.PhoneNumber> {
+            val defaultInstance by lazy { pbandk.examples.addressbook.pb.Person.PhoneNumber() }
+            override fun decodeWith(u: pbandk.MessageDecoder) = pbandk.examples.addressbook.pb.Person.PhoneNumber.decodeWithImpl(u)
 
-            override val descriptor: pbandk.MessageDescriptor<Person.PhoneNumber> by lazy {
-                val fieldsList = ArrayList<pbandk.FieldDescriptor<Person.PhoneNumber, *>>(2).apply {
+            override val descriptor: pbandk.MessageDescriptor<pbandk.examples.addressbook.pb.Person.PhoneNumber> by lazy {
+                val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.examples.addressbook.pb.Person.PhoneNumber, *>>(2)
+                fieldsList.apply {
                     add(
                         pbandk.FieldDescriptor(
                             messageDescriptor = this@Companion::descriptor,
@@ -116,7 +118,7 @@ data class Person(
                             number = 1,
                             type = pbandk.FieldDescriptor.Type.Primitive.String(),
                             jsonName = "number",
-                            value = Person.PhoneNumber::number
+                            value = pbandk.examples.addressbook.pb.Person.PhoneNumber::number
                         )
                     )
                     add(
@@ -126,12 +128,12 @@ data class Person(
                             number = 2,
                             type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.examples.addressbook.pb.Person.PhoneType.Companion),
                             jsonName = "type",
-                            value = Person.PhoneNumber::type
+                            value = pbandk.examples.addressbook.pb.Person.PhoneNumber::type
                         )
                     )
                 }
                 pbandk.MessageDescriptor(
-                    messageClass = Person.PhoneNumber::class,
+                    messageClass = pbandk.examples.addressbook.pb.Person.PhoneNumber::class,
                     messageCompanion = this,
                     fields = fieldsList
                 )
@@ -147,12 +149,13 @@ data class AddressBook(
     override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
     override val descriptor get() = Companion.descriptor
     override val protoSize by lazy { super.protoSize }
-    companion object : pbandk.Message.Companion<AddressBook> {
-        val defaultInstance by lazy { AddressBook() }
-        override fun decodeWith(u: pbandk.MessageDecoder) = AddressBook.decodeWithImpl(u)
+    companion object : pbandk.Message.Companion<pbandk.examples.addressbook.pb.AddressBook> {
+        val defaultInstance by lazy { pbandk.examples.addressbook.pb.AddressBook() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = pbandk.examples.addressbook.pb.AddressBook.decodeWithImpl(u)
 
-        override val descriptor: pbandk.MessageDescriptor<AddressBook> by lazy {
-            val fieldsList = ArrayList<pbandk.FieldDescriptor<AddressBook, *>>(1).apply {
+        override val descriptor: pbandk.MessageDescriptor<pbandk.examples.addressbook.pb.AddressBook> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.examples.addressbook.pb.AddressBook, *>>(1)
+            fieldsList.apply {
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -160,12 +163,12 @@ data class AddressBook(
                         number = 1,
                         type = pbandk.FieldDescriptor.Type.Repeated<pbandk.examples.addressbook.pb.Person>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.examples.addressbook.pb.Person.Companion)),
                         jsonName = "people",
-                        value = AddressBook::people
+                        value = pbandk.examples.addressbook.pb.AddressBook::people
                     )
                 )
             }
             pbandk.MessageDescriptor(
-                messageClass = AddressBook::class,
+                messageClass = pbandk.examples.addressbook.pb.AddressBook::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -175,11 +178,13 @@ data class AddressBook(
 
 fun Person?.orDefault() = this ?: Person.defaultInstance
 
-private fun Person.protoMergeImpl(plus: pbandk.Message?): Person = (plus as? Person)?.copy(
-    phones = phones + plus.phones,
-    lastUpdated = lastUpdated?.plus(plus.lastUpdated) ?: plus.lastUpdated,
-    unknownFields = unknownFields + plus.unknownFields
-) ?: this
+private fun Person.protoMergeImpl(plus: pbandk.Message?): Person = (plus as? Person)?.let {
+    it.copy(
+        phones = phones + plus.phones,
+        lastUpdated = lastUpdated?.plus(plus.lastUpdated) ?: plus.lastUpdated,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
 
 @Suppress("UNCHECKED_CAST")
 private fun Person.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Person {
@@ -204,9 +209,11 @@ private fun Person.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Person {
 
 fun Person.PhoneNumber?.orDefault() = this ?: Person.PhoneNumber.defaultInstance
 
-private fun Person.PhoneNumber.protoMergeImpl(plus: pbandk.Message?): Person.PhoneNumber = (plus as? Person.PhoneNumber)?.copy(
-    unknownFields = unknownFields + plus.unknownFields
-) ?: this
+private fun Person.PhoneNumber.protoMergeImpl(plus: pbandk.Message?): Person.PhoneNumber = (plus as? Person.PhoneNumber)?.let {
+    it.copy(
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
 
 @Suppress("UNCHECKED_CAST")
 private fun Person.PhoneNumber.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Person.PhoneNumber {
@@ -224,10 +231,12 @@ private fun Person.PhoneNumber.Companion.decodeWithImpl(u: pbandk.MessageDecoder
 
 fun AddressBook?.orDefault() = this ?: AddressBook.defaultInstance
 
-private fun AddressBook.protoMergeImpl(plus: pbandk.Message?): AddressBook = (plus as? AddressBook)?.copy(
-    people = people + plus.people,
-    unknownFields = unknownFields + plus.unknownFields
-) ?: this
+private fun AddressBook.protoMergeImpl(plus: pbandk.Message?): AddressBook = (plus as? AddressBook)?.let {
+    it.copy(
+        people = people + plus.people,
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
 
 @Suppress("UNCHECKED_CAST")
 private fun AddressBook.Companion.decodeWithImpl(u: pbandk.MessageDecoder): AddressBook {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,7 @@ group=pro.streem.pbandk
 version=0.10.0-SNAPSHOT
 
 kotlin.code.style=official
+kotlin.mpp.stability.nowarn=true
 org.gradle.caching=true
 
 # Workaround because Bintray doesn't support *.sha256 and *.sha512 checksum
@@ -11,4 +12,6 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # Gradle 6.3+ seem to require a larger metaspace size when run against this
 # project. Otherwise the build crashes with an out-of-memory error. Can be
 # removed when/if this is resolved on the gradle side.
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m
+#
+# Gradle also needs more heap space to build this project than the default 1GB.
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -Xmx2048m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/protoc-gen-kotlin/lib/build.gradle.kts
+++ b/protoc-gen-kotlin/lib/build.gradle.kts
@@ -19,7 +19,6 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
                 implementation(project(":runtime"))
             }
         }
@@ -28,12 +27,6 @@ kotlin {
             dependencies {
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
-            }
-        }
-
-        val jvmMain by getting {
-            dependencies {
-                implementation(kotlin("stdlib-jdk8"))
             }
         }
 

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -171,7 +171,7 @@ open class CodeGenerator(
         line("override val descriptor: pbandk.MessageDescriptor<$fullTypeName> by lazy {").indented {
             // XXX: When a message has lots of fields (e.g. `TestAllTypesProto3`), declaring the list of field
             // descriptors directly in the [MessageDescriptor] constructor can cause a
-            // `java.lang.OutOfMemoryError: Java heap space` error in the Kotlin compiler (as of Kotlin 1.4.10).
+            // `java.lang.OutOfMemoryError: Java heap space` error in the Kotlin compiler (as of Kotlin 1.4.20).
             // As a workaround, we generate methods to generate each fieldDescriptor in chunks, as many as needed, with
             // a max size of $chunkSize to limit the size of the methods.
             line("val fieldsList = ArrayList<pbandk.FieldDescriptor<$fullTypeName, *>>(${allFields.size})")

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -20,11 +20,11 @@ open class CodeGenerator(
         return bld.toString()
     }
 
-    protected fun line() = also { bld.append("\n") }
-    protected fun line(str: String) = also { bld.append(indent).append(str).append("\n") }
+    protected fun line() = also { bld.appendLine() }
+    protected fun line(str: String) = also { bld.append(indent).appendLine(str) }
     protected fun lineBegin(str: String = "") = also { bld.append(indent).append(str) }
     protected fun lineMid(str: String) = also { bld.append(str) }
-    protected fun lineEnd(str: String = "") = also { bld.append(str).append("\n") }
+    protected fun lineEnd(str: String = "") = also { bld.appendLine(str) }
     protected fun indented(fn: () -> Any?) = also {
         indent += "    "
         fn().also { indent = indent.dropLast(4) }

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/FileBuilder.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/FileBuilder.kt
@@ -1,7 +1,5 @@
 package pbandk.gen
 
-import pbandk.PbandkInternal
-import pbandk.internal.Util
 import pbandk.wkt.DescriptorProto
 import pbandk.wkt.EnumDescriptorProto
 import pbandk.wkt.FieldDescriptorProto
@@ -18,12 +16,11 @@ open class FileBuilder(val namer: Namer = Namer.Standard, val supportMaps: Boole
         extensions = ctx.fileDesc.extension.map { numberedFieldFromProto(ctx, it, mutableSetOf()) }
     )
 
-    @OptIn(PbandkInternal::class)
     protected fun packageName(ctx: Context) =
         ctx.params["kotlin_package"]
             ?: ctx.fileDesc.options?.uninterpretedOption?.find {
                 it.name.singleOrNull()?.namePart == "kotlin_package"
-            }?.stringValue?.array?.let(Util::utf8ToString)
+            }?.stringValue?.array?.decodeToString()
             ?: ctx.packageMappings[ctx.fileDesc.`package`]
             ?: ctx.fileDesc.options?.javaPackage?.takeIf { it.isNotEmpty() }
             ?: ctx.fileDesc.`package`?.takeIf { it.isNotEmpty() }

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/Main.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/Main.kt
@@ -6,7 +6,7 @@ import pbandk.gen.pb.CodeGeneratorResponse
 var logDebug = false
 inline fun debug(fn: () -> String) { if (logDebug) Platform.stderrPrintln(fn()) }
 
-fun main(args: Array<String>) {
+fun main() {
     Platform.stdoutWriteResponse(runGenerator(Platform.stdinReadRequest()))
 }
 

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -375,24 +375,6 @@ public final class pbandk/UnknownField$Value {
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract class pbandk/internal/AbstractUtil {
-	public fun <init> ()V
-	public fun base64ToBytes (Ljava/lang/String;)[B
-	public fun bytesToBase64 ([B)Ljava/lang/String;
-	public final fun durationToString (Lpbandk/wkt/Duration;)Ljava/lang/String;
-	public final fun stringToDuration (Ljava/lang/String;)Lpbandk/wkt/Duration;
-	public final fun stringToTimestamp (Ljava/lang/String;)Lpbandk/wkt/Timestamp;
-	public final fun timestampToString (Lpbandk/wkt/Timestamp;)Ljava/lang/String;
-}
-
-public final class pbandk/internal/Util : pbandk/internal/AbstractUtil {
-	public static final field INSTANCE Lpbandk/internal/Util;
-	public fun base64ToBytes (Ljava/lang/String;)[B
-	public fun bytesToBase64 ([B)Ljava/lang/String;
-	public final fun stringToUtf8 (Ljava/lang/String;)[B
-	public final fun utf8ToString ([B)Ljava/lang/String;
-}
-
 public final class pbandk/json/JsonConfig {
 	public static final field Companion Lpbandk/json/JsonConfig$Companion;
 	public fun <init> ()V

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -27,19 +27,7 @@ kotlin {
     macosX64()
     linuxX64()
 
-    targets.withType<KotlinNativeTarget> {
-        val main by compilations.getting {
-            defaultSourceSet {
-                kotlin.srcDir("src/nativeMain/kotlin")
-            }
-            dependencies {
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-native:${Versions.kotlinSerialization}")
-            }
-        }
-    }
-
-
-    sourceSets {
+   sourceSets {
         all {
             languageSettings.enableLanguageFeature("InlineClasses")
 
@@ -51,8 +39,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-common"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-common:${Versions.kotlinSerialization}")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:${Versions.kotlinSerialization}")
             }
         }
 
@@ -65,8 +52,6 @@ kotlin {
 
         val jvmMain by getting {
             dependencies {
-                implementation(kotlin("stdlib"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:${Versions.kotlinSerialization}")
                 api("com.google.protobuf:protobuf-java:${Versions.protobufJava}")
             }
         }
@@ -81,8 +66,6 @@ kotlin {
 
         val jsMain by getting {
             dependencies {
-                implementation(kotlin("stdlib-js"))
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime-js:${Versions.kotlinSerialization}")
                 implementation(npm("protobufjs", "^${Versions.protobufJs}"))
             }
         }
@@ -90,6 +73,19 @@ kotlin {
         val jsTest by getting {
             dependencies {
                 implementation(kotlin("test-js"))
+            }
+        }
+
+        val nativeMain by creating {
+            dependsOn(commonMain)
+        }
+    }
+
+    targets.withType<KotlinNativeTarget> {
+        val main by compilations.getting {
+            defaultSourceSet {
+                val nativeMain by sourceSets.getting
+                dependsOn(nativeMain)
             }
         }
     }
@@ -127,7 +123,7 @@ tasks {
         dependsOn(generateKotlinTestTypes, generateJavaTestTypes)
     }
 
-    // DCE is now enable by default in Kotlin 1.3.7x
+    // DCE is now enabled by default in Kotlin 1.3.7x
     // and it doesn't work well with commonJS modules
     // Use of commonJs could be removed since default module is now UMD
     // but would require some code change

--- a/runtime/src/commonMain/kotlin/pbandk/internal/AbstractUtil.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/AbstractUtil.kt
@@ -3,14 +3,14 @@ package pbandk.internal
 import pbandk.wkt.Duration
 import pbandk.wkt.Timestamp
 
-abstract class AbstractUtil {
+internal abstract class AbstractUtil {
     open fun base64ToBytes(str: String): ByteArray {
         return str.decodeBase64ToArray()
             ?: throw RuntimeException("Unable to base64-decode string: $str")
     }
 
     open fun bytesToBase64(bytes: ByteArray): String {
-        return Util.utf8ToString(bytes.encodeBase64())
+        return bytes.encodeBase64().decodeToString()
     }
 
     fun timestampToString(ts: Timestamp): String = formatTime(ts.seconds, ts.nanos)

--- a/runtime/src/commonMain/kotlin/pbandk/internal/Util.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/Util.kt
@@ -4,12 +4,7 @@ import pbandk.PbandkInternal
 import pbandk.wkt.Duration
 import pbandk.wkt.Timestamp
 
-// This is public only so that it can be used from protoc-gen-kotlin
-@PbandkInternal
-expect object Util {
-    fun stringToUtf8(str: String): ByteArray
-    fun utf8ToString(bytes: ByteArray): String
-
+internal expect object Util {
     fun base64ToBytes(str: String): ByteArray
     fun bytesToBase64(bytes: ByteArray): String
 

--- a/runtime/src/commonMain/kotlin/pbandk/internal/binary/BinaryMessageDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/binary/BinaryMessageDecoder.kt
@@ -10,26 +10,22 @@ internal fun FieldDescriptor.Type.allowedWireType(wireType: WireType) =
 
 internal val FieldDescriptor.Type.binaryReadFn: BinaryWireDecoder.() -> Any
     get() {
-        // XXX: The "useless" casts below are required in order to work around a compiler bug in Kotlin 1.3 (see
-        // https://youtrack.jetbrains.com/issue/KT-12693 and linked issues). Without the cast, the compiler crashes
-        // with an obscure error. This is supposedly fixed in Kotlin 1.4.
-        @Suppress("USELESS_CAST")
         return when (this) {
-            is FieldDescriptor.Type.Primitive.Double -> BinaryWireDecoder::readDouble as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Float -> BinaryWireDecoder::readFloat as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Int64 -> BinaryWireDecoder::readInt64 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.UInt64 -> BinaryWireDecoder::readUInt64 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Int32 -> BinaryWireDecoder::readInt32 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Fixed64 -> BinaryWireDecoder::readFixed64 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Fixed32 -> BinaryWireDecoder::readFixed32 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Bool -> BinaryWireDecoder::readBool as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.String -> BinaryWireDecoder::readString as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.Bytes -> BinaryWireDecoder::readBytes as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.UInt32 -> BinaryWireDecoder::readUInt32 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.SFixed32 -> BinaryWireDecoder::readSFixed32 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.SFixed64 -> BinaryWireDecoder::readSFixed64 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.SInt32 -> BinaryWireDecoder::readSInt32 as BinaryWireDecoder.() -> Any
-            is FieldDescriptor.Type.Primitive.SInt64 -> BinaryWireDecoder::readSInt64 as BinaryWireDecoder.() -> Any
+            is FieldDescriptor.Type.Primitive.Double -> BinaryWireDecoder::readDouble
+            is FieldDescriptor.Type.Primitive.Float -> BinaryWireDecoder::readFloat
+            is FieldDescriptor.Type.Primitive.Int64 -> BinaryWireDecoder::readInt64
+            is FieldDescriptor.Type.Primitive.UInt64 -> BinaryWireDecoder::readUInt64
+            is FieldDescriptor.Type.Primitive.Int32 -> BinaryWireDecoder::readInt32
+            is FieldDescriptor.Type.Primitive.Fixed64 -> BinaryWireDecoder::readFixed64
+            is FieldDescriptor.Type.Primitive.Fixed32 -> BinaryWireDecoder::readFixed32
+            is FieldDescriptor.Type.Primitive.Bool -> BinaryWireDecoder::readBool
+            is FieldDescriptor.Type.Primitive.String -> BinaryWireDecoder::readString
+            is FieldDescriptor.Type.Primitive.Bytes -> BinaryWireDecoder::readBytes
+            is FieldDescriptor.Type.Primitive.UInt32 -> BinaryWireDecoder::readUInt32
+            is FieldDescriptor.Type.Primitive.SFixed32 -> BinaryWireDecoder::readSFixed32
+            is FieldDescriptor.Type.Primitive.SFixed64 -> BinaryWireDecoder::readSFixed64
+            is FieldDescriptor.Type.Primitive.SInt32 -> BinaryWireDecoder::readSInt32
+            is FieldDescriptor.Type.Primitive.SInt64 -> BinaryWireDecoder::readSInt64
             is FieldDescriptor.Type.Message<*> -> when (messageCompanion) {
                 DoubleValue.Companion -> fun BinaryWireDecoder.(): Any =
                     (readMessage(this@binaryReadFn.messageCompanion) as DoubleValue).value

--- a/runtime/src/commonMain/kotlin/pbandk/internal/binary/kotlin/KotlinBinaryWireDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/binary/kotlin/KotlinBinaryWireDecoder.kt
@@ -30,7 +30,6 @@
 package pbandk.internal.binary.kotlin
 
 import pbandk.*
-import pbandk.internal.Util
 import pbandk.internal.binary.*
 import pbandk.internal.binary.BinaryMessageDecoder
 import pbandk.internal.binary.BinaryWireDecoder
@@ -237,7 +236,7 @@ internal class KotlinBinaryWireDecoder(private val wireReader: WireReader) : Bin
 
     override fun readBool(): Boolean = readRawVarint64() != 0L
 
-    override fun readString(): String = Util.utf8ToString(readBytes().array)
+    override fun readString(): String = readBytes().array.decodeToString()
 
     override fun readBytes(): ByteArr = ByteArr(readRawBytes(readRawVarint32()))
 

--- a/runtime/src/commonMain/kotlin/pbandk/internal/binary/kotlin/KotlinBinaryWireEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/binary/kotlin/KotlinBinaryWireEncoder.kt
@@ -30,7 +30,6 @@
 package pbandk.internal.binary.kotlin
 
 import pbandk.*
-import pbandk.internal.Util
 import pbandk.internal.binary.*
 import pbandk.internal.binary.BinaryWireEncoder
 import pbandk.internal.binary.WireType
@@ -238,7 +237,7 @@ internal class KotlinBinaryWireEncoder(private val wireWriter: WireWriter) : Bin
     }
 
     private fun writeStringNoTag(value: String) {
-        writeBytesNoTag(ByteArr(Util.stringToUtf8(value)))
+        writeBytesNoTag(ByteArr(value.encodeToByteArray()))
     }
 
     override fun writeString(fieldNum: Int, value: String) {

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageDecoder.kt
@@ -44,7 +44,7 @@ internal class JsonMessageDecoder internal constructor(
                     throw InvalidProtocolBufferException("Unknown field name and ignoreUnknownFieldsInInput=false: $key")
                 }
 
-            if (jsonValue.isNull) {
+            if (jsonValue is JsonNull) {
                 // JSON messages can be primitive wrappers, where null signifies a default value
                 // https://developers.google.com/protocol-buffers/docs/proto3#default
                 if (fd.type is FieldDescriptor.Type.Message<*>) {
@@ -63,8 +63,7 @@ internal class JsonMessageDecoder internal constructor(
 
     companion object {
         fun fromString(data: String, jsonConfig: JsonConfig = JsonConfig.DEFAULT): JsonMessageDecoder {
-            val json = Json(JsonConfiguration.Stable)
-            val content = json.parse(JsonElementSerializer, data)
+            val content = Json.decodeFromString(JsonElement.serializer(), data)
             return JsonMessageDecoder(content, jsonConfig)
         }
     }

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageEncoder.kt
@@ -9,15 +9,13 @@ import kotlin.Any
 import kotlin.reflect.KProperty1
 
 internal class JsonMessageEncoder(private val jsonConfig: JsonConfig) : MessageEncoder {
-    private val json = Json(
-        JsonConfiguration.Stable.copy(
-            prettyPrint = !jsonConfig.compactOutput
-        )
-    )
+    private val json = Json {
+        prettyPrint = !jsonConfig.compactOutput
+    }
     private val jsonValueEncoder = JsonValueEncoder(jsonConfig)
     private var currentMessage: JsonElement? = null
 
-    fun toJsonString(): String = currentMessage?.let { json.stringify(JsonElementSerializer, it) }.orEmpty()
+    fun toJsonString(): String = currentMessage?.let { json.encodeToString(JsonElement.serializer(), it) }.orEmpty()
 
     internal fun toJsonElement(): JsonElement =
         currentMessage ?: error("Must call writeMessage() before toJsonElement()")

--- a/runtime/src/commonTest/kotlin/pbandk/internal/UtilTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/internal/UtilTest.kt
@@ -1,6 +1,5 @@
-package pbandk
+package pbandk.internal
 
-import pbandk.internal.Util
 import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/runtime/src/commonTest/kotlin/pbandk/json/BytesTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/BytesTest.kt
@@ -1,8 +1,8 @@
 package pbandk.json
 
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.JsonConfiguration
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import pbandk.ByteArr
 import pbandk.testpb.TestAllTypesProto3
 import kotlin.test.Test
@@ -12,9 +12,9 @@ class BytesTest {
     @Test
     fun testBytesField_base64() {
         val testAllTypesProto3 = TestAllTypesProto3(optionalBytes = ByteArr(byteArrayOf(1, 2)))
-        val expectedJson = json { "optionalBytes" to "AQI=" }
+        val expectedJson = buildJsonObject { put("optionalBytes", "AQI=") }
 
-        val actualJson = Json(JsonConfiguration.Stable).parseJson(testAllTypesProto3.encodeToJsonString())
+        val actualJson = Json.parseToJsonElement(testAllTypesProto3.encodeToJsonString())
         assertEquals(expectedJson, actualJson)
 
         val actualProto = TestAllTypesProto3.decodeFromJsonString(expectedJson.toString())

--- a/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/DoubleTest.kt
@@ -1,14 +1,11 @@
 package pbandk.json
 
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.TestAllTypesProto3
-import pbandk.wkt.Duration
-import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class DoubleTest {
@@ -19,7 +16,7 @@ class DoubleTest {
     fun testDoubleField_EncodeFinite() {
         val input = TestAllTypesProto3(optionalDouble = 1.1)
 
-        val expected = json { "optionalDouble" to 1.1 }.toString()
+        val expected = buildJsonObject { put("optionalDouble", 1.1) }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -27,7 +24,7 @@ class DoubleTest {
 
     @Test
     fun testDoubleField_DecodeFinite() {
-        val json = json { "optionalDouble" to "1.1" }.toString()
+        val json = buildJsonObject { put("optionalDouble", "1.1") }.toString()
         val expectedDouble = 1.1
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -36,7 +33,7 @@ class DoubleTest {
 
     @Test
     fun testDoubleField_DecodeMinNegative() {
-        val json = json { "optionalDouble" to "-2.22507e-308" }.toString()
+        val json = buildJsonObject { put("optionalDouble", "-2.22507e-308") }.toString()
         val expectedDouble = -2.22507e-308
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -45,7 +42,7 @@ class DoubleTest {
 
     @Test
     fun testOneOfDoubleField_Zero() {
-        val json = json { "oneofDouble" to 0.0 }.toString()
+        val json = buildJsonObject { put("oneofDouble", 0.0) }.toString()
         val expectedDouble = 0.0
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -56,7 +53,7 @@ class DoubleTest {
     fun testDoubleField_EncodeNaN() {
         val input = TestAllTypesProto3(optionalDouble = Double.NaN)
 
-        val expected = json { "optionalDouble" to "NaN" }.toString()
+        val expected = buildJsonObject { put("optionalDouble", "NaN") }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -64,7 +61,7 @@ class DoubleTest {
 
     @Test
     fun testDoubleField_DecodeNaN() {
-        val json = json { "optionalDouble" to "NaN" }.toString()
+        val json = buildJsonObject { put("optionalDouble", "NaN") }.toString()
         val expectedDouble = Double.NaN
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -75,7 +72,7 @@ class DoubleTest {
     fun testDoubleField_EncodePositiveInfinity() {
         val input = TestAllTypesProto3(optionalDouble = Double.POSITIVE_INFINITY)
 
-        val expected = json { "optionalDouble" to "Infinity" }.toString()
+        val expected = buildJsonObject { put("optionalDouble", "Infinity") }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -83,7 +80,7 @@ class DoubleTest {
 
     @Test
     fun testDoubleField_DecodePositiveInfinity() {
-        val json = json { "optionalDouble" to "Infinity" }.toString()
+        val json = buildJsonObject { put("optionalDouble", "Infinity") }.toString()
         val expectedDouble = Double.POSITIVE_INFINITY
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -94,7 +91,7 @@ class DoubleTest {
     fun testDoubleField_EncodeNegativeInfinity() {
         val input = TestAllTypesProto3(optionalDouble = Double.NEGATIVE_INFINITY)
 
-        val expected = json { "optionalDouble" to "-Infinity" }.toString()
+        val expected = buildJsonObject { put("optionalDouble", "-Infinity") }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -102,7 +99,7 @@ class DoubleTest {
 
     @Test
     fun testDoubleField_DecodeNegativeInfinity() {
-        val json = json { "optionalDouble" to "-Infinity" }.toString()
+        val json = buildJsonObject { put("optionalDouble", "-Infinity") }.toString()
         val expectedDouble = Double.NEGATIVE_INFINITY
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -113,7 +110,7 @@ class DoubleTest {
     fun testDoubleField_EncodeExponentialNotation() {
         val input = TestAllTypesProto3(optionalDouble = 2e-12)
 
-        val expected = json { "optionalDouble" to 2e-12 }.toString()
+        val expected = buildJsonObject { put("optionalDouble", 2e-12) }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -121,7 +118,7 @@ class DoubleTest {
 
     @Test
     fun testDoubleField_DecodeExponentialNotation() {
-        val json = json { "optionalDouble" to "2e-12" }.toString()
+        val json = buildJsonObject { put("optionalDouble", "2e-12") }.toString()
         val expectedDouble = 2e-12
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)

--- a/runtime/src/commonTest/kotlin/pbandk/json/DurationTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/DurationTest.kt
@@ -1,10 +1,11 @@
 package pbandk.json
 
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import pbandk.testpb.TestAllTypesProto3
 import pbandk.wkt.Duration
-import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -12,7 +13,7 @@ import kotlin.test.assertFails
 class DurationTest {
     @Test
     fun testDurationField() {
-        val json = json { "optionalDuration" to "1s" }.toString()
+        val json = buildJsonObject { put("optionalDuration", "1s") }.toString()
         val expectedDuration = Duration(seconds = 1, nanos = 0)
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -21,7 +22,7 @@ class DurationTest {
 
     @Test
     fun testDurationField_withNanos() {
-        val json = json { "optionalDuration" to "1.001s" }.toString()
+        val json = buildJsonObject { put("optionalDuration", "1.001s") }.toString()
         val expectedDuration = Duration(seconds = 1, nanos = 1000000)
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -30,8 +31,14 @@ class DurationTest {
 
     @Test
     fun testDurationField_repeated() {
-        val json = json { "repeatedDuration" to jsonArray { +"1.5s"; +"-1.5s"; } }.toString()
-        val expectedDurations = listOf(Duration(seconds = 1, nanos = 500000000), Duration(seconds = -1, nanos = -500000000))
+        val json = buildJsonObject {
+            put("repeatedDuration", buildJsonArray {
+                add("1.5s")
+                add("-1.5s")
+            })
+        }.toString()
+        val expectedDurations =
+            listOf(Duration(seconds = 1, nanos = 500000000), Duration(seconds = -1, nanos = -500000000))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedDurations, testAllTypesProto3.repeatedDuration)
@@ -39,10 +46,10 @@ class DurationTest {
 
     @Test
     fun testDurationField_maxMinParse() {
-        val maxJson = json { "optionalDuration" to "315576000001s" }.toString()
+        val maxJson = buildJsonObject { put("optionalDuration", "315576000001s") }.toString()
         assertFails { TestAllTypesProto3.decodeFromJsonString(maxJson) }
 
-        val minJson = json { "optionalDuration" to "-315576000001s" }.toString()
+        val minJson = buildJsonObject { put("optionalDuration", "-315576000001s") }.toString()
         assertFails { TestAllTypesProto3.decodeFromJsonString(minJson) }
     }
 

--- a/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/FloatTest.kt
@@ -1,14 +1,11 @@
 package pbandk.json
 
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.TestAllTypesProto3
-import pbandk.wkt.Duration
-import pbandk.wkt.Timestamp
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertFails
 import kotlin.test.assertFailsWith
 
 class FloatTest {
@@ -19,7 +16,7 @@ class FloatTest {
     fun testFloatField_EncodeFinite() {
         val input = TestAllTypesProto3(optionalFloat = 1.1F)
 
-        val expected = json { "optionalFloat" to 1.1F }.toString()
+        val expected = buildJsonObject { put("optionalFloat", 1.1F) }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -27,7 +24,7 @@ class FloatTest {
 
     @Test
     fun testFloatField_DecodeFinite() {
-        val json = json { "optionalFloat" to "1.1" }.toString()
+        val json = buildJsonObject { put("optionalFloat", "1.1") }.toString()
         val expectedFloat = 1.1F
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -38,7 +35,7 @@ class FloatTest {
     fun testFloatField_EncodeNaN() {
         val input = TestAllTypesProto3(optionalFloat = Float.NaN)
 
-        val expected = json { "optionalFloat" to "NaN" }.toString()
+        val expected = buildJsonObject { put("optionalFloat", "NaN") }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -46,7 +43,7 @@ class FloatTest {
 
     @Test
     fun testFloatField_DecodeNaN() {
-        val json = json { "optionalFloat" to "NaN" }.toString()
+        val json = buildJsonObject { put("optionalFloat", "NaN") }.toString()
         val expectedFloat = Float.NaN
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -64,7 +61,7 @@ class FloatTest {
     fun testFloatField_EncodePositiveInfinity() {
         val input = TestAllTypesProto3(optionalFloat = Float.POSITIVE_INFINITY)
 
-        val expected = json { "optionalFloat" to "Infinity" }.toString()
+        val expected = buildJsonObject { put("optionalFloat", "Infinity") }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -72,7 +69,7 @@ class FloatTest {
 
     @Test
     fun testFloatField_DecodePositiveInfinity() {
-        val json = json { "optionalFloat" to "Infinity" }.toString()
+        val json = buildJsonObject { put("optionalFloat", "Infinity") }.toString()
         val expectedFloat = Float.POSITIVE_INFINITY
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -90,7 +87,7 @@ class FloatTest {
     fun testFloatField_EncodeNegativeInfinity() {
         val input = TestAllTypesProto3(optionalFloat = Float.NEGATIVE_INFINITY)
 
-        val expected = json { "optionalFloat" to "-Infinity" }.toString()
+        val expected = buildJsonObject { put("optionalFloat", "-Infinity") }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -98,7 +95,7 @@ class FloatTest {
 
     @Test
     fun testFloatField_DecodeNegativeInfinity() {
-        val json = json { "optionalFloat" to "-Infinity" }.toString()
+        val json = buildJsonObject { put("optionalFloat", "-Infinity") }.toString()
         val expectedFloat = Float.NEGATIVE_INFINITY
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -116,7 +113,7 @@ class FloatTest {
     fun testFloatField_EncodeExponentNotation() {
         val input = TestAllTypesProto3(optionalFloat = 2e-12F)
 
-        val expected = json { "optionalFloat" to 2e-12F }.toString()
+        val expected = buildJsonObject { put("optionalFloat", 2e-12F) }.toString()
         val actual = input.encodeToJsonString(jsonConfig)
 
         assertEquals(expected, actual)
@@ -124,7 +121,7 @@ class FloatTest {
 
     @Test
     fun testFloatField_DecodeExponentNotation() {
-        val json = json { "optionalFloat" to "2e-12" }.toString()
+        val json = buildJsonObject { put("optionalFloat", "2e-12") }.toString()
         val expectedFloat = 2e-12F
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)

--- a/runtime/src/commonTest/kotlin/pbandk/json/IgnoreUnknownFieldsTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/IgnoreUnknownFieldsTest.kt
@@ -1,11 +1,11 @@
 package pbandk.json
 
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
-import pbandk.*
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.ForeignEnum
-import pbandk.testpb.ForeignMessage
 import pbandk.testpb.TestAllTypesProto3
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,8 +14,8 @@ import kotlin.test.assertFailsWith
 class IgnoreUnknownFieldsTest {
     @Test
     fun testEnumWithUnknownValue() {
-        val json = json {
-            "optionalForeignEnum" to "XXX"
+        val json = buildJsonObject {
+            put("optionalForeignEnum", "XXX")
         }.toString()
 
         // Without [ignoreUnknownFieldsInInput], a known enum field with an unknown enum value should fail to decode.
@@ -34,8 +34,8 @@ class IgnoreUnknownFieldsTest {
 
     @Test
     fun testEnumWithUnknownNumericValue() {
-        val json = json {
-            "optionalForeignEnum" to 1234
+        val json = buildJsonObject {
+            put("optionalForeignEnum", 1234)
         }.toString()
 
         val expected = TestAllTypesProto3(optionalForeignEnum = ForeignEnum.UNRECOGNIZED(1234))
@@ -53,12 +53,12 @@ class IgnoreUnknownFieldsTest {
 
     @Test
     fun testRepeatedEnumWithUnknownValue() {
-        val json = json {
-            "repeatedForeignEnum" to jsonArray {
-                +"FOREIGN_FOO"
-                +"XXX"
-                +"FOREIGN_BAR"
-            }
+        val json = buildJsonObject {
+            put("repeatedForeignEnum", buildJsonArray {
+                add("FOREIGN_FOO")
+                add("XXX")
+                add("FOREIGN_BAR")
+            })
         }.toString()
 
         // Without [ignoreUnknownFieldsInInput], a repeated enum field with some known and some unknown values should
@@ -80,11 +80,11 @@ class IgnoreUnknownFieldsTest {
 
     @Test
     fun testMapEnumWithUnknownValue() {
-        val json = json {
-            "mapStringForeignEnum" to json {
-                "a" to "FOREIGN_FOO"
-                "b" to "XXX"
-            }
+        val json = buildJsonObject {
+            put("mapStringForeignEnum", buildJsonObject {
+                put("a", "FOREIGN_FOO")
+                put("b", "XXX")
+            })
         }.toString()
 
         // Without [ignoreUnknownFieldsInInput], a map field with some known and some unknown enum values should fail

--- a/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/IntTest.kt
@@ -1,6 +1,7 @@
 package pbandk.json
 
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.TestAllTypesProto3
 import kotlin.test.Test
@@ -11,7 +12,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeTrailingZero_PassesOnValidNumber() {
-        val json = json { "optionalInt32" to "1.00" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "1.00") }.toString()
         val expectedInt = 1
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -20,7 +21,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeTrailingZero_FailsOnFloat() {
-        val json = json { "optionalInt32" to "1.10" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "1.10") }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString(json)
@@ -29,7 +30,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeTrailingZero_FailsOnInvalidNumber() {
-        val json = json { "optionalInt32" to "1.00.00" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "1.00.00") }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString(json)
@@ -38,7 +39,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_PassesOnValidNumber() {
-        val json = json { "optionalInt32" to "1e0" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "1e0") }.toString()
         val expectedInt = 1
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -47,7 +48,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_PassesOnValidNumberCapitalized() {
-        val json = json { "optionalInt32" to "1E2" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "1E2") }.toString()
         val expectedInt = 100
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -56,7 +57,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_PassesOnValidFloat() {
-        val json = json { "optionalInt32" to "-1.2e1" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "-1.2e1") }.toString()
         val expectedInt = -12
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -65,7 +66,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_PassesOnValidFloatTrailingZero() {
-        val json = json { "optionalInt32" to "-1.200e2" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "-1.200e2") }.toString()
         val expectedInt = -120
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -74,7 +75,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_PassesOnValidIntTrailingZero() {
-        val json = json { "optionalInt32" to "-1.000e0" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "-1.000e0") }.toString()
         val expectedInt = -1
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -83,7 +84,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeExponentNotation_FailsOnInvalidNumber() {
-        val json = json { "optionalInt32" to "1e2e2" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "1e2e2") }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString(json)
@@ -92,7 +93,7 @@ class IntTest {
 
     @Test
     fun testInt32Field_DecodeMinFloatValue_Success() {
-        val json = json { "optionalInt32" to "-2.147483648e9" }.toString()
+        val json = buildJsonObject { put("optionalInt32", "-2.147483648e9") }.toString()
         val expectedInt = -2147483648
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -101,7 +102,7 @@ class IntTest {
 
     @Test
     fun testInt64Field_DecodeFieldTooLarge_Fails() {
-        val json = json { "optionalInt64" to "9223372036854775808" }.toString()
+        val json = buildJsonObject { put("optionalInt64", "9223372036854775808") }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString(json)
@@ -110,7 +111,7 @@ class IntTest {
 
     @Test
     fun testUInt64Field_DecodeFieldTooLarge_Fails() {
-        val json = json { "optionalUint64" to "18446744073709551616" }.toString()
+        val json = buildJsonObject { put("optionalUint64", "18446744073709551616") }.toString()
 
         assertFailsWith<InvalidProtocolBufferException> {
             TestAllTypesProto3.decodeFromJsonString(json)

--- a/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/JsonTest.kt
@@ -1,13 +1,11 @@
 package pbandk.json
 
 import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
 import pbandk.encodeToByteArray
 import pbandk.testpb.Bar
 import pbandk.testpb.TestAllTypesProto3
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.*
 
 class JsonTest {
     @Test
@@ -22,11 +20,11 @@ class JsonTest {
 
     @Test
     fun testNullValues() {
-        val json = json {
-            "optionalInt32" to JsonNull
-            "mapBoolBool" to JsonNull
-            "repeatedString" to JsonNull
-            "optionalNestedMessage" to JsonNull
+        val json = buildJsonObject {
+            put("optionalInt32", JsonNull)
+            put("mapBoolBool", JsonNull)
+            put("repeatedString", JsonNull)
+            put("optionalNestedMessage", JsonNull)
         }.toString()
         val expectedMessage = TestAllTypesProto3.defaultInstance
 
@@ -46,3 +44,4 @@ class JsonTest {
         assertEquals(1, compactJson.lines().size)
     }
 }
+

--- a/runtime/src/commonTest/kotlin/pbandk/json/MapTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/MapTest.kt
@@ -1,7 +1,7 @@
 package pbandk.json
 
 import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
 import pbandk.InvalidProtocolBufferException
 import pbandk.testpb.ForeignMessage
 import pbandk.testpb.TestAllTypesProto3
@@ -12,10 +12,10 @@ import kotlin.test.assertFailsWith
 class MapTest {
     @Test
     fun testMapWithDefaultValues() {
-        val json = json {
-            "mapStringForeignMessage" to json {
-                "foo" to json { }
-            }
+        val json = buildJsonObject {
+            put("mapStringForeignMessage", buildJsonObject {
+                put("foo", buildJsonObject { })
+            })
         }.toString()
 
         val expected = TestAllTypesProto3(
@@ -27,10 +27,10 @@ class MapTest {
 
     @Test
     fun testMapWithNullValues() {
-        val json = json {
-            "mapStringForeignMessage" to json {
-                "foo" to JsonNull
-            }
+        val json = buildJsonObject {
+            put("mapStringForeignMessage", buildJsonObject {
+                put("foo", JsonNull)
+            })
         }.toString()
         assertFailsWith(InvalidProtocolBufferException::class) {
             TestAllTypesProto3.decodeFromJsonString(json)

--- a/runtime/src/commonTest/kotlin/pbandk/json/OutputDefaultValuesTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/OutputDefaultValuesTest.kt
@@ -4,13 +4,16 @@ import kotlinx.serialization.json.*
 import pbandk.testpb.TestAllTypesProto3
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class OutputDefaultValuesTest {
     @Test
     fun testOutputDefaultValues_false() {
-        val jsonString = TestAllTypesProto3().encodeToJsonString(JsonConfig.DEFAULT.copy(outputDefaultValues = false))
-        val parsedJson = Json(JsonConfiguration.Stable).parseJson(jsonString).jsonObject
-        assertEquals(JsonObject(emptyMap()), parsedJson)
+        val testAllTypesProto3 = TestAllTypesProto3(optionalString = "")
+
+        val actualJson = Json.parseToJsonElement(testAllTypesProto3.encodeToJsonString())
+        assertFalse("optionalString" in actualJson.jsonObject)
     }
 
     @Test
@@ -18,7 +21,7 @@ class OutputDefaultValuesTest {
         val jsonString = TestAllTypesProto3(
             optionalBoolWrapper = false
         ).encodeToJsonString(JsonConfig.DEFAULT.copy(outputDefaultValues = true))
-        val parsedJson = Json(JsonConfiguration.Stable).parseJson(jsonString).jsonObject
+        val parsedJson = Json.parseToJsonElement(jsonString).jsonObject
 
         assertEquals(JsonPrimitive(false), parsedJson["optionalBool"])
         assertEquals(JsonPrimitive(0), parsedJson["optionalInt32"])
@@ -40,7 +43,7 @@ class OutputDefaultValuesTest {
         val jsonString = TestAllTypesProto3(
             optionalStringWrapper = ""
         ).encodeToJsonString(JsonConfig.DEFAULT.copy(outputDefaultValues = true, outputDefaultStringsAsNull = true))
-        val parsedJson = Json(JsonConfiguration.Stable).parseJson(jsonString).jsonObject
+        val parsedJson = Json.parseToJsonElement(jsonString).jsonObject
         assertEquals(JsonPrimitive(false), parsedJson["optionalBool"])
         assertEquals(JsonNull, parsedJson["optionalString"])
         assertEquals(JsonPrimitive(""), parsedJson["optionalStringWrapper"])

--- a/runtime/src/commonTest/kotlin/pbandk/json/StructAndValueTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/StructAndValueTest.kt
@@ -1,8 +1,6 @@
 package pbandk.json
 
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.json
-import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.*
 import pbandk.testpb.TestAllTypesProto3
 import pbandk.wkt.ListValue
 import pbandk.wkt.Struct
@@ -13,8 +11,12 @@ import kotlin.test.assertEquals
 class StructAndValueTest {
     @Test
     fun testStructField_withStrings() {
-        val json = json { "optionalStruct" to json { "key" to "value" } }.toString()
-        val expectedStruct = Struct(mapOf( "key" to Value(Value.Kind.StringValue("value")) ))
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key", "value")
+            })
+        }.toString()
+        val expectedStruct = Struct(mapOf("key" to Value(Value.Kind.StringValue("value"))))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedStruct, testAllTypesProto3.optionalStruct)
@@ -22,7 +24,11 @@ class StructAndValueTest {
 
     @Test
     fun testStructField_withNumbers() {
-        val json = json { "optionalStruct" to json { "key" to 1.0 } }.toString()
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key", 1.0)
+            })
+        }.toString()
         val expectedStruct = Struct(mapOf("key" to Value(Value.Kind.NumberValue(1.0))))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -31,16 +37,28 @@ class StructAndValueTest {
 
     @Test
     fun testStructField_withList() {
-        val json = json { "optionalStruct" to json { "key" to jsonArray { +"value1"; +"value2" } } }.toString()
-        val expectedStruct = Struct(mapOf("key" to Value(
-            Value.Kind.ListValue(
-                ListValue(listOf(
-            Value(Value.Kind.StringValue("value1")),
-            Value(Value.Kind.StringValue("value2"))
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key", buildJsonArray {
+                    add("value1")
+                    add("value2")
+                })
+            })
+        }.toString()
+        val expectedStruct = Struct(
+            mapOf(
+                "key" to Value(
+                    Value.Kind.ListValue(
+                        ListValue(
+                            listOf(
+                                Value(Value.Kind.StringValue("value1")),
+                                Value(Value.Kind.StringValue("value2"))
+                            )
+                        )
+                    )
                 )
+            )
         )
-            ))
-        ))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedStruct, testAllTypesProto3.optionalStruct)
@@ -48,14 +66,24 @@ class StructAndValueTest {
 
     @Test
     fun testStructField_withStruct() {
-        val json = json { "optionalStruct" to json { "key" to json { "innerKey" to "value" } } }.toString()
-        val expectedStruct = Struct(mapOf("key" to Value(
-            Value.Kind.StructValue(
-                Struct(
-            mapOf("innerKey" to Value(Value.Kind.StringValue("value")))
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key", buildJsonObject {
+                    put("innerKey", "value")
+                })
+            })
+        }.toString()
+        val expectedStruct = Struct(
+            mapOf(
+                "key" to Value(
+                    Value.Kind.StructValue(
+                        Struct(
+                            mapOf("innerKey" to Value(Value.Kind.StringValue("value")))
+                        )
+                    )
+                )
+            )
         )
-            ))
-        ))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedStruct, testAllTypesProto3.optionalStruct)
@@ -63,7 +91,11 @@ class StructAndValueTest {
 
     @Test
     fun testStructField_withNull() {
-        val json = json { "optionalStruct" to json { "key" to JsonNull } }.toString()
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key", JsonNull)
+            })
+        }.toString()
         val expectedStruct = Struct(mapOf("key" to Value(Value.Kind.NullValue())))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -72,7 +104,11 @@ class StructAndValueTest {
 
     @Test
     fun testStructField_withNumberString() {
-        val json = json { "optionalStruct" to json { "key" to "1.0" } }.toString()
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key", "1.0")
+            })
+        }.toString()
         val expectedStruct = Struct(mapOf("key" to Value(Value.Kind.StringValue("1.0"))))
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -82,29 +118,37 @@ class StructAndValueTest {
 
     @Test
     fun testStructField_withMix() {
-        val json = json { "optionalStruct" to json {
-            "key1" to 1.0
-            "key2" to "TWO"
-            "key3" to jsonArray { +"value1"; +"value2" }
-            "key4" to true
-            "key5" to JsonNull
-        }
+        val json = buildJsonObject {
+            put("optionalStruct", buildJsonObject {
+                put("key1", 1.0)
+                put("key2", "TWO")
+                put("key3", buildJsonArray {
+                    add("value1")
+                    add("value2")
+                })
+                put("key4", true)
+                put("key5", JsonNull)
+            })
         }.toString()
 
-        val expectedStruct = Struct(mapOf(
-            "key1" to Value(Value.Kind.NumberValue(1.0)),
-            "key2" to Value(Value.Kind.StringValue("TWO")),
-            "key3" to Value(
-                Value.Kind.ListValue(
-                    ListValue(listOf(
-                Value(Value.Kind.StringValue("value1")),
-                Value(Value.Kind.StringValue("value2"))
+        val expectedStruct = Struct(
+            mapOf(
+                "key1" to Value(Value.Kind.NumberValue(1.0)),
+                "key2" to Value(Value.Kind.StringValue("TWO")),
+                "key3" to Value(
+                    Value.Kind.ListValue(
+                        ListValue(
+                            listOf(
+                                Value(Value.Kind.StringValue("value1")),
+                                Value(Value.Kind.StringValue("value2"))
+                            )
+                        )
                     )
+                ),
+                "key4" to Value(Value.Kind.BoolValue(true)),
+                "key5" to Value(Value.Kind.NullValue())
             )
-                )),
-            "key4" to Value(Value.Kind.BoolValue(true)),
-            "key5" to Value(Value.Kind.NullValue())
-        ))
+        )
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedStruct, testAllTypesProto3.optionalStruct)
@@ -112,10 +156,10 @@ class StructAndValueTest {
 
     @Test
     fun testRepeatedList() {
-        val json = json {
-            "repeatedListValue" to jsonArray {
-                +jsonArray { +"a" }
-            }
+        val json = buildJsonObject {
+            put("repeatedListValue", buildJsonArray {
+                add(buildJsonArray { add("a") })
+            })
         }.toString()
         val expectedRepeatedList = listOf(ListValue(listOf(Value(kind = Value.Kind.StringValue("a")))))
 
@@ -125,7 +169,7 @@ class StructAndValueTest {
 
     @Test
     fun testValueField_null() {
-        val json = json { "optionalValue" to JsonNull }.toString()
+        val json = buildJsonObject { put("optionalValue", JsonNull) }.toString()
         val expectedValue = Value(kind = Value.Kind.NullValue())
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)

--- a/runtime/src/commonTest/kotlin/pbandk/json/TimestampTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/json/TimestampTest.kt
@@ -1,6 +1,7 @@
 package pbandk.json
 
-import kotlinx.serialization.json.json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
 import pbandk.testpb.TestAllTypesProto3
 import pbandk.wkt.Timestamp
 import kotlin.test.Test
@@ -9,7 +10,7 @@ import kotlin.test.assertEquals
 class TimestampTest {
     @Test
     fun testTimestampField() {
-        val json = json { "optionalTimestamp" to "0001-01-01T00:00:00Z" }.toString()
+        val json = buildJsonObject { put("optionalTimestamp", "0001-01-01T00:00:00Z") }.toString()
         val expectedTimestamp = Timestamp(seconds = -62135596800, nanos = 0)
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
@@ -18,11 +19,10 @@ class TimestampTest {
 
     @Test
     fun testTimestampField_withNanos() {
-        val json = json { "optionalTimestamp" to "1993-02-10T00:00:00.000Z" }.toString()
+        val json = buildJsonObject { put("optionalTimestamp", "1993-02-10T00:00:00.000Z") }.toString()
         val expectedTimestamp = Timestamp(seconds = 729302400, nanos = 0)
 
         val testAllTypesProto3 = TestAllTypesProto3.decodeFromJsonString(json)
         assertEquals(expectedTimestamp, testAllTypesProto3.optionalTimestamp)
     }
-
 }

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_compiler_limits.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_compiler_limits.kt
@@ -1017,6 +1017,11052 @@ sealed class HugeEnum(override val value: Int, override val name: String? = null
     }
 }
 
+data class MessageWithLotsOfFields(
+    val field1000: String = "",
+    val field1001: String = "",
+    val field1002: String = "",
+    val field1003: String = "",
+    val field1004: String = "",
+    val field1005: String = "",
+    val field1006: String = "",
+    val field1007: String = "",
+    val field1008: String = "",
+    val field1009: String = "",
+    val field1010: String = "",
+    val field1011: String = "",
+    val field1012: String = "",
+    val field1013: String = "",
+    val field1014: String = "",
+    val field1015: String = "",
+    val field1016: String = "",
+    val field1017: String = "",
+    val field1018: String = "",
+    val field1019: String = "",
+    val field1020: String = "",
+    val field1021: String = "",
+    val field1022: String = "",
+    val field1023: String = "",
+    val field1024: String = "",
+    val field1025: String = "",
+    val field1026: String = "",
+    val field1027: String = "",
+    val field1028: String = "",
+    val field1029: String = "",
+    val field1030: String = "",
+    val field1031: String = "",
+    val field1032: String = "",
+    val field1033: String = "",
+    val field1034: String = "",
+    val field1035: String = "",
+    val field1036: String = "",
+    val field1037: String = "",
+    val field1038: String = "",
+    val field1039: String = "",
+    val field1040: String = "",
+    val field1041: String = "",
+    val field1042: String = "",
+    val field1043: String = "",
+    val field1044: String = "",
+    val field1045: String = "",
+    val field1046: String = "",
+    val field1047: String = "",
+    val field1048: String = "",
+    val field1049: String = "",
+    val field1050: String = "",
+    val field1051: String = "",
+    val field1052: String = "",
+    val field1053: String = "",
+    val field1054: String = "",
+    val field1055: String = "",
+    val field1056: String = "",
+    val field1057: String = "",
+    val field1058: String = "",
+    val field1059: String = "",
+    val field1060: String = "",
+    val field1061: String = "",
+    val field1062: String = "",
+    val field1063: String = "",
+    val field1064: String = "",
+    val field1065: String = "",
+    val field1066: String = "",
+    val field1067: String = "",
+    val field1068: String = "",
+    val field1069: String = "",
+    val field1070: String = "",
+    val field1071: String = "",
+    val field1072: String = "",
+    val field1073: String = "",
+    val field1074: String = "",
+    val field1075: String = "",
+    val field1076: String = "",
+    val field1077: String = "",
+    val field1078: String = "",
+    val field1079: String = "",
+    val field1080: String = "",
+    val field1081: String = "",
+    val field1082: String = "",
+    val field1083: String = "",
+    val field1084: String = "",
+    val field1085: String = "",
+    val field1086: String = "",
+    val field1087: String = "",
+    val field1088: String = "",
+    val field1089: String = "",
+    val field1090: String = "",
+    val field1091: String = "",
+    val field1092: String = "",
+    val field1093: String = "",
+    val field1094: String = "",
+    val field1095: String = "",
+    val field1096: String = "",
+    val field1097: String = "",
+    val field1098: String = "",
+    val field1099: String = "",
+    val field1100: String = "",
+    val field1101: String = "",
+    val field1102: String = "",
+    val field1103: String = "",
+    val field1104: String = "",
+    val field1105: String = "",
+    val field1106: String = "",
+    val field1107: String = "",
+    val field1108: String = "",
+    val field1109: String = "",
+    val field1110: String = "",
+    val field1111: String = "",
+    val field1112: String = "",
+    val field1113: String = "",
+    val field1114: String = "",
+    val field1115: String = "",
+    val field1116: String = "",
+    val field1117: String = "",
+    val field1118: String = "",
+    val field1119: String = "",
+    val field1120: String = "",
+    val field1121: String = "",
+    val field1122: String = "",
+    val field1123: String = "",
+    val field1124: String = "",
+    val field1125: String = "",
+    val field1126: String = "",
+    val field1127: String = "",
+    val field1128: String = "",
+    val field1129: String = "",
+    val field1130: String = "",
+    val field1131: String = "",
+    val field1132: String = "",
+    val field1133: String = "",
+    val field1134: String = "",
+    val field1135: String = "",
+    val field1136: String = "",
+    val field1137: String = "",
+    val field1138: String = "",
+    val field1139: String = "",
+    val field1140: String = "",
+    val field1141: String = "",
+    val field1142: String = "",
+    val field1143: String = "",
+    val field1144: String = "",
+    val field1145: String = "",
+    val field1146: String = "",
+    val field1147: String = "",
+    val field1148: String = "",
+    val field1149: String = "",
+    val field1150: String = "",
+    val field1151: String = "",
+    val field1152: String = "",
+    val field1153: String = "",
+    val field1154: String = "",
+    val field1155: String = "",
+    val field1156: String = "",
+    val field1157: String = "",
+    val field1158: String = "",
+    val field1159: String = "",
+    val field1160: String = "",
+    val field1161: String = "",
+    val field1162: String = "",
+    val field1163: String = "",
+    val field1164: String = "",
+    val field1165: String = "",
+    val field1166: String = "",
+    val field1167: String = "",
+    val field1168: String = "",
+    val field1169: String = "",
+    val field1170: String = "",
+    val field1171: String = "",
+    val field1172: String = "",
+    val field1173: String = "",
+    val field1174: String = "",
+    val field1175: String = "",
+    val field1176: String = "",
+    val field1177: String = "",
+    val field1178: String = "",
+    val field1179: String = "",
+    val field1180: String = "",
+    val field1181: String = "",
+    val field1182: String = "",
+    val field1183: String = "",
+    val field1184: String = "",
+    val field1185: String = "",
+    val field1186: String = "",
+    val field1187: String = "",
+    val field1188: String = "",
+    val field1189: String = "",
+    val field1190: String = "",
+    val field1191: String = "",
+    val field1192: String = "",
+    val field1193: String = "",
+    val field1194: String = "",
+    val field1195: String = "",
+    val field1196: String = "",
+    val field1197: String = "",
+    val field1198: String = "",
+    val field1199: String = "",
+    val field1200: String = "",
+    val field1201: String = "",
+    val field1202: String = "",
+    val field1203: String = "",
+    val field1204: String = "",
+    val field1205: String = "",
+    val field1206: String = "",
+    val field1207: String = "",
+    val field1208: String = "",
+    val field1209: String = "",
+    val field1210: String = "",
+    val field1211: String = "",
+    val field1212: String = "",
+    val field1213: String = "",
+    val field1214: String = "",
+    val field1215: String = "",
+    val field1216: String = "",
+    val field1217: String = "",
+    val field1218: String = "",
+    val field1219: String = "",
+    val field1220: String = "",
+    val field1221: String = "",
+    val field1222: String = "",
+    val field1223: String = "",
+    val field1224: String = "",
+    val field1225: String = "",
+    val field1226: String = "",
+    val field1227: String = "",
+    val field1228: String = "",
+    val field1229: String = "",
+    val field1230: String = "",
+    val field1231: String = "",
+    val field1232: String = "",
+    val field1233: String = "",
+    val field1234: String = "",
+    val field1235: String = "",
+    val field1236: String = "",
+    val field1237: String = "",
+    val field1238: String = "",
+    val field1239: String = "",
+    val field1240: String = "",
+    val field1241: String = "",
+    val field1242: String = "",
+    val field1243: String = "",
+    val field1244: String = "",
+    val field1245: String = "",
+    val field1246: String = "",
+    val field1247: String = "",
+    val field1248: String = "",
+    val field1249: String = "",
+    val field1250: String = "",
+    val field1251: String = "",
+    val field1252: String = "",
+    val field1253: String = "",
+    val field1254: String = "",
+    val field1255: String = "",
+    val field1256: String = "",
+    val field1257: String = "",
+    val field1258: String = "",
+    val field1259: String = "",
+    val field1260: String = "",
+    val field1261: String = "",
+    val field1262: String = "",
+    val field1263: String = "",
+    val field1264: String = "",
+    val field1265: String = "",
+    val field1266: String = "",
+    val field1267: String = "",
+    val field1268: String = "",
+    val field1269: String = "",
+    val field1270: String = "",
+    val field1271: String = "",
+    val field1272: String = "",
+    val field1273: String = "",
+    val field1274: String = "",
+    val field1275: String = "",
+    val field1276: String = "",
+    val field1277: String = "",
+    val field1278: String = "",
+    val field1279: String = "",
+    val field1280: String = "",
+    val field1281: String = "",
+    val field1282: String = "",
+    val field1283: String = "",
+    val field1284: String = "",
+    val field1285: String = "",
+    val field1286: String = "",
+    val field1287: String = "",
+    val field1288: String = "",
+    val field1289: String = "",
+    val field1290: String = "",
+    val field1291: String = "",
+    val field1292: String = "",
+    val field1293: String = "",
+    val field1294: String = "",
+    val field1295: String = "",
+    val field1296: String = "",
+    val field1297: String = "",
+    val field1298: String = "",
+    val field1299: String = "",
+    val field1300: String = "",
+    val field1301: String = "",
+    val field1302: String = "",
+    val field1303: String = "",
+    val field1304: String = "",
+    val field1305: String = "",
+    val field1306: String = "",
+    val field1307: String = "",
+    val field1308: String = "",
+    val field1309: String = "",
+    val field1310: String = "",
+    val field1311: String = "",
+    val field1312: String = "",
+    val field1313: String = "",
+    val field1314: String = "",
+    val field1315: String = "",
+    val field1316: String = "",
+    val field1317: String = "",
+    val field1318: String = "",
+    val field1319: String = "",
+    val field1320: String = "",
+    val field1321: String = "",
+    val field1322: String = "",
+    val field1323: String = "",
+    val field1324: String = "",
+    val field1325: String = "",
+    val field1326: String = "",
+    val field1327: String = "",
+    val field1328: String = "",
+    val field1329: String = "",
+    val field1330: String = "",
+    val field1331: String = "",
+    val field1332: String = "",
+    val field1333: String = "",
+    val field1334: String = "",
+    val field1335: String = "",
+    val field1336: String = "",
+    val field1337: String = "",
+    val field1338: String = "",
+    val field1339: String = "",
+    val field1340: String = "",
+    val field1341: String = "",
+    val field1342: String = "",
+    val field1343: String = "",
+    val field1344: String = "",
+    val field1345: String = "",
+    val field1346: String = "",
+    val field1347: String = "",
+    val field1348: String = "",
+    val field1349: String = "",
+    val field1350: String = "",
+    val field1351: String = "",
+    val field1352: String = "",
+    val field1353: String = "",
+    val field1354: String = "",
+    val field1355: String = "",
+    val field1356: String = "",
+    val field1357: String = "",
+    val field1358: String = "",
+    val field1359: String = "",
+    val field1360: String = "",
+    val field1361: String = "",
+    val field1362: String = "",
+    val field1363: String = "",
+    val field1364: String = "",
+    val field1365: String = "",
+    val field1366: String = "",
+    val field1367: String = "",
+    val field1368: String = "",
+    val field1369: String = "",
+    val field1370: String = "",
+    val field1371: String = "",
+    val field1372: String = "",
+    val field1373: String = "",
+    val field1374: String = "",
+    val field1375: String = "",
+    val field1376: String = "",
+    val field1377: String = "",
+    val field1378: String = "",
+    val field1379: String = "",
+    val field1380: String = "",
+    val field1381: String = "",
+    val field1382: String = "",
+    val field1383: String = "",
+    val field1384: String = "",
+    val field1385: String = "",
+    val field1386: String = "",
+    val field1387: String = "",
+    val field1388: String = "",
+    val field1389: String = "",
+    val field1390: String = "",
+    val field1391: String = "",
+    val field1392: String = "",
+    val field1393: String = "",
+    val field1394: String = "",
+    val field1395: String = "",
+    val field1396: String = "",
+    val field1397: String = "",
+    val field1398: String = "",
+    val field1399: String = "",
+    val field1400: String = "",
+    val field1401: String = "",
+    val field1402: String = "",
+    val field1403: String = "",
+    val field1404: String = "",
+    val field1405: String = "",
+    val field1406: String = "",
+    val field1407: String = "",
+    val field1408: String = "",
+    val field1409: String = "",
+    val field1410: String = "",
+    val field1411: String = "",
+    val field1412: String = "",
+    val field1413: String = "",
+    val field1414: String = "",
+    val field1415: String = "",
+    val field1416: String = "",
+    val field1417: String = "",
+    val field1418: String = "",
+    val field1419: String = "",
+    val field1420: String = "",
+    val field1421: String = "",
+    val field1422: String = "",
+    val field1423: String = "",
+    val field1424: String = "",
+    val field1425: String = "",
+    val field1426: String = "",
+    val field1427: String = "",
+    val field1428: String = "",
+    val field1429: String = "",
+    val field1430: String = "",
+    val field1431: String = "",
+    val field1432: String = "",
+    val field1433: String = "",
+    val field1434: String = "",
+    val field1435: String = "",
+    val field1436: String = "",
+    val field1437: String = "",
+    val field1438: String = "",
+    val field1439: String = "",
+    val field1440: String = "",
+    val field1441: String = "",
+    val field1442: String = "",
+    val field1443: String = "",
+    val field1444: String = "",
+    val field1445: String = "",
+    val field1446: String = "",
+    val field1447: String = "",
+    val field1448: String = "",
+    val field1449: String = "",
+    val field1450: String = "",
+    val field1451: String = "",
+    val field1452: String = "",
+    val field1453: String = "",
+    val field1454: String = "",
+    val field1455: String = "",
+    val field1456: String = "",
+    val field1457: String = "",
+    val field1458: String = "",
+    val field1459: String = "",
+    val field1460: String = "",
+    val field1461: String = "",
+    val field1462: String = "",
+    val field1463: String = "",
+    val field1464: String = "",
+    val field1465: String = "",
+    val field1466: String = "",
+    val field1467: String = "",
+    val field1468: String = "",
+    val field1469: String = "",
+    val field1470: String = "",
+    val field1471: String = "",
+    val field1472: String = "",
+    val field1473: String = "",
+    val field1474: String = "",
+    val field1475: String = "",
+    val field1476: String = "",
+    val field1477: String = "",
+    val field1478: String = "",
+    val field1479: String = "",
+    val field1480: String = "",
+    val field1481: String = "",
+    val field1482: String = "",
+    val field1483: String = "",
+    val field1484: String = "",
+    val field1485: String = "",
+    val field1486: String = "",
+    val field1487: String = "",
+    val field1488: String = "",
+    val field1489: String = "",
+    val field1490: String = "",
+    val field1491: String = "",
+    val field1492: String = "",
+    val field1493: String = "",
+    val field1494: String = "",
+    val field1495: String = "",
+    val field1496: String = "",
+    val field1497: String = "",
+    val field1498: String = "",
+    val field1499: String = "",
+    val field1500: String = "",
+    val field1501: String = "",
+    val field1502: String = "",
+    val field1503: String = "",
+    val field1504: String = "",
+    val field1505: String = "",
+    val field1506: String = "",
+    val field1507: String = "",
+    val field1508: String = "",
+    val field1509: String = "",
+    val field1510: String = "",
+    val field1511: String = "",
+    val field1512: String = "",
+    val field1513: String = "",
+    val field1514: String = "",
+    val field1515: String = "",
+    val field1516: String = "",
+    val field1517: String = "",
+    val field1518: String = "",
+    val field1519: String = "",
+    val field1520: String = "",
+    val field1521: String = "",
+    val field1522: String = "",
+    val field1523: String = "",
+    val field1524: String = "",
+    val field1525: String = "",
+    val field1526: String = "",
+    val field1527: String = "",
+    val field1528: String = "",
+    val field1529: String = "",
+    val field1530: String = "",
+    val field1531: String = "",
+    val field1532: String = "",
+    val field1533: String = "",
+    val field1534: String = "",
+    val field1535: String = "",
+    val field1536: String = "",
+    val field1537: String = "",
+    val field1538: String = "",
+    val field1539: String = "",
+    val field1540: String = "",
+    val field1541: String = "",
+    val field1542: String = "",
+    val field1543: String = "",
+    val field1544: String = "",
+    val field1545: String = "",
+    val field1546: String = "",
+    val field1547: String = "",
+    val field1548: String = "",
+    val field1549: String = "",
+    val field1550: String = "",
+    val field1551: String = "",
+    val field1552: String = "",
+    val field1553: String = "",
+    val field1554: String = "",
+    val field1555: String = "",
+    val field1556: String = "",
+    val field1557: String = "",
+    val field1558: String = "",
+    val field1559: String = "",
+    val field1560: String = "",
+    val field1561: String = "",
+    val field1562: String = "",
+    val field1563: String = "",
+    val field1564: String = "",
+    val field1565: String = "",
+    val field1566: String = "",
+    val field1567: String = "",
+    val field1568: String = "",
+    val field1569: String = "",
+    val field1570: String = "",
+    val field1571: String = "",
+    val field1572: String = "",
+    val field1573: String = "",
+    val field1574: String = "",
+    val field1575: String = "",
+    val field1576: String = "",
+    val field1577: String = "",
+    val field1578: String = "",
+    val field1579: String = "",
+    val field1580: String = "",
+    val field1581: String = "",
+    val field1582: String = "",
+    val field1583: String = "",
+    val field1584: String = "",
+    val field1585: String = "",
+    val field1586: String = "",
+    val field1587: String = "",
+    val field1588: String = "",
+    val field1589: String = "",
+    val field1590: String = "",
+    val field1591: String = "",
+    val field1592: String = "",
+    val field1593: String = "",
+    val field1594: String = "",
+    val field1595: String = "",
+    val field1596: String = "",
+    val field1597: String = "",
+    val field1598: String = "",
+    val field1599: String = "",
+    val field1600: String = "",
+    val field1601: String = "",
+    val field1602: String = "",
+    val field1603: String = "",
+    val field1604: String = "",
+    val field1605: String = "",
+    val field1606: String = "",
+    val field1607: String = "",
+    val field1608: String = "",
+    val field1609: String = "",
+    val field1610: String = "",
+    val field1611: String = "",
+    val field1612: String = "",
+    val field1613: String = "",
+    val field1614: String = "",
+    val field1615: String = "",
+    val field1616: String = "",
+    val field1617: String = "",
+    val field1618: String = "",
+    val field1619: String = "",
+    val field1620: String = "",
+    val field1621: String = "",
+    val field1622: String = "",
+    val field1623: String = "",
+    val field1624: String = "",
+    val field1625: String = "",
+    val field1626: String = "",
+    val field1627: String = "",
+    val field1628: String = "",
+    val field1629: String = "",
+    val field1630: String = "",
+    val field1631: String = "",
+    val field1632: String = "",
+    val field1633: String = "",
+    val field1634: String = "",
+    val field1635: String = "",
+    val field1636: String = "",
+    val field1637: String = "",
+    val field1638: String = "",
+    val field1639: String = "",
+    val field1640: String = "",
+    val field1641: String = "",
+    val field1642: String = "",
+    val field1643: String = "",
+    val field1644: String = "",
+    val field1645: String = "",
+    val field1646: String = "",
+    val field1647: String = "",
+    val field1648: String = "",
+    val field1649: String = "",
+    val field1650: String = "",
+    val field1651: String = "",
+    val field1652: String = "",
+    val field1653: String = "",
+    val field1654: String = "",
+    val field1655: String = "",
+    val field1656: String = "",
+    val field1657: String = "",
+    val field1658: String = "",
+    val field1659: String = "",
+    val field1660: String = "",
+    val field1661: String = "",
+    val field1662: String = "",
+    val field1663: String = "",
+    val field1664: String = "",
+    val field1665: String = "",
+    val field1666: String = "",
+    val field1667: String = "",
+    val field1668: String = "",
+    val field1669: String = "",
+    val field1670: String = "",
+    val field1671: String = "",
+    val field1672: String = "",
+    val field1673: String = "",
+    val field1674: String = "",
+    val field1675: String = "",
+    val field1676: String = "",
+    val field1677: String = "",
+    val field1678: String = "",
+    val field1679: String = "",
+    val field1680: String = "",
+    val field1681: String = "",
+    val field1682: String = "",
+    val field1683: String = "",
+    val field1684: String = "",
+    val field1685: String = "",
+    val field1686: String = "",
+    val field1687: String = "",
+    val field1688: String = "",
+    val field1689: String = "",
+    val field1690: String = "",
+    val field1691: String = "",
+    val field1692: String = "",
+    val field1693: String = "",
+    val field1694: String = "",
+    val field1695: String = "",
+    val field1696: String = "",
+    val field1697: String = "",
+    val field1698: String = "",
+    val field1699: String = "",
+    val field1700: String = "",
+    val field1701: String = "",
+    val field1702: String = "",
+    val field1703: String = "",
+    val field1704: String = "",
+    val field1705: String = "",
+    val field1706: String = "",
+    val field1707: String = "",
+    val field1708: String = "",
+    val field1709: String = "",
+    val field1710: String = "",
+    val field1711: String = "",
+    val field1712: String = "",
+    val field1713: String = "",
+    val field1714: String = "",
+    val field1715: String = "",
+    val field1716: String = "",
+    val field1717: String = "",
+    val field1718: String = "",
+    val field1719: String = "",
+    val field1720: String = "",
+    val field1721: String = "",
+    val field1722: String = "",
+    val field1723: String = "",
+    val field1724: String = "",
+    val field1725: String = "",
+    val field1726: String = "",
+    val field1727: String = "",
+    val field1728: String = "",
+    val field1729: String = "",
+    val field1730: String = "",
+    val field1731: String = "",
+    val field1732: String = "",
+    val field1733: String = "",
+    val field1734: String = "",
+    val field1735: String = "",
+    val field1736: String = "",
+    val field1737: String = "",
+    val field1738: String = "",
+    val field1739: String = "",
+    val field1740: String = "",
+    val field1741: String = "",
+    val field1742: String = "",
+    val field1743: String = "",
+    val field1744: String = "",
+    val field1745: String = "",
+    val field1746: String = "",
+    val field1747: String = "",
+    val field1748: String = "",
+    val field1749: String = "",
+    val field1750: String = "",
+    val field1751: String = "",
+    val field1752: String = "",
+    val field1753: String = "",
+    val field1754: String = "",
+    val field1755: String = "",
+    val field1756: String = "",
+    val field1757: String = "",
+    val field1758: String = "",
+    val field1759: String = "",
+    val field1760: String = "",
+    val field1761: String = "",
+    val field1762: String = "",
+    val field1763: String = "",
+    val field1764: String = "",
+    val field1765: String = "",
+    val field1766: String = "",
+    val field1767: String = "",
+    val field1768: String = "",
+    val field1769: String = "",
+    val field1770: String = "",
+    val field1771: String = "",
+    val field1772: String = "",
+    val field1773: String = "",
+    val field1774: String = "",
+    val field1775: String = "",
+    val field1776: String = "",
+    val field1777: String = "",
+    val field1778: String = "",
+    val field1779: String = "",
+    val field1780: String = "",
+    val field1781: String = "",
+    val field1782: String = "",
+    val field1783: String = "",
+    val field1784: String = "",
+    val field1785: String = "",
+    val field1786: String = "",
+    val field1787: String = "",
+    val field1788: String = "",
+    val field1789: String = "",
+    val field1790: String = "",
+    val field1791: String = "",
+    val field1792: String = "",
+    val field1793: String = "",
+    val field1794: String = "",
+    val field1795: String = "",
+    val field1796: String = "",
+    val field1797: String = "",
+    val field1798: String = "",
+    val field1799: String = "",
+    val field1800: String = "",
+    val field1801: String = "",
+    val field1802: String = "",
+    val field1803: String = "",
+    val field1804: String = "",
+    val field1805: String = "",
+    val field1806: String = "",
+    val field1807: String = "",
+    val field1808: String = "",
+    val field1809: String = "",
+    val field1810: String = "",
+    val field1811: String = "",
+    val field1812: String = "",
+    val field1813: String = "",
+    val field1814: String = "",
+    val field1815: String = "",
+    val field1816: String = "",
+    val field1817: String = "",
+    val field1818: String = "",
+    val field1819: String = "",
+    val field1820: String = "",
+    val field1821: String = "",
+    val field1822: String = "",
+    val field1823: String = "",
+    val field1824: String = "",
+    val field1825: String = "",
+    val field1826: String = "",
+    val field1827: String = "",
+    val field1828: String = "",
+    val field1829: String = "",
+    val field1830: String = "",
+    val field1831: String = "",
+    val field1832: String = "",
+    val field1833: String = "",
+    val field1834: String = "",
+    val field1835: String = "",
+    val field1836: String = "",
+    val field1837: String = "",
+    val field1838: String = "",
+    val field1839: String = "",
+    val field1840: String = "",
+    val field1841: String = "",
+    val field1842: String = "",
+    val field1843: String = "",
+    val field1844: String = "",
+    val field1845: String = "",
+    val field1846: String = "",
+    val field1847: String = "",
+    val field1848: String = "",
+    val field1849: String = "",
+    val field1850: String = "",
+    val field1851: String = "",
+    val field1852: String = "",
+    val field1853: String = "",
+    val field1854: String = "",
+    val field1855: String = "",
+    val field1856: String = "",
+    val field1857: String = "",
+    val field1858: String = "",
+    val field1859: String = "",
+    val field1860: String = "",
+    val field1861: String = "",
+    val field1862: String = "",
+    val field1863: String = "",
+    val field1864: String = "",
+    val field1865: String = "",
+    val field1866: String = "",
+    val field1867: String = "",
+    val field1868: String = "",
+    val field1869: String = "",
+    val field1870: String = "",
+    val field1871: String = "",
+    val field1872: String = "",
+    val field1873: String = "",
+    val field1874: String = "",
+    val field1875: String = "",
+    val field1876: String = "",
+    val field1877: String = "",
+    val field1878: String = "",
+    val field1879: String = "",
+    val field1880: String = "",
+    val field1881: String = "",
+    val field1882: String = "",
+    val field1883: String = "",
+    val field1884: String = "",
+    val field1885: String = "",
+    val field1886: String = "",
+    val field1887: String = "",
+    val field1888: String = "",
+    val field1889: String = "",
+    val field1890: String = "",
+    val field1891: String = "",
+    val field1892: String = "",
+    val field1893: String = "",
+    val field1894: String = "",
+    val field1895: String = "",
+    val field1896: String = "",
+    val field1897: String = "",
+    val field1898: String = "",
+    val field1899: String = "",
+    val field1900: String = "",
+    val field1901: String = "",
+    val field1902: String = "",
+    val field1903: String = "",
+    val field1904: String = "",
+    val field1905: String = "",
+    val field1906: String = "",
+    val field1907: String = "",
+    val field1908: String = "",
+    val field1909: String = "",
+    val field1910: String = "",
+    val field1911: String = "",
+    val field1912: String = "",
+    val field1913: String = "",
+    val field1914: String = "",
+    val field1915: String = "",
+    val field1916: String = "",
+    val field1917: String = "",
+    val field1918: String = "",
+    val field1919: String = "",
+    val field1920: String = "",
+    val field1921: String = "",
+    val field1922: String = "",
+    val field1923: String = "",
+    val field1924: String = "",
+    val field1925: String = "",
+    val field1926: String = "",
+    val field1927: String = "",
+    val field1928: String = "",
+    val field1929: String = "",
+    val field1930: String = "",
+    val field1931: String = "",
+    val field1932: String = "",
+    val field1933: String = "",
+    val field1934: String = "",
+    val field1935: String = "",
+    val field1936: String = "",
+    val field1937: String = "",
+    val field1938: String = "",
+    val field1939: String = "",
+    val field1940: String = "",
+    val field1941: String = "",
+    val field1942: String = "",
+    val field1943: String = "",
+    val field1944: String = "",
+    val field1945: String = "",
+    val field1946: String = "",
+    val field1947: String = "",
+    val field1948: String = "",
+    val field1949: String = "",
+    val field1950: String = "",
+    val field1951: String = "",
+    val field1952: String = "",
+    val field1953: String = "",
+    val field1954: String = "",
+    val field1955: String = "",
+    val field1956: String = "",
+    val field1957: String = "",
+    val field1958: String = "",
+    val field1959: String = "",
+    val field1960: String = "",
+    val field1961: String = "",
+    val field1962: String = "",
+    val field1963: String = "",
+    val field1964: String = "",
+    val field1965: String = "",
+    val field1966: String = "",
+    val field1967: String = "",
+    val field1968: String = "",
+    val field1969: String = "",
+    val field1970: String = "",
+    val field1971: String = "",
+    val field1972: String = "",
+    val field1973: String = "",
+    val field1974: String = "",
+    val field1975: String = "",
+    val field1976: String = "",
+    val field1977: String = "",
+    val field1978: String = "",
+    val field1979: String = "",
+    val field1980: String = "",
+    val field1981: String = "",
+    val field1982: String = "",
+    val field1983: String = "",
+    val field1984: String = "",
+    val field1985: String = "",
+    val field1986: String = "",
+    val field1987: String = "",
+    val field1988: String = "",
+    val field1989: String = "",
+    val field1990: String = "",
+    val field1991: String = "",
+    val field1992: String = "",
+    val field1993: String = "",
+    val field1994: String = "",
+    val field1995: String = "",
+    val field1996: String = "",
+    val field1997: String = "",
+    val field1998: String = "",
+    val field1999: String = "",
+    override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
+) : pbandk.Message {
+    override operator fun plus(other: pbandk.Message?) = protoMergeImpl(other)
+    override val descriptor get() = Companion.descriptor
+    override val protoSize by lazy { super.protoSize }
+    companion object : pbandk.Message.Companion<pbandk.testpb.MessageWithLotsOfFields> {
+        val defaultInstance by lazy { pbandk.testpb.MessageWithLotsOfFields() }
+        override fun decodeWith(u: pbandk.MessageDecoder) = pbandk.testpb.MessageWithLotsOfFields.decodeWithImpl(u)
+
+        override val descriptor: pbandk.MessageDescriptor<pbandk.testpb.MessageWithLotsOfFields> by lazy {
+            val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>(1000)
+            addFields0(fieldsList)
+            addFields1(fieldsList)
+            addFields2(fieldsList)
+            addFields3(fieldsList)
+            addFields4(fieldsList)
+            pbandk.MessageDescriptor(
+                messageClass = pbandk.testpb.MessageWithLotsOfFields::class,
+                messageCompanion = this,
+                fields = fieldsList
+            )
+        }
+        fun addFields0(fieldsList: ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>) {
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1000",
+                        number = 1000,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1000",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1000
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1001",
+                        number = 1001,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1001",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1001
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1002",
+                        number = 1002,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1002",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1002
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1003",
+                        number = 1003,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1003",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1003
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1004",
+                        number = 1004,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1004",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1004
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1005",
+                        number = 1005,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1005",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1005
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1006",
+                        number = 1006,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1006",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1006
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1007",
+                        number = 1007,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1007",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1007
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1008",
+                        number = 1008,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1008",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1008
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1009",
+                        number = 1009,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1009",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1009
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1010",
+                        number = 1010,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1010",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1010
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1011",
+                        number = 1011,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1011",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1011
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1012",
+                        number = 1012,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1012",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1012
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1013",
+                        number = 1013,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1013",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1013
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1014",
+                        number = 1014,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1014",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1014
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1015",
+                        number = 1015,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1015",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1015
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1016",
+                        number = 1016,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1016",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1016
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1017",
+                        number = 1017,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1017",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1017
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1018",
+                        number = 1018,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1018",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1018
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1019",
+                        number = 1019,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1019",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1019
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1020",
+                        number = 1020,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1020",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1020
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1021",
+                        number = 1021,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1021",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1021
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1022",
+                        number = 1022,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1022",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1022
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1023",
+                        number = 1023,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1023",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1023
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1024",
+                        number = 1024,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1024",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1024
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1025",
+                        number = 1025,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1025",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1025
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1026",
+                        number = 1026,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1026",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1026
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1027",
+                        number = 1027,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1027",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1027
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1028",
+                        number = 1028,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1028",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1028
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1029",
+                        number = 1029,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1029",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1029
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1030",
+                        number = 1030,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1030",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1030
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1031",
+                        number = 1031,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1031",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1031
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1032",
+                        number = 1032,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1032",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1032
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1033",
+                        number = 1033,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1033",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1033
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1034",
+                        number = 1034,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1034",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1034
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1035",
+                        number = 1035,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1035",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1035
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1036",
+                        number = 1036,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1036",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1036
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1037",
+                        number = 1037,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1037",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1037
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1038",
+                        number = 1038,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1038",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1038
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1039",
+                        number = 1039,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1039",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1039
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1040",
+                        number = 1040,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1040",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1040
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1041",
+                        number = 1041,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1041",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1041
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1042",
+                        number = 1042,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1042",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1042
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1043",
+                        number = 1043,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1043",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1043
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1044",
+                        number = 1044,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1044",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1044
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1045",
+                        number = 1045,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1045",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1045
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1046",
+                        number = 1046,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1046",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1046
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1047",
+                        number = 1047,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1047",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1047
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1048",
+                        number = 1048,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1048",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1048
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1049",
+                        number = 1049,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1049",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1049
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1050",
+                        number = 1050,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1050",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1050
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1051",
+                        number = 1051,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1051",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1051
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1052",
+                        number = 1052,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1052",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1052
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1053",
+                        number = 1053,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1053",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1053
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1054",
+                        number = 1054,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1054",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1054
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1055",
+                        number = 1055,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1055",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1055
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1056",
+                        number = 1056,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1056",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1056
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1057",
+                        number = 1057,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1057",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1057
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1058",
+                        number = 1058,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1058",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1058
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1059",
+                        number = 1059,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1059",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1059
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1060",
+                        number = 1060,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1060",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1060
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1061",
+                        number = 1061,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1061",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1061
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1062",
+                        number = 1062,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1062",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1062
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1063",
+                        number = 1063,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1063",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1063
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1064",
+                        number = 1064,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1064",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1064
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1065",
+                        number = 1065,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1065",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1065
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1066",
+                        number = 1066,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1066",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1066
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1067",
+                        number = 1067,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1067",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1067
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1068",
+                        number = 1068,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1068",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1068
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1069",
+                        number = 1069,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1069",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1069
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1070",
+                        number = 1070,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1070",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1070
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1071",
+                        number = 1071,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1071",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1071
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1072",
+                        number = 1072,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1072",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1072
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1073",
+                        number = 1073,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1073",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1073
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1074",
+                        number = 1074,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1074",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1074
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1075",
+                        number = 1075,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1075",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1075
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1076",
+                        number = 1076,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1076",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1076
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1077",
+                        number = 1077,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1077",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1077
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1078",
+                        number = 1078,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1078",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1078
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1079",
+                        number = 1079,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1079",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1079
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1080",
+                        number = 1080,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1080",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1080
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1081",
+                        number = 1081,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1081",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1081
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1082",
+                        number = 1082,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1082",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1082
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1083",
+                        number = 1083,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1083",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1083
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1084",
+                        number = 1084,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1084",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1084
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1085",
+                        number = 1085,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1085",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1085
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1086",
+                        number = 1086,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1086",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1086
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1087",
+                        number = 1087,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1087",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1087
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1088",
+                        number = 1088,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1088",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1088
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1089",
+                        number = 1089,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1089",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1089
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1090",
+                        number = 1090,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1090",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1090
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1091",
+                        number = 1091,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1091",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1091
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1092",
+                        number = 1092,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1092",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1092
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1093",
+                        number = 1093,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1093",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1093
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1094",
+                        number = 1094,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1094",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1094
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1095",
+                        number = 1095,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1095",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1095
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1096",
+                        number = 1096,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1096",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1096
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1097",
+                        number = 1097,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1097",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1097
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1098",
+                        number = 1098,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1098",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1098
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1099",
+                        number = 1099,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1099",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1099
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1100",
+                        number = 1100,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1100",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1100
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1101",
+                        number = 1101,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1101",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1101
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1102",
+                        number = 1102,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1102",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1102
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1103",
+                        number = 1103,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1103",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1103
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1104",
+                        number = 1104,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1104",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1104
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1105",
+                        number = 1105,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1105",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1105
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1106",
+                        number = 1106,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1106",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1106
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1107",
+                        number = 1107,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1107",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1107
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1108",
+                        number = 1108,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1108",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1108
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1109",
+                        number = 1109,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1109",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1109
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1110",
+                        number = 1110,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1110",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1110
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1111",
+                        number = 1111,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1111",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1111
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1112",
+                        number = 1112,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1112",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1112
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1113",
+                        number = 1113,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1113",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1113
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1114",
+                        number = 1114,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1114",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1114
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1115",
+                        number = 1115,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1115",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1115
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1116",
+                        number = 1116,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1116",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1116
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1117",
+                        number = 1117,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1117",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1117
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1118",
+                        number = 1118,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1118",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1118
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1119",
+                        number = 1119,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1119",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1119
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1120",
+                        number = 1120,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1120",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1120
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1121",
+                        number = 1121,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1121",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1121
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1122",
+                        number = 1122,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1122",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1122
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1123",
+                        number = 1123,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1123",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1123
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1124",
+                        number = 1124,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1124",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1124
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1125",
+                        number = 1125,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1125",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1125
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1126",
+                        number = 1126,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1126",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1126
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1127",
+                        number = 1127,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1127",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1127
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1128",
+                        number = 1128,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1128",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1128
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1129",
+                        number = 1129,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1129",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1129
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1130",
+                        number = 1130,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1130",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1130
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1131",
+                        number = 1131,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1131",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1131
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1132",
+                        number = 1132,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1132",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1132
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1133",
+                        number = 1133,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1133",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1133
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1134",
+                        number = 1134,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1134",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1134
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1135",
+                        number = 1135,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1135",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1135
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1136",
+                        number = 1136,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1136",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1136
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1137",
+                        number = 1137,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1137",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1137
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1138",
+                        number = 1138,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1138",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1138
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1139",
+                        number = 1139,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1139",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1139
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1140",
+                        number = 1140,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1140",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1140
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1141",
+                        number = 1141,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1141",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1141
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1142",
+                        number = 1142,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1142",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1142
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1143",
+                        number = 1143,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1143",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1143
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1144",
+                        number = 1144,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1144",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1144
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1145",
+                        number = 1145,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1145",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1145
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1146",
+                        number = 1146,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1146",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1146
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1147",
+                        number = 1147,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1147",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1147
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1148",
+                        number = 1148,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1148",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1148
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1149",
+                        number = 1149,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1149",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1149
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1150",
+                        number = 1150,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1150",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1150
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1151",
+                        number = 1151,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1151",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1151
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1152",
+                        number = 1152,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1152",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1152
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1153",
+                        number = 1153,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1153",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1153
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1154",
+                        number = 1154,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1154",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1154
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1155",
+                        number = 1155,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1155",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1155
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1156",
+                        number = 1156,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1156",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1156
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1157",
+                        number = 1157,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1157",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1157
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1158",
+                        number = 1158,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1158",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1158
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1159",
+                        number = 1159,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1159",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1159
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1160",
+                        number = 1160,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1160",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1160
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1161",
+                        number = 1161,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1161",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1161
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1162",
+                        number = 1162,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1162",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1162
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1163",
+                        number = 1163,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1163",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1163
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1164",
+                        number = 1164,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1164",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1164
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1165",
+                        number = 1165,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1165",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1165
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1166",
+                        number = 1166,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1166",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1166
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1167",
+                        number = 1167,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1167",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1167
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1168",
+                        number = 1168,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1168",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1168
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1169",
+                        number = 1169,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1169",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1169
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1170",
+                        number = 1170,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1170",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1170
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1171",
+                        number = 1171,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1171",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1171
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1172",
+                        number = 1172,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1172",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1172
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1173",
+                        number = 1173,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1173",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1173
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1174",
+                        number = 1174,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1174",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1174
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1175",
+                        number = 1175,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1175",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1175
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1176",
+                        number = 1176,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1176",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1176
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1177",
+                        number = 1177,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1177",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1177
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1178",
+                        number = 1178,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1178",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1178
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1179",
+                        number = 1179,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1179",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1179
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1180",
+                        number = 1180,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1180",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1180
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1181",
+                        number = 1181,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1181",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1181
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1182",
+                        number = 1182,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1182",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1182
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1183",
+                        number = 1183,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1183",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1183
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1184",
+                        number = 1184,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1184",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1184
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1185",
+                        number = 1185,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1185",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1185
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1186",
+                        number = 1186,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1186",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1186
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1187",
+                        number = 1187,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1187",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1187
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1188",
+                        number = 1188,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1188",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1188
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1189",
+                        number = 1189,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1189",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1189
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1190",
+                        number = 1190,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1190",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1190
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1191",
+                        number = 1191,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1191",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1191
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1192",
+                        number = 1192,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1192",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1192
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1193",
+                        number = 1193,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1193",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1193
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1194",
+                        number = 1194,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1194",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1194
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1195",
+                        number = 1195,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1195",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1195
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1196",
+                        number = 1196,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1196",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1196
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1197",
+                        number = 1197,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1197",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1197
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1198",
+                        number = 1198,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1198",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1198
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1199",
+                        number = 1199,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1199",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1199
+                    )
+                )
+            }
+        }
+        fun addFields1(fieldsList: ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>) {
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1200",
+                        number = 1200,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1200",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1200
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1201",
+                        number = 1201,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1201",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1201
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1202",
+                        number = 1202,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1202",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1202
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1203",
+                        number = 1203,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1203",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1203
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1204",
+                        number = 1204,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1204",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1204
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1205",
+                        number = 1205,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1205",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1205
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1206",
+                        number = 1206,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1206",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1206
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1207",
+                        number = 1207,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1207",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1207
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1208",
+                        number = 1208,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1208",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1208
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1209",
+                        number = 1209,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1209",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1209
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1210",
+                        number = 1210,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1210",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1210
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1211",
+                        number = 1211,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1211",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1211
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1212",
+                        number = 1212,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1212",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1212
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1213",
+                        number = 1213,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1213",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1213
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1214",
+                        number = 1214,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1214",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1214
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1215",
+                        number = 1215,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1215",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1215
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1216",
+                        number = 1216,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1216",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1216
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1217",
+                        number = 1217,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1217",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1217
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1218",
+                        number = 1218,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1218",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1218
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1219",
+                        number = 1219,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1219",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1219
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1220",
+                        number = 1220,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1220",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1220
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1221",
+                        number = 1221,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1221",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1221
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1222",
+                        number = 1222,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1222",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1222
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1223",
+                        number = 1223,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1223",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1223
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1224",
+                        number = 1224,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1224",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1224
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1225",
+                        number = 1225,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1225",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1225
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1226",
+                        number = 1226,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1226",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1226
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1227",
+                        number = 1227,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1227",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1227
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1228",
+                        number = 1228,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1228",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1228
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1229",
+                        number = 1229,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1229",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1229
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1230",
+                        number = 1230,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1230",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1230
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1231",
+                        number = 1231,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1231",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1231
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1232",
+                        number = 1232,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1232",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1232
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1233",
+                        number = 1233,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1233",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1233
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1234",
+                        number = 1234,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1234",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1234
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1235",
+                        number = 1235,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1235",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1235
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1236",
+                        number = 1236,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1236",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1236
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1237",
+                        number = 1237,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1237",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1237
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1238",
+                        number = 1238,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1238",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1238
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1239",
+                        number = 1239,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1239",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1239
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1240",
+                        number = 1240,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1240",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1240
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1241",
+                        number = 1241,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1241",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1241
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1242",
+                        number = 1242,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1242",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1242
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1243",
+                        number = 1243,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1243",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1243
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1244",
+                        number = 1244,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1244",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1244
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1245",
+                        number = 1245,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1245",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1245
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1246",
+                        number = 1246,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1246",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1246
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1247",
+                        number = 1247,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1247",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1247
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1248",
+                        number = 1248,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1248",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1248
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1249",
+                        number = 1249,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1249",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1249
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1250",
+                        number = 1250,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1250",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1250
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1251",
+                        number = 1251,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1251",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1251
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1252",
+                        number = 1252,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1252",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1252
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1253",
+                        number = 1253,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1253",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1253
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1254",
+                        number = 1254,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1254",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1254
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1255",
+                        number = 1255,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1255",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1255
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1256",
+                        number = 1256,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1256",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1256
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1257",
+                        number = 1257,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1257",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1257
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1258",
+                        number = 1258,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1258",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1258
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1259",
+                        number = 1259,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1259",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1259
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1260",
+                        number = 1260,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1260",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1260
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1261",
+                        number = 1261,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1261",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1261
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1262",
+                        number = 1262,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1262",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1262
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1263",
+                        number = 1263,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1263",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1263
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1264",
+                        number = 1264,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1264",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1264
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1265",
+                        number = 1265,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1265",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1265
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1266",
+                        number = 1266,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1266",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1266
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1267",
+                        number = 1267,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1267",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1267
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1268",
+                        number = 1268,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1268",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1268
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1269",
+                        number = 1269,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1269",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1269
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1270",
+                        number = 1270,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1270",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1270
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1271",
+                        number = 1271,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1271",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1271
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1272",
+                        number = 1272,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1272",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1272
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1273",
+                        number = 1273,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1273",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1273
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1274",
+                        number = 1274,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1274",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1274
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1275",
+                        number = 1275,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1275",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1275
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1276",
+                        number = 1276,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1276",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1276
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1277",
+                        number = 1277,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1277",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1277
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1278",
+                        number = 1278,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1278",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1278
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1279",
+                        number = 1279,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1279",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1279
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1280",
+                        number = 1280,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1280",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1280
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1281",
+                        number = 1281,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1281",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1281
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1282",
+                        number = 1282,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1282",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1282
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1283",
+                        number = 1283,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1283",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1283
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1284",
+                        number = 1284,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1284",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1284
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1285",
+                        number = 1285,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1285",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1285
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1286",
+                        number = 1286,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1286",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1286
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1287",
+                        number = 1287,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1287",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1287
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1288",
+                        number = 1288,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1288",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1288
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1289",
+                        number = 1289,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1289",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1289
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1290",
+                        number = 1290,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1290",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1290
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1291",
+                        number = 1291,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1291",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1291
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1292",
+                        number = 1292,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1292",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1292
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1293",
+                        number = 1293,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1293",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1293
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1294",
+                        number = 1294,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1294",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1294
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1295",
+                        number = 1295,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1295",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1295
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1296",
+                        number = 1296,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1296",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1296
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1297",
+                        number = 1297,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1297",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1297
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1298",
+                        number = 1298,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1298",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1298
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1299",
+                        number = 1299,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1299",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1299
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1300",
+                        number = 1300,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1300",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1300
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1301",
+                        number = 1301,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1301",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1301
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1302",
+                        number = 1302,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1302",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1302
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1303",
+                        number = 1303,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1303",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1303
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1304",
+                        number = 1304,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1304",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1304
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1305",
+                        number = 1305,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1305",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1305
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1306",
+                        number = 1306,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1306",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1306
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1307",
+                        number = 1307,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1307",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1307
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1308",
+                        number = 1308,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1308",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1308
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1309",
+                        number = 1309,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1309",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1309
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1310",
+                        number = 1310,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1310",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1310
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1311",
+                        number = 1311,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1311",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1311
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1312",
+                        number = 1312,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1312",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1312
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1313",
+                        number = 1313,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1313",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1313
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1314",
+                        number = 1314,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1314",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1314
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1315",
+                        number = 1315,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1315",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1315
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1316",
+                        number = 1316,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1316",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1316
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1317",
+                        number = 1317,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1317",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1317
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1318",
+                        number = 1318,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1318",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1318
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1319",
+                        number = 1319,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1319",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1319
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1320",
+                        number = 1320,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1320",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1320
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1321",
+                        number = 1321,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1321",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1321
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1322",
+                        number = 1322,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1322",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1322
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1323",
+                        number = 1323,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1323",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1323
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1324",
+                        number = 1324,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1324",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1324
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1325",
+                        number = 1325,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1325",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1325
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1326",
+                        number = 1326,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1326",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1326
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1327",
+                        number = 1327,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1327",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1327
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1328",
+                        number = 1328,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1328",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1328
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1329",
+                        number = 1329,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1329",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1329
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1330",
+                        number = 1330,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1330",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1330
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1331",
+                        number = 1331,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1331",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1331
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1332",
+                        number = 1332,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1332",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1332
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1333",
+                        number = 1333,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1333",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1333
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1334",
+                        number = 1334,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1334",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1334
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1335",
+                        number = 1335,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1335",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1335
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1336",
+                        number = 1336,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1336",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1336
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1337",
+                        number = 1337,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1337",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1337
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1338",
+                        number = 1338,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1338",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1338
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1339",
+                        number = 1339,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1339",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1339
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1340",
+                        number = 1340,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1340",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1340
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1341",
+                        number = 1341,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1341",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1341
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1342",
+                        number = 1342,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1342",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1342
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1343",
+                        number = 1343,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1343",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1343
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1344",
+                        number = 1344,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1344",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1344
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1345",
+                        number = 1345,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1345",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1345
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1346",
+                        number = 1346,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1346",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1346
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1347",
+                        number = 1347,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1347",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1347
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1348",
+                        number = 1348,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1348",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1348
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1349",
+                        number = 1349,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1349",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1349
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1350",
+                        number = 1350,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1350",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1350
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1351",
+                        number = 1351,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1351",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1351
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1352",
+                        number = 1352,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1352",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1352
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1353",
+                        number = 1353,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1353",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1353
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1354",
+                        number = 1354,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1354",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1354
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1355",
+                        number = 1355,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1355",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1355
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1356",
+                        number = 1356,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1356",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1356
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1357",
+                        number = 1357,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1357",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1357
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1358",
+                        number = 1358,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1358",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1358
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1359",
+                        number = 1359,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1359",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1359
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1360",
+                        number = 1360,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1360",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1360
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1361",
+                        number = 1361,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1361",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1361
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1362",
+                        number = 1362,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1362",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1362
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1363",
+                        number = 1363,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1363",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1363
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1364",
+                        number = 1364,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1364",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1364
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1365",
+                        number = 1365,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1365",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1365
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1366",
+                        number = 1366,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1366",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1366
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1367",
+                        number = 1367,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1367",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1367
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1368",
+                        number = 1368,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1368",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1368
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1369",
+                        number = 1369,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1369",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1369
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1370",
+                        number = 1370,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1370",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1370
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1371",
+                        number = 1371,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1371",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1371
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1372",
+                        number = 1372,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1372",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1372
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1373",
+                        number = 1373,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1373",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1373
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1374",
+                        number = 1374,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1374",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1374
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1375",
+                        number = 1375,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1375",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1375
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1376",
+                        number = 1376,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1376",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1376
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1377",
+                        number = 1377,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1377",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1377
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1378",
+                        number = 1378,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1378",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1378
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1379",
+                        number = 1379,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1379",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1379
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1380",
+                        number = 1380,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1380",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1380
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1381",
+                        number = 1381,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1381",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1381
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1382",
+                        number = 1382,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1382",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1382
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1383",
+                        number = 1383,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1383",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1383
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1384",
+                        number = 1384,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1384",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1384
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1385",
+                        number = 1385,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1385",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1385
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1386",
+                        number = 1386,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1386",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1386
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1387",
+                        number = 1387,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1387",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1387
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1388",
+                        number = 1388,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1388",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1388
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1389",
+                        number = 1389,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1389",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1389
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1390",
+                        number = 1390,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1390",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1390
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1391",
+                        number = 1391,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1391",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1391
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1392",
+                        number = 1392,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1392",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1392
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1393",
+                        number = 1393,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1393",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1393
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1394",
+                        number = 1394,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1394",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1394
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1395",
+                        number = 1395,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1395",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1395
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1396",
+                        number = 1396,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1396",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1396
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1397",
+                        number = 1397,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1397",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1397
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1398",
+                        number = 1398,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1398",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1398
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1399",
+                        number = 1399,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1399",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1399
+                    )
+                )
+            }
+        }
+        fun addFields2(fieldsList: ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>) {
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1400",
+                        number = 1400,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1400",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1400
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1401",
+                        number = 1401,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1401",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1401
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1402",
+                        number = 1402,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1402",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1402
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1403",
+                        number = 1403,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1403",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1403
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1404",
+                        number = 1404,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1404",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1404
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1405",
+                        number = 1405,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1405",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1405
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1406",
+                        number = 1406,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1406",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1406
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1407",
+                        number = 1407,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1407",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1407
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1408",
+                        number = 1408,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1408",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1408
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1409",
+                        number = 1409,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1409",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1409
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1410",
+                        number = 1410,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1410",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1410
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1411",
+                        number = 1411,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1411",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1411
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1412",
+                        number = 1412,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1412",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1412
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1413",
+                        number = 1413,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1413",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1413
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1414",
+                        number = 1414,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1414",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1414
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1415",
+                        number = 1415,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1415",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1415
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1416",
+                        number = 1416,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1416",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1416
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1417",
+                        number = 1417,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1417",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1417
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1418",
+                        number = 1418,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1418",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1418
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1419",
+                        number = 1419,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1419",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1419
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1420",
+                        number = 1420,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1420",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1420
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1421",
+                        number = 1421,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1421",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1421
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1422",
+                        number = 1422,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1422",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1422
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1423",
+                        number = 1423,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1423",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1423
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1424",
+                        number = 1424,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1424",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1424
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1425",
+                        number = 1425,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1425",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1425
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1426",
+                        number = 1426,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1426",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1426
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1427",
+                        number = 1427,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1427",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1427
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1428",
+                        number = 1428,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1428",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1428
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1429",
+                        number = 1429,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1429",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1429
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1430",
+                        number = 1430,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1430",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1430
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1431",
+                        number = 1431,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1431",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1431
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1432",
+                        number = 1432,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1432",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1432
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1433",
+                        number = 1433,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1433",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1433
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1434",
+                        number = 1434,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1434",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1434
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1435",
+                        number = 1435,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1435",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1435
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1436",
+                        number = 1436,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1436",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1436
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1437",
+                        number = 1437,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1437",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1437
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1438",
+                        number = 1438,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1438",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1438
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1439",
+                        number = 1439,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1439",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1439
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1440",
+                        number = 1440,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1440",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1440
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1441",
+                        number = 1441,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1441",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1441
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1442",
+                        number = 1442,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1442",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1442
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1443",
+                        number = 1443,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1443",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1443
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1444",
+                        number = 1444,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1444",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1444
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1445",
+                        number = 1445,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1445",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1445
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1446",
+                        number = 1446,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1446",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1446
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1447",
+                        number = 1447,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1447",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1447
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1448",
+                        number = 1448,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1448",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1448
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1449",
+                        number = 1449,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1449",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1449
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1450",
+                        number = 1450,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1450",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1450
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1451",
+                        number = 1451,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1451",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1451
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1452",
+                        number = 1452,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1452",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1452
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1453",
+                        number = 1453,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1453",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1453
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1454",
+                        number = 1454,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1454",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1454
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1455",
+                        number = 1455,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1455",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1455
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1456",
+                        number = 1456,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1456",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1456
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1457",
+                        number = 1457,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1457",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1457
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1458",
+                        number = 1458,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1458",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1458
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1459",
+                        number = 1459,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1459",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1459
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1460",
+                        number = 1460,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1460",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1460
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1461",
+                        number = 1461,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1461",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1461
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1462",
+                        number = 1462,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1462",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1462
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1463",
+                        number = 1463,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1463",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1463
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1464",
+                        number = 1464,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1464",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1464
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1465",
+                        number = 1465,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1465",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1465
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1466",
+                        number = 1466,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1466",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1466
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1467",
+                        number = 1467,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1467",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1467
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1468",
+                        number = 1468,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1468",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1468
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1469",
+                        number = 1469,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1469",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1469
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1470",
+                        number = 1470,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1470",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1470
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1471",
+                        number = 1471,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1471",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1471
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1472",
+                        number = 1472,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1472",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1472
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1473",
+                        number = 1473,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1473",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1473
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1474",
+                        number = 1474,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1474",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1474
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1475",
+                        number = 1475,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1475",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1475
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1476",
+                        number = 1476,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1476",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1476
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1477",
+                        number = 1477,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1477",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1477
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1478",
+                        number = 1478,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1478",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1478
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1479",
+                        number = 1479,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1479",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1479
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1480",
+                        number = 1480,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1480",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1480
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1481",
+                        number = 1481,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1481",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1481
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1482",
+                        number = 1482,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1482",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1482
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1483",
+                        number = 1483,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1483",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1483
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1484",
+                        number = 1484,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1484",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1484
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1485",
+                        number = 1485,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1485",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1485
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1486",
+                        number = 1486,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1486",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1486
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1487",
+                        number = 1487,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1487",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1487
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1488",
+                        number = 1488,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1488",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1488
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1489",
+                        number = 1489,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1489",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1489
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1490",
+                        number = 1490,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1490",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1490
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1491",
+                        number = 1491,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1491",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1491
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1492",
+                        number = 1492,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1492",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1492
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1493",
+                        number = 1493,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1493",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1493
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1494",
+                        number = 1494,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1494",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1494
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1495",
+                        number = 1495,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1495",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1495
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1496",
+                        number = 1496,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1496",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1496
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1497",
+                        number = 1497,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1497",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1497
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1498",
+                        number = 1498,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1498",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1498
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1499",
+                        number = 1499,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1499",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1499
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1500",
+                        number = 1500,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1500",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1500
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1501",
+                        number = 1501,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1501",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1501
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1502",
+                        number = 1502,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1502",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1502
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1503",
+                        number = 1503,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1503",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1503
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1504",
+                        number = 1504,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1504",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1504
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1505",
+                        number = 1505,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1505",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1505
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1506",
+                        number = 1506,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1506",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1506
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1507",
+                        number = 1507,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1507",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1507
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1508",
+                        number = 1508,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1508",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1508
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1509",
+                        number = 1509,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1509",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1509
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1510",
+                        number = 1510,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1510",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1510
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1511",
+                        number = 1511,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1511",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1511
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1512",
+                        number = 1512,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1512",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1512
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1513",
+                        number = 1513,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1513",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1513
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1514",
+                        number = 1514,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1514",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1514
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1515",
+                        number = 1515,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1515",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1515
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1516",
+                        number = 1516,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1516",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1516
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1517",
+                        number = 1517,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1517",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1517
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1518",
+                        number = 1518,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1518",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1518
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1519",
+                        number = 1519,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1519",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1519
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1520",
+                        number = 1520,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1520",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1520
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1521",
+                        number = 1521,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1521",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1521
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1522",
+                        number = 1522,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1522",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1522
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1523",
+                        number = 1523,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1523",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1523
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1524",
+                        number = 1524,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1524",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1524
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1525",
+                        number = 1525,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1525",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1525
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1526",
+                        number = 1526,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1526",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1526
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1527",
+                        number = 1527,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1527",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1527
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1528",
+                        number = 1528,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1528",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1528
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1529",
+                        number = 1529,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1529",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1529
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1530",
+                        number = 1530,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1530",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1530
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1531",
+                        number = 1531,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1531",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1531
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1532",
+                        number = 1532,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1532",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1532
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1533",
+                        number = 1533,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1533",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1533
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1534",
+                        number = 1534,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1534",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1534
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1535",
+                        number = 1535,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1535",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1535
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1536",
+                        number = 1536,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1536",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1536
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1537",
+                        number = 1537,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1537",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1537
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1538",
+                        number = 1538,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1538",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1538
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1539",
+                        number = 1539,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1539",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1539
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1540",
+                        number = 1540,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1540",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1540
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1541",
+                        number = 1541,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1541",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1541
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1542",
+                        number = 1542,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1542",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1542
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1543",
+                        number = 1543,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1543",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1543
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1544",
+                        number = 1544,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1544",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1544
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1545",
+                        number = 1545,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1545",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1545
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1546",
+                        number = 1546,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1546",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1546
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1547",
+                        number = 1547,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1547",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1547
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1548",
+                        number = 1548,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1548",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1548
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1549",
+                        number = 1549,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1549",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1549
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1550",
+                        number = 1550,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1550",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1550
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1551",
+                        number = 1551,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1551",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1551
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1552",
+                        number = 1552,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1552",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1552
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1553",
+                        number = 1553,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1553",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1553
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1554",
+                        number = 1554,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1554",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1554
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1555",
+                        number = 1555,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1555",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1555
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1556",
+                        number = 1556,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1556",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1556
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1557",
+                        number = 1557,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1557",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1557
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1558",
+                        number = 1558,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1558",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1558
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1559",
+                        number = 1559,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1559",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1559
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1560",
+                        number = 1560,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1560",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1560
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1561",
+                        number = 1561,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1561",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1561
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1562",
+                        number = 1562,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1562",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1562
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1563",
+                        number = 1563,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1563",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1563
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1564",
+                        number = 1564,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1564",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1564
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1565",
+                        number = 1565,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1565",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1565
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1566",
+                        number = 1566,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1566",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1566
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1567",
+                        number = 1567,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1567",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1567
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1568",
+                        number = 1568,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1568",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1568
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1569",
+                        number = 1569,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1569",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1569
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1570",
+                        number = 1570,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1570",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1570
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1571",
+                        number = 1571,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1571",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1571
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1572",
+                        number = 1572,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1572",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1572
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1573",
+                        number = 1573,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1573",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1573
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1574",
+                        number = 1574,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1574",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1574
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1575",
+                        number = 1575,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1575",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1575
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1576",
+                        number = 1576,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1576",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1576
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1577",
+                        number = 1577,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1577",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1577
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1578",
+                        number = 1578,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1578",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1578
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1579",
+                        number = 1579,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1579",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1579
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1580",
+                        number = 1580,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1580",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1580
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1581",
+                        number = 1581,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1581",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1581
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1582",
+                        number = 1582,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1582",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1582
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1583",
+                        number = 1583,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1583",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1583
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1584",
+                        number = 1584,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1584",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1584
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1585",
+                        number = 1585,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1585",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1585
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1586",
+                        number = 1586,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1586",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1586
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1587",
+                        number = 1587,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1587",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1587
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1588",
+                        number = 1588,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1588",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1588
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1589",
+                        number = 1589,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1589",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1589
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1590",
+                        number = 1590,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1590",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1590
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1591",
+                        number = 1591,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1591",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1591
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1592",
+                        number = 1592,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1592",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1592
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1593",
+                        number = 1593,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1593",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1593
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1594",
+                        number = 1594,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1594",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1594
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1595",
+                        number = 1595,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1595",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1595
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1596",
+                        number = 1596,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1596",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1596
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1597",
+                        number = 1597,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1597",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1597
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1598",
+                        number = 1598,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1598",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1598
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1599",
+                        number = 1599,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1599",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1599
+                    )
+                )
+            }
+        }
+        fun addFields3(fieldsList: ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>) {
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1600",
+                        number = 1600,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1600",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1600
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1601",
+                        number = 1601,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1601",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1601
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1602",
+                        number = 1602,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1602",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1602
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1603",
+                        number = 1603,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1603",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1603
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1604",
+                        number = 1604,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1604",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1604
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1605",
+                        number = 1605,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1605",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1605
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1606",
+                        number = 1606,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1606",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1606
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1607",
+                        number = 1607,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1607",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1607
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1608",
+                        number = 1608,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1608",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1608
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1609",
+                        number = 1609,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1609",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1609
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1610",
+                        number = 1610,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1610",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1610
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1611",
+                        number = 1611,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1611",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1611
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1612",
+                        number = 1612,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1612",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1612
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1613",
+                        number = 1613,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1613",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1613
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1614",
+                        number = 1614,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1614",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1614
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1615",
+                        number = 1615,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1615",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1615
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1616",
+                        number = 1616,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1616",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1616
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1617",
+                        number = 1617,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1617",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1617
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1618",
+                        number = 1618,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1618",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1618
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1619",
+                        number = 1619,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1619",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1619
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1620",
+                        number = 1620,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1620",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1620
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1621",
+                        number = 1621,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1621",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1621
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1622",
+                        number = 1622,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1622",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1622
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1623",
+                        number = 1623,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1623",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1623
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1624",
+                        number = 1624,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1624",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1624
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1625",
+                        number = 1625,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1625",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1625
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1626",
+                        number = 1626,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1626",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1626
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1627",
+                        number = 1627,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1627",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1627
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1628",
+                        number = 1628,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1628",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1628
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1629",
+                        number = 1629,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1629",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1629
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1630",
+                        number = 1630,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1630",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1630
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1631",
+                        number = 1631,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1631",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1631
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1632",
+                        number = 1632,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1632",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1632
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1633",
+                        number = 1633,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1633",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1633
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1634",
+                        number = 1634,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1634",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1634
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1635",
+                        number = 1635,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1635",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1635
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1636",
+                        number = 1636,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1636",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1636
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1637",
+                        number = 1637,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1637",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1637
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1638",
+                        number = 1638,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1638",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1638
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1639",
+                        number = 1639,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1639",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1639
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1640",
+                        number = 1640,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1640",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1640
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1641",
+                        number = 1641,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1641",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1641
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1642",
+                        number = 1642,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1642",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1642
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1643",
+                        number = 1643,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1643",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1643
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1644",
+                        number = 1644,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1644",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1644
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1645",
+                        number = 1645,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1645",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1645
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1646",
+                        number = 1646,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1646",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1646
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1647",
+                        number = 1647,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1647",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1647
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1648",
+                        number = 1648,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1648",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1648
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1649",
+                        number = 1649,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1649",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1649
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1650",
+                        number = 1650,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1650",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1650
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1651",
+                        number = 1651,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1651",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1651
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1652",
+                        number = 1652,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1652",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1652
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1653",
+                        number = 1653,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1653",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1653
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1654",
+                        number = 1654,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1654",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1654
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1655",
+                        number = 1655,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1655",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1655
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1656",
+                        number = 1656,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1656",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1656
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1657",
+                        number = 1657,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1657",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1657
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1658",
+                        number = 1658,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1658",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1658
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1659",
+                        number = 1659,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1659",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1659
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1660",
+                        number = 1660,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1660",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1660
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1661",
+                        number = 1661,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1661",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1661
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1662",
+                        number = 1662,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1662",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1662
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1663",
+                        number = 1663,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1663",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1663
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1664",
+                        number = 1664,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1664",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1664
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1665",
+                        number = 1665,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1665",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1665
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1666",
+                        number = 1666,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1666",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1666
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1667",
+                        number = 1667,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1667",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1667
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1668",
+                        number = 1668,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1668",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1668
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1669",
+                        number = 1669,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1669",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1669
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1670",
+                        number = 1670,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1670",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1670
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1671",
+                        number = 1671,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1671",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1671
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1672",
+                        number = 1672,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1672",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1672
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1673",
+                        number = 1673,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1673",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1673
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1674",
+                        number = 1674,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1674",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1674
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1675",
+                        number = 1675,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1675",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1675
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1676",
+                        number = 1676,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1676",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1676
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1677",
+                        number = 1677,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1677",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1677
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1678",
+                        number = 1678,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1678",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1678
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1679",
+                        number = 1679,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1679",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1679
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1680",
+                        number = 1680,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1680",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1680
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1681",
+                        number = 1681,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1681",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1681
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1682",
+                        number = 1682,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1682",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1682
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1683",
+                        number = 1683,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1683",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1683
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1684",
+                        number = 1684,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1684",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1684
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1685",
+                        number = 1685,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1685",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1685
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1686",
+                        number = 1686,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1686",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1686
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1687",
+                        number = 1687,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1687",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1687
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1688",
+                        number = 1688,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1688",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1688
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1689",
+                        number = 1689,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1689",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1689
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1690",
+                        number = 1690,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1690",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1690
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1691",
+                        number = 1691,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1691",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1691
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1692",
+                        number = 1692,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1692",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1692
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1693",
+                        number = 1693,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1693",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1693
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1694",
+                        number = 1694,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1694",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1694
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1695",
+                        number = 1695,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1695",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1695
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1696",
+                        number = 1696,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1696",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1696
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1697",
+                        number = 1697,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1697",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1697
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1698",
+                        number = 1698,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1698",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1698
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1699",
+                        number = 1699,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1699",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1699
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1700",
+                        number = 1700,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1700",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1700
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1701",
+                        number = 1701,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1701",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1701
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1702",
+                        number = 1702,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1702",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1702
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1703",
+                        number = 1703,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1703",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1703
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1704",
+                        number = 1704,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1704",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1704
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1705",
+                        number = 1705,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1705",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1705
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1706",
+                        number = 1706,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1706",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1706
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1707",
+                        number = 1707,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1707",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1707
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1708",
+                        number = 1708,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1708",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1708
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1709",
+                        number = 1709,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1709",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1709
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1710",
+                        number = 1710,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1710",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1710
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1711",
+                        number = 1711,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1711",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1711
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1712",
+                        number = 1712,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1712",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1712
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1713",
+                        number = 1713,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1713",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1713
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1714",
+                        number = 1714,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1714",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1714
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1715",
+                        number = 1715,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1715",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1715
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1716",
+                        number = 1716,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1716",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1716
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1717",
+                        number = 1717,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1717",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1717
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1718",
+                        number = 1718,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1718",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1718
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1719",
+                        number = 1719,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1719",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1719
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1720",
+                        number = 1720,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1720",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1720
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1721",
+                        number = 1721,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1721",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1721
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1722",
+                        number = 1722,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1722",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1722
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1723",
+                        number = 1723,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1723",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1723
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1724",
+                        number = 1724,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1724",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1724
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1725",
+                        number = 1725,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1725",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1725
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1726",
+                        number = 1726,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1726",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1726
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1727",
+                        number = 1727,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1727",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1727
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1728",
+                        number = 1728,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1728",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1728
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1729",
+                        number = 1729,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1729",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1729
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1730",
+                        number = 1730,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1730",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1730
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1731",
+                        number = 1731,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1731",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1731
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1732",
+                        number = 1732,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1732",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1732
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1733",
+                        number = 1733,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1733",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1733
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1734",
+                        number = 1734,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1734",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1734
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1735",
+                        number = 1735,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1735",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1735
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1736",
+                        number = 1736,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1736",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1736
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1737",
+                        number = 1737,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1737",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1737
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1738",
+                        number = 1738,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1738",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1738
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1739",
+                        number = 1739,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1739",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1739
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1740",
+                        number = 1740,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1740",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1740
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1741",
+                        number = 1741,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1741",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1741
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1742",
+                        number = 1742,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1742",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1742
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1743",
+                        number = 1743,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1743",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1743
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1744",
+                        number = 1744,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1744",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1744
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1745",
+                        number = 1745,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1745",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1745
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1746",
+                        number = 1746,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1746",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1746
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1747",
+                        number = 1747,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1747",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1747
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1748",
+                        number = 1748,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1748",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1748
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1749",
+                        number = 1749,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1749",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1749
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1750",
+                        number = 1750,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1750",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1750
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1751",
+                        number = 1751,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1751",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1751
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1752",
+                        number = 1752,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1752",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1752
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1753",
+                        number = 1753,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1753",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1753
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1754",
+                        number = 1754,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1754",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1754
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1755",
+                        number = 1755,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1755",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1755
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1756",
+                        number = 1756,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1756",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1756
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1757",
+                        number = 1757,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1757",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1757
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1758",
+                        number = 1758,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1758",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1758
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1759",
+                        number = 1759,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1759",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1759
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1760",
+                        number = 1760,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1760",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1760
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1761",
+                        number = 1761,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1761",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1761
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1762",
+                        number = 1762,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1762",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1762
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1763",
+                        number = 1763,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1763",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1763
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1764",
+                        number = 1764,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1764",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1764
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1765",
+                        number = 1765,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1765",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1765
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1766",
+                        number = 1766,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1766",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1766
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1767",
+                        number = 1767,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1767",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1767
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1768",
+                        number = 1768,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1768",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1768
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1769",
+                        number = 1769,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1769",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1769
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1770",
+                        number = 1770,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1770",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1770
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1771",
+                        number = 1771,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1771",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1771
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1772",
+                        number = 1772,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1772",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1772
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1773",
+                        number = 1773,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1773",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1773
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1774",
+                        number = 1774,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1774",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1774
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1775",
+                        number = 1775,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1775",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1775
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1776",
+                        number = 1776,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1776",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1776
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1777",
+                        number = 1777,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1777",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1777
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1778",
+                        number = 1778,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1778",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1778
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1779",
+                        number = 1779,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1779",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1779
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1780",
+                        number = 1780,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1780",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1780
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1781",
+                        number = 1781,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1781",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1781
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1782",
+                        number = 1782,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1782",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1782
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1783",
+                        number = 1783,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1783",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1783
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1784",
+                        number = 1784,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1784",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1784
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1785",
+                        number = 1785,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1785",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1785
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1786",
+                        number = 1786,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1786",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1786
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1787",
+                        number = 1787,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1787",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1787
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1788",
+                        number = 1788,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1788",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1788
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1789",
+                        number = 1789,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1789",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1789
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1790",
+                        number = 1790,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1790",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1790
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1791",
+                        number = 1791,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1791",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1791
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1792",
+                        number = 1792,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1792",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1792
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1793",
+                        number = 1793,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1793",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1793
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1794",
+                        number = 1794,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1794",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1794
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1795",
+                        number = 1795,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1795",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1795
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1796",
+                        number = 1796,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1796",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1796
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1797",
+                        number = 1797,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1797",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1797
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1798",
+                        number = 1798,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1798",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1798
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1799",
+                        number = 1799,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1799",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1799
+                    )
+                )
+            }
+        }
+        fun addFields4(fieldsList: ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>) {
+            fieldsList.apply {
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1800",
+                        number = 1800,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1800",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1800
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1801",
+                        number = 1801,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1801",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1801
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1802",
+                        number = 1802,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1802",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1802
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1803",
+                        number = 1803,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1803",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1803
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1804",
+                        number = 1804,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1804",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1804
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1805",
+                        number = 1805,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1805",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1805
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1806",
+                        number = 1806,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1806",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1806
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1807",
+                        number = 1807,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1807",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1807
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1808",
+                        number = 1808,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1808",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1808
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1809",
+                        number = 1809,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1809",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1809
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1810",
+                        number = 1810,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1810",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1810
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1811",
+                        number = 1811,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1811",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1811
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1812",
+                        number = 1812,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1812",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1812
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1813",
+                        number = 1813,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1813",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1813
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1814",
+                        number = 1814,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1814",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1814
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1815",
+                        number = 1815,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1815",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1815
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1816",
+                        number = 1816,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1816",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1816
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1817",
+                        number = 1817,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1817",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1817
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1818",
+                        number = 1818,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1818",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1818
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1819",
+                        number = 1819,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1819",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1819
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1820",
+                        number = 1820,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1820",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1820
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1821",
+                        number = 1821,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1821",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1821
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1822",
+                        number = 1822,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1822",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1822
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1823",
+                        number = 1823,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1823",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1823
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1824",
+                        number = 1824,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1824",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1824
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1825",
+                        number = 1825,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1825",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1825
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1826",
+                        number = 1826,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1826",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1826
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1827",
+                        number = 1827,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1827",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1827
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1828",
+                        number = 1828,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1828",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1828
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1829",
+                        number = 1829,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1829",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1829
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1830",
+                        number = 1830,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1830",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1830
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1831",
+                        number = 1831,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1831",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1831
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1832",
+                        number = 1832,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1832",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1832
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1833",
+                        number = 1833,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1833",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1833
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1834",
+                        number = 1834,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1834",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1834
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1835",
+                        number = 1835,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1835",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1835
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1836",
+                        number = 1836,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1836",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1836
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1837",
+                        number = 1837,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1837",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1837
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1838",
+                        number = 1838,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1838",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1838
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1839",
+                        number = 1839,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1839",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1839
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1840",
+                        number = 1840,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1840",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1840
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1841",
+                        number = 1841,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1841",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1841
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1842",
+                        number = 1842,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1842",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1842
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1843",
+                        number = 1843,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1843",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1843
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1844",
+                        number = 1844,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1844",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1844
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1845",
+                        number = 1845,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1845",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1845
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1846",
+                        number = 1846,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1846",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1846
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1847",
+                        number = 1847,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1847",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1847
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1848",
+                        number = 1848,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1848",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1848
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1849",
+                        number = 1849,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1849",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1849
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1850",
+                        number = 1850,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1850",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1850
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1851",
+                        number = 1851,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1851",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1851
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1852",
+                        number = 1852,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1852",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1852
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1853",
+                        number = 1853,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1853",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1853
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1854",
+                        number = 1854,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1854",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1854
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1855",
+                        number = 1855,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1855",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1855
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1856",
+                        number = 1856,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1856",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1856
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1857",
+                        number = 1857,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1857",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1857
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1858",
+                        number = 1858,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1858",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1858
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1859",
+                        number = 1859,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1859",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1859
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1860",
+                        number = 1860,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1860",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1860
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1861",
+                        number = 1861,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1861",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1861
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1862",
+                        number = 1862,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1862",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1862
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1863",
+                        number = 1863,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1863",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1863
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1864",
+                        number = 1864,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1864",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1864
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1865",
+                        number = 1865,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1865",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1865
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1866",
+                        number = 1866,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1866",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1866
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1867",
+                        number = 1867,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1867",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1867
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1868",
+                        number = 1868,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1868",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1868
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1869",
+                        number = 1869,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1869",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1869
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1870",
+                        number = 1870,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1870",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1870
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1871",
+                        number = 1871,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1871",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1871
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1872",
+                        number = 1872,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1872",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1872
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1873",
+                        number = 1873,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1873",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1873
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1874",
+                        number = 1874,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1874",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1874
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1875",
+                        number = 1875,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1875",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1875
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1876",
+                        number = 1876,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1876",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1876
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1877",
+                        number = 1877,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1877",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1877
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1878",
+                        number = 1878,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1878",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1878
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1879",
+                        number = 1879,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1879",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1879
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1880",
+                        number = 1880,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1880",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1880
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1881",
+                        number = 1881,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1881",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1881
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1882",
+                        number = 1882,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1882",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1882
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1883",
+                        number = 1883,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1883",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1883
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1884",
+                        number = 1884,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1884",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1884
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1885",
+                        number = 1885,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1885",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1885
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1886",
+                        number = 1886,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1886",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1886
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1887",
+                        number = 1887,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1887",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1887
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1888",
+                        number = 1888,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1888",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1888
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1889",
+                        number = 1889,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1889",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1889
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1890",
+                        number = 1890,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1890",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1890
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1891",
+                        number = 1891,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1891",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1891
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1892",
+                        number = 1892,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1892",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1892
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1893",
+                        number = 1893,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1893",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1893
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1894",
+                        number = 1894,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1894",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1894
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1895",
+                        number = 1895,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1895",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1895
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1896",
+                        number = 1896,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1896",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1896
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1897",
+                        number = 1897,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1897",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1897
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1898",
+                        number = 1898,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1898",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1898
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1899",
+                        number = 1899,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1899",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1899
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1900",
+                        number = 1900,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1900",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1900
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1901",
+                        number = 1901,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1901",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1901
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1902",
+                        number = 1902,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1902",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1902
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1903",
+                        number = 1903,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1903",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1903
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1904",
+                        number = 1904,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1904",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1904
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1905",
+                        number = 1905,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1905",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1905
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1906",
+                        number = 1906,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1906",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1906
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1907",
+                        number = 1907,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1907",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1907
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1908",
+                        number = 1908,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1908",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1908
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1909",
+                        number = 1909,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1909",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1909
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1910",
+                        number = 1910,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1910",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1910
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1911",
+                        number = 1911,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1911",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1911
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1912",
+                        number = 1912,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1912",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1912
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1913",
+                        number = 1913,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1913",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1913
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1914",
+                        number = 1914,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1914",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1914
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1915",
+                        number = 1915,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1915",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1915
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1916",
+                        number = 1916,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1916",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1916
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1917",
+                        number = 1917,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1917",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1917
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1918",
+                        number = 1918,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1918",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1918
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1919",
+                        number = 1919,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1919",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1919
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1920",
+                        number = 1920,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1920",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1920
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1921",
+                        number = 1921,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1921",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1921
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1922",
+                        number = 1922,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1922",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1922
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1923",
+                        number = 1923,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1923",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1923
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1924",
+                        number = 1924,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1924",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1924
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1925",
+                        number = 1925,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1925",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1925
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1926",
+                        number = 1926,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1926",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1926
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1927",
+                        number = 1927,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1927",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1927
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1928",
+                        number = 1928,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1928",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1928
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1929",
+                        number = 1929,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1929",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1929
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1930",
+                        number = 1930,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1930",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1930
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1931",
+                        number = 1931,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1931",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1931
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1932",
+                        number = 1932,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1932",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1932
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1933",
+                        number = 1933,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1933",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1933
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1934",
+                        number = 1934,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1934",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1934
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1935",
+                        number = 1935,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1935",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1935
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1936",
+                        number = 1936,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1936",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1936
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1937",
+                        number = 1937,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1937",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1937
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1938",
+                        number = 1938,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1938",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1938
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1939",
+                        number = 1939,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1939",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1939
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1940",
+                        number = 1940,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1940",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1940
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1941",
+                        number = 1941,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1941",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1941
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1942",
+                        number = 1942,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1942",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1942
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1943",
+                        number = 1943,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1943",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1943
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1944",
+                        number = 1944,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1944",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1944
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1945",
+                        number = 1945,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1945",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1945
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1946",
+                        number = 1946,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1946",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1946
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1947",
+                        number = 1947,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1947",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1947
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1948",
+                        number = 1948,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1948",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1948
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1949",
+                        number = 1949,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1949",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1949
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1950",
+                        number = 1950,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1950",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1950
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1951",
+                        number = 1951,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1951",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1951
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1952",
+                        number = 1952,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1952",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1952
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1953",
+                        number = 1953,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1953",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1953
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1954",
+                        number = 1954,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1954",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1954
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1955",
+                        number = 1955,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1955",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1955
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1956",
+                        number = 1956,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1956",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1956
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1957",
+                        number = 1957,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1957",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1957
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1958",
+                        number = 1958,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1958",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1958
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1959",
+                        number = 1959,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1959",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1959
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1960",
+                        number = 1960,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1960",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1960
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1961",
+                        number = 1961,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1961",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1961
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1962",
+                        number = 1962,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1962",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1962
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1963",
+                        number = 1963,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1963",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1963
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1964",
+                        number = 1964,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1964",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1964
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1965",
+                        number = 1965,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1965",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1965
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1966",
+                        number = 1966,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1966",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1966
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1967",
+                        number = 1967,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1967",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1967
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1968",
+                        number = 1968,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1968",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1968
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1969",
+                        number = 1969,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1969",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1969
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1970",
+                        number = 1970,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1970",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1970
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1971",
+                        number = 1971,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1971",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1971
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1972",
+                        number = 1972,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1972",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1972
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1973",
+                        number = 1973,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1973",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1973
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1974",
+                        number = 1974,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1974",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1974
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1975",
+                        number = 1975,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1975",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1975
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1976",
+                        number = 1976,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1976",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1976
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1977",
+                        number = 1977,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1977",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1977
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1978",
+                        number = 1978,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1978",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1978
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1979",
+                        number = 1979,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1979",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1979
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1980",
+                        number = 1980,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1980",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1980
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1981",
+                        number = 1981,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1981",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1981
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1982",
+                        number = 1982,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1982",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1982
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1983",
+                        number = 1983,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1983",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1983
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1984",
+                        number = 1984,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1984",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1984
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1985",
+                        number = 1985,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1985",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1985
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1986",
+                        number = 1986,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1986",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1986
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1987",
+                        number = 1987,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1987",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1987
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1988",
+                        number = 1988,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1988",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1988
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1989",
+                        number = 1989,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1989",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1989
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1990",
+                        number = 1990,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1990",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1990
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1991",
+                        number = 1991,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1991",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1991
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1992",
+                        number = 1992,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1992",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1992
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1993",
+                        number = 1993,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1993",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1993
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1994",
+                        number = 1994,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1994",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1994
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1995",
+                        number = 1995,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1995",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1995
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1996",
+                        number = 1996,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1996",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1996
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1997",
+                        number = 1997,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1997",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1997
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1998",
+                        number = 1998,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1998",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1998
+                    )
+                )
+                add(
+                    pbandk.FieldDescriptor(
+                        messageDescriptor = this@Companion::descriptor,
+                        name = "field_1999",
+                        number = 1999,
+                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                        jsonName = "field1999",
+                        value = pbandk.testpb.MessageWithLotsOfFields::field1999
+                    )
+                )
+            }
+        }
+    }
+}
+
 data class MessageWithHugeOneof(
     val hugeOneof: HugeOneof<*>? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -29091,6 +40137,2273 @@ data class MessageWithHugeOneof(
             }
         }
     }
+}
+
+fun MessageWithLotsOfFields?.orDefault() = this ?: MessageWithLotsOfFields.defaultInstance
+
+private fun MessageWithLotsOfFields.protoMergeImpl(plus: pbandk.Message?): MessageWithLotsOfFields = (plus as? MessageWithLotsOfFields)?.let {
+    it.copy(
+        unknownFields = unknownFields + plus.unknownFields
+    )
+} ?: this
+
+@Suppress("UNCHECKED_CAST")
+private fun MessageWithLotsOfFields.Companion.decodeWithImpl(u: pbandk.MessageDecoder): MessageWithLotsOfFields {
+    var field1000 = ""
+    var field1001 = ""
+    var field1002 = ""
+    var field1003 = ""
+    var field1004 = ""
+    var field1005 = ""
+    var field1006 = ""
+    var field1007 = ""
+    var field1008 = ""
+    var field1009 = ""
+    var field1010 = ""
+    var field1011 = ""
+    var field1012 = ""
+    var field1013 = ""
+    var field1014 = ""
+    var field1015 = ""
+    var field1016 = ""
+    var field1017 = ""
+    var field1018 = ""
+    var field1019 = ""
+    var field1020 = ""
+    var field1021 = ""
+    var field1022 = ""
+    var field1023 = ""
+    var field1024 = ""
+    var field1025 = ""
+    var field1026 = ""
+    var field1027 = ""
+    var field1028 = ""
+    var field1029 = ""
+    var field1030 = ""
+    var field1031 = ""
+    var field1032 = ""
+    var field1033 = ""
+    var field1034 = ""
+    var field1035 = ""
+    var field1036 = ""
+    var field1037 = ""
+    var field1038 = ""
+    var field1039 = ""
+    var field1040 = ""
+    var field1041 = ""
+    var field1042 = ""
+    var field1043 = ""
+    var field1044 = ""
+    var field1045 = ""
+    var field1046 = ""
+    var field1047 = ""
+    var field1048 = ""
+    var field1049 = ""
+    var field1050 = ""
+    var field1051 = ""
+    var field1052 = ""
+    var field1053 = ""
+    var field1054 = ""
+    var field1055 = ""
+    var field1056 = ""
+    var field1057 = ""
+    var field1058 = ""
+    var field1059 = ""
+    var field1060 = ""
+    var field1061 = ""
+    var field1062 = ""
+    var field1063 = ""
+    var field1064 = ""
+    var field1065 = ""
+    var field1066 = ""
+    var field1067 = ""
+    var field1068 = ""
+    var field1069 = ""
+    var field1070 = ""
+    var field1071 = ""
+    var field1072 = ""
+    var field1073 = ""
+    var field1074 = ""
+    var field1075 = ""
+    var field1076 = ""
+    var field1077 = ""
+    var field1078 = ""
+    var field1079 = ""
+    var field1080 = ""
+    var field1081 = ""
+    var field1082 = ""
+    var field1083 = ""
+    var field1084 = ""
+    var field1085 = ""
+    var field1086 = ""
+    var field1087 = ""
+    var field1088 = ""
+    var field1089 = ""
+    var field1090 = ""
+    var field1091 = ""
+    var field1092 = ""
+    var field1093 = ""
+    var field1094 = ""
+    var field1095 = ""
+    var field1096 = ""
+    var field1097 = ""
+    var field1098 = ""
+    var field1099 = ""
+    var field1100 = ""
+    var field1101 = ""
+    var field1102 = ""
+    var field1103 = ""
+    var field1104 = ""
+    var field1105 = ""
+    var field1106 = ""
+    var field1107 = ""
+    var field1108 = ""
+    var field1109 = ""
+    var field1110 = ""
+    var field1111 = ""
+    var field1112 = ""
+    var field1113 = ""
+    var field1114 = ""
+    var field1115 = ""
+    var field1116 = ""
+    var field1117 = ""
+    var field1118 = ""
+    var field1119 = ""
+    var field1120 = ""
+    var field1121 = ""
+    var field1122 = ""
+    var field1123 = ""
+    var field1124 = ""
+    var field1125 = ""
+    var field1126 = ""
+    var field1127 = ""
+    var field1128 = ""
+    var field1129 = ""
+    var field1130 = ""
+    var field1131 = ""
+    var field1132 = ""
+    var field1133 = ""
+    var field1134 = ""
+    var field1135 = ""
+    var field1136 = ""
+    var field1137 = ""
+    var field1138 = ""
+    var field1139 = ""
+    var field1140 = ""
+    var field1141 = ""
+    var field1142 = ""
+    var field1143 = ""
+    var field1144 = ""
+    var field1145 = ""
+    var field1146 = ""
+    var field1147 = ""
+    var field1148 = ""
+    var field1149 = ""
+    var field1150 = ""
+    var field1151 = ""
+    var field1152 = ""
+    var field1153 = ""
+    var field1154 = ""
+    var field1155 = ""
+    var field1156 = ""
+    var field1157 = ""
+    var field1158 = ""
+    var field1159 = ""
+    var field1160 = ""
+    var field1161 = ""
+    var field1162 = ""
+    var field1163 = ""
+    var field1164 = ""
+    var field1165 = ""
+    var field1166 = ""
+    var field1167 = ""
+    var field1168 = ""
+    var field1169 = ""
+    var field1170 = ""
+    var field1171 = ""
+    var field1172 = ""
+    var field1173 = ""
+    var field1174 = ""
+    var field1175 = ""
+    var field1176 = ""
+    var field1177 = ""
+    var field1178 = ""
+    var field1179 = ""
+    var field1180 = ""
+    var field1181 = ""
+    var field1182 = ""
+    var field1183 = ""
+    var field1184 = ""
+    var field1185 = ""
+    var field1186 = ""
+    var field1187 = ""
+    var field1188 = ""
+    var field1189 = ""
+    var field1190 = ""
+    var field1191 = ""
+    var field1192 = ""
+    var field1193 = ""
+    var field1194 = ""
+    var field1195 = ""
+    var field1196 = ""
+    var field1197 = ""
+    var field1198 = ""
+    var field1199 = ""
+    var field1200 = ""
+    var field1201 = ""
+    var field1202 = ""
+    var field1203 = ""
+    var field1204 = ""
+    var field1205 = ""
+    var field1206 = ""
+    var field1207 = ""
+    var field1208 = ""
+    var field1209 = ""
+    var field1210 = ""
+    var field1211 = ""
+    var field1212 = ""
+    var field1213 = ""
+    var field1214 = ""
+    var field1215 = ""
+    var field1216 = ""
+    var field1217 = ""
+    var field1218 = ""
+    var field1219 = ""
+    var field1220 = ""
+    var field1221 = ""
+    var field1222 = ""
+    var field1223 = ""
+    var field1224 = ""
+    var field1225 = ""
+    var field1226 = ""
+    var field1227 = ""
+    var field1228 = ""
+    var field1229 = ""
+    var field1230 = ""
+    var field1231 = ""
+    var field1232 = ""
+    var field1233 = ""
+    var field1234 = ""
+    var field1235 = ""
+    var field1236 = ""
+    var field1237 = ""
+    var field1238 = ""
+    var field1239 = ""
+    var field1240 = ""
+    var field1241 = ""
+    var field1242 = ""
+    var field1243 = ""
+    var field1244 = ""
+    var field1245 = ""
+    var field1246 = ""
+    var field1247 = ""
+    var field1248 = ""
+    var field1249 = ""
+    var field1250 = ""
+    var field1251 = ""
+    var field1252 = ""
+    var field1253 = ""
+    var field1254 = ""
+    var field1255 = ""
+    var field1256 = ""
+    var field1257 = ""
+    var field1258 = ""
+    var field1259 = ""
+    var field1260 = ""
+    var field1261 = ""
+    var field1262 = ""
+    var field1263 = ""
+    var field1264 = ""
+    var field1265 = ""
+    var field1266 = ""
+    var field1267 = ""
+    var field1268 = ""
+    var field1269 = ""
+    var field1270 = ""
+    var field1271 = ""
+    var field1272 = ""
+    var field1273 = ""
+    var field1274 = ""
+    var field1275 = ""
+    var field1276 = ""
+    var field1277 = ""
+    var field1278 = ""
+    var field1279 = ""
+    var field1280 = ""
+    var field1281 = ""
+    var field1282 = ""
+    var field1283 = ""
+    var field1284 = ""
+    var field1285 = ""
+    var field1286 = ""
+    var field1287 = ""
+    var field1288 = ""
+    var field1289 = ""
+    var field1290 = ""
+    var field1291 = ""
+    var field1292 = ""
+    var field1293 = ""
+    var field1294 = ""
+    var field1295 = ""
+    var field1296 = ""
+    var field1297 = ""
+    var field1298 = ""
+    var field1299 = ""
+    var field1300 = ""
+    var field1301 = ""
+    var field1302 = ""
+    var field1303 = ""
+    var field1304 = ""
+    var field1305 = ""
+    var field1306 = ""
+    var field1307 = ""
+    var field1308 = ""
+    var field1309 = ""
+    var field1310 = ""
+    var field1311 = ""
+    var field1312 = ""
+    var field1313 = ""
+    var field1314 = ""
+    var field1315 = ""
+    var field1316 = ""
+    var field1317 = ""
+    var field1318 = ""
+    var field1319 = ""
+    var field1320 = ""
+    var field1321 = ""
+    var field1322 = ""
+    var field1323 = ""
+    var field1324 = ""
+    var field1325 = ""
+    var field1326 = ""
+    var field1327 = ""
+    var field1328 = ""
+    var field1329 = ""
+    var field1330 = ""
+    var field1331 = ""
+    var field1332 = ""
+    var field1333 = ""
+    var field1334 = ""
+    var field1335 = ""
+    var field1336 = ""
+    var field1337 = ""
+    var field1338 = ""
+    var field1339 = ""
+    var field1340 = ""
+    var field1341 = ""
+    var field1342 = ""
+    var field1343 = ""
+    var field1344 = ""
+    var field1345 = ""
+    var field1346 = ""
+    var field1347 = ""
+    var field1348 = ""
+    var field1349 = ""
+    var field1350 = ""
+    var field1351 = ""
+    var field1352 = ""
+    var field1353 = ""
+    var field1354 = ""
+    var field1355 = ""
+    var field1356 = ""
+    var field1357 = ""
+    var field1358 = ""
+    var field1359 = ""
+    var field1360 = ""
+    var field1361 = ""
+    var field1362 = ""
+    var field1363 = ""
+    var field1364 = ""
+    var field1365 = ""
+    var field1366 = ""
+    var field1367 = ""
+    var field1368 = ""
+    var field1369 = ""
+    var field1370 = ""
+    var field1371 = ""
+    var field1372 = ""
+    var field1373 = ""
+    var field1374 = ""
+    var field1375 = ""
+    var field1376 = ""
+    var field1377 = ""
+    var field1378 = ""
+    var field1379 = ""
+    var field1380 = ""
+    var field1381 = ""
+    var field1382 = ""
+    var field1383 = ""
+    var field1384 = ""
+    var field1385 = ""
+    var field1386 = ""
+    var field1387 = ""
+    var field1388 = ""
+    var field1389 = ""
+    var field1390 = ""
+    var field1391 = ""
+    var field1392 = ""
+    var field1393 = ""
+    var field1394 = ""
+    var field1395 = ""
+    var field1396 = ""
+    var field1397 = ""
+    var field1398 = ""
+    var field1399 = ""
+    var field1400 = ""
+    var field1401 = ""
+    var field1402 = ""
+    var field1403 = ""
+    var field1404 = ""
+    var field1405 = ""
+    var field1406 = ""
+    var field1407 = ""
+    var field1408 = ""
+    var field1409 = ""
+    var field1410 = ""
+    var field1411 = ""
+    var field1412 = ""
+    var field1413 = ""
+    var field1414 = ""
+    var field1415 = ""
+    var field1416 = ""
+    var field1417 = ""
+    var field1418 = ""
+    var field1419 = ""
+    var field1420 = ""
+    var field1421 = ""
+    var field1422 = ""
+    var field1423 = ""
+    var field1424 = ""
+    var field1425 = ""
+    var field1426 = ""
+    var field1427 = ""
+    var field1428 = ""
+    var field1429 = ""
+    var field1430 = ""
+    var field1431 = ""
+    var field1432 = ""
+    var field1433 = ""
+    var field1434 = ""
+    var field1435 = ""
+    var field1436 = ""
+    var field1437 = ""
+    var field1438 = ""
+    var field1439 = ""
+    var field1440 = ""
+    var field1441 = ""
+    var field1442 = ""
+    var field1443 = ""
+    var field1444 = ""
+    var field1445 = ""
+    var field1446 = ""
+    var field1447 = ""
+    var field1448 = ""
+    var field1449 = ""
+    var field1450 = ""
+    var field1451 = ""
+    var field1452 = ""
+    var field1453 = ""
+    var field1454 = ""
+    var field1455 = ""
+    var field1456 = ""
+    var field1457 = ""
+    var field1458 = ""
+    var field1459 = ""
+    var field1460 = ""
+    var field1461 = ""
+    var field1462 = ""
+    var field1463 = ""
+    var field1464 = ""
+    var field1465 = ""
+    var field1466 = ""
+    var field1467 = ""
+    var field1468 = ""
+    var field1469 = ""
+    var field1470 = ""
+    var field1471 = ""
+    var field1472 = ""
+    var field1473 = ""
+    var field1474 = ""
+    var field1475 = ""
+    var field1476 = ""
+    var field1477 = ""
+    var field1478 = ""
+    var field1479 = ""
+    var field1480 = ""
+    var field1481 = ""
+    var field1482 = ""
+    var field1483 = ""
+    var field1484 = ""
+    var field1485 = ""
+    var field1486 = ""
+    var field1487 = ""
+    var field1488 = ""
+    var field1489 = ""
+    var field1490 = ""
+    var field1491 = ""
+    var field1492 = ""
+    var field1493 = ""
+    var field1494 = ""
+    var field1495 = ""
+    var field1496 = ""
+    var field1497 = ""
+    var field1498 = ""
+    var field1499 = ""
+    var field1500 = ""
+    var field1501 = ""
+    var field1502 = ""
+    var field1503 = ""
+    var field1504 = ""
+    var field1505 = ""
+    var field1506 = ""
+    var field1507 = ""
+    var field1508 = ""
+    var field1509 = ""
+    var field1510 = ""
+    var field1511 = ""
+    var field1512 = ""
+    var field1513 = ""
+    var field1514 = ""
+    var field1515 = ""
+    var field1516 = ""
+    var field1517 = ""
+    var field1518 = ""
+    var field1519 = ""
+    var field1520 = ""
+    var field1521 = ""
+    var field1522 = ""
+    var field1523 = ""
+    var field1524 = ""
+    var field1525 = ""
+    var field1526 = ""
+    var field1527 = ""
+    var field1528 = ""
+    var field1529 = ""
+    var field1530 = ""
+    var field1531 = ""
+    var field1532 = ""
+    var field1533 = ""
+    var field1534 = ""
+    var field1535 = ""
+    var field1536 = ""
+    var field1537 = ""
+    var field1538 = ""
+    var field1539 = ""
+    var field1540 = ""
+    var field1541 = ""
+    var field1542 = ""
+    var field1543 = ""
+    var field1544 = ""
+    var field1545 = ""
+    var field1546 = ""
+    var field1547 = ""
+    var field1548 = ""
+    var field1549 = ""
+    var field1550 = ""
+    var field1551 = ""
+    var field1552 = ""
+    var field1553 = ""
+    var field1554 = ""
+    var field1555 = ""
+    var field1556 = ""
+    var field1557 = ""
+    var field1558 = ""
+    var field1559 = ""
+    var field1560 = ""
+    var field1561 = ""
+    var field1562 = ""
+    var field1563 = ""
+    var field1564 = ""
+    var field1565 = ""
+    var field1566 = ""
+    var field1567 = ""
+    var field1568 = ""
+    var field1569 = ""
+    var field1570 = ""
+    var field1571 = ""
+    var field1572 = ""
+    var field1573 = ""
+    var field1574 = ""
+    var field1575 = ""
+    var field1576 = ""
+    var field1577 = ""
+    var field1578 = ""
+    var field1579 = ""
+    var field1580 = ""
+    var field1581 = ""
+    var field1582 = ""
+    var field1583 = ""
+    var field1584 = ""
+    var field1585 = ""
+    var field1586 = ""
+    var field1587 = ""
+    var field1588 = ""
+    var field1589 = ""
+    var field1590 = ""
+    var field1591 = ""
+    var field1592 = ""
+    var field1593 = ""
+    var field1594 = ""
+    var field1595 = ""
+    var field1596 = ""
+    var field1597 = ""
+    var field1598 = ""
+    var field1599 = ""
+    var field1600 = ""
+    var field1601 = ""
+    var field1602 = ""
+    var field1603 = ""
+    var field1604 = ""
+    var field1605 = ""
+    var field1606 = ""
+    var field1607 = ""
+    var field1608 = ""
+    var field1609 = ""
+    var field1610 = ""
+    var field1611 = ""
+    var field1612 = ""
+    var field1613 = ""
+    var field1614 = ""
+    var field1615 = ""
+    var field1616 = ""
+    var field1617 = ""
+    var field1618 = ""
+    var field1619 = ""
+    var field1620 = ""
+    var field1621 = ""
+    var field1622 = ""
+    var field1623 = ""
+    var field1624 = ""
+    var field1625 = ""
+    var field1626 = ""
+    var field1627 = ""
+    var field1628 = ""
+    var field1629 = ""
+    var field1630 = ""
+    var field1631 = ""
+    var field1632 = ""
+    var field1633 = ""
+    var field1634 = ""
+    var field1635 = ""
+    var field1636 = ""
+    var field1637 = ""
+    var field1638 = ""
+    var field1639 = ""
+    var field1640 = ""
+    var field1641 = ""
+    var field1642 = ""
+    var field1643 = ""
+    var field1644 = ""
+    var field1645 = ""
+    var field1646 = ""
+    var field1647 = ""
+    var field1648 = ""
+    var field1649 = ""
+    var field1650 = ""
+    var field1651 = ""
+    var field1652 = ""
+    var field1653 = ""
+    var field1654 = ""
+    var field1655 = ""
+    var field1656 = ""
+    var field1657 = ""
+    var field1658 = ""
+    var field1659 = ""
+    var field1660 = ""
+    var field1661 = ""
+    var field1662 = ""
+    var field1663 = ""
+    var field1664 = ""
+    var field1665 = ""
+    var field1666 = ""
+    var field1667 = ""
+    var field1668 = ""
+    var field1669 = ""
+    var field1670 = ""
+    var field1671 = ""
+    var field1672 = ""
+    var field1673 = ""
+    var field1674 = ""
+    var field1675 = ""
+    var field1676 = ""
+    var field1677 = ""
+    var field1678 = ""
+    var field1679 = ""
+    var field1680 = ""
+    var field1681 = ""
+    var field1682 = ""
+    var field1683 = ""
+    var field1684 = ""
+    var field1685 = ""
+    var field1686 = ""
+    var field1687 = ""
+    var field1688 = ""
+    var field1689 = ""
+    var field1690 = ""
+    var field1691 = ""
+    var field1692 = ""
+    var field1693 = ""
+    var field1694 = ""
+    var field1695 = ""
+    var field1696 = ""
+    var field1697 = ""
+    var field1698 = ""
+    var field1699 = ""
+    var field1700 = ""
+    var field1701 = ""
+    var field1702 = ""
+    var field1703 = ""
+    var field1704 = ""
+    var field1705 = ""
+    var field1706 = ""
+    var field1707 = ""
+    var field1708 = ""
+    var field1709 = ""
+    var field1710 = ""
+    var field1711 = ""
+    var field1712 = ""
+    var field1713 = ""
+    var field1714 = ""
+    var field1715 = ""
+    var field1716 = ""
+    var field1717 = ""
+    var field1718 = ""
+    var field1719 = ""
+    var field1720 = ""
+    var field1721 = ""
+    var field1722 = ""
+    var field1723 = ""
+    var field1724 = ""
+    var field1725 = ""
+    var field1726 = ""
+    var field1727 = ""
+    var field1728 = ""
+    var field1729 = ""
+    var field1730 = ""
+    var field1731 = ""
+    var field1732 = ""
+    var field1733 = ""
+    var field1734 = ""
+    var field1735 = ""
+    var field1736 = ""
+    var field1737 = ""
+    var field1738 = ""
+    var field1739 = ""
+    var field1740 = ""
+    var field1741 = ""
+    var field1742 = ""
+    var field1743 = ""
+    var field1744 = ""
+    var field1745 = ""
+    var field1746 = ""
+    var field1747 = ""
+    var field1748 = ""
+    var field1749 = ""
+    var field1750 = ""
+    var field1751 = ""
+    var field1752 = ""
+    var field1753 = ""
+    var field1754 = ""
+    var field1755 = ""
+    var field1756 = ""
+    var field1757 = ""
+    var field1758 = ""
+    var field1759 = ""
+    var field1760 = ""
+    var field1761 = ""
+    var field1762 = ""
+    var field1763 = ""
+    var field1764 = ""
+    var field1765 = ""
+    var field1766 = ""
+    var field1767 = ""
+    var field1768 = ""
+    var field1769 = ""
+    var field1770 = ""
+    var field1771 = ""
+    var field1772 = ""
+    var field1773 = ""
+    var field1774 = ""
+    var field1775 = ""
+    var field1776 = ""
+    var field1777 = ""
+    var field1778 = ""
+    var field1779 = ""
+    var field1780 = ""
+    var field1781 = ""
+    var field1782 = ""
+    var field1783 = ""
+    var field1784 = ""
+    var field1785 = ""
+    var field1786 = ""
+    var field1787 = ""
+    var field1788 = ""
+    var field1789 = ""
+    var field1790 = ""
+    var field1791 = ""
+    var field1792 = ""
+    var field1793 = ""
+    var field1794 = ""
+    var field1795 = ""
+    var field1796 = ""
+    var field1797 = ""
+    var field1798 = ""
+    var field1799 = ""
+    var field1800 = ""
+    var field1801 = ""
+    var field1802 = ""
+    var field1803 = ""
+    var field1804 = ""
+    var field1805 = ""
+    var field1806 = ""
+    var field1807 = ""
+    var field1808 = ""
+    var field1809 = ""
+    var field1810 = ""
+    var field1811 = ""
+    var field1812 = ""
+    var field1813 = ""
+    var field1814 = ""
+    var field1815 = ""
+    var field1816 = ""
+    var field1817 = ""
+    var field1818 = ""
+    var field1819 = ""
+    var field1820 = ""
+    var field1821 = ""
+    var field1822 = ""
+    var field1823 = ""
+    var field1824 = ""
+    var field1825 = ""
+    var field1826 = ""
+    var field1827 = ""
+    var field1828 = ""
+    var field1829 = ""
+    var field1830 = ""
+    var field1831 = ""
+    var field1832 = ""
+    var field1833 = ""
+    var field1834 = ""
+    var field1835 = ""
+    var field1836 = ""
+    var field1837 = ""
+    var field1838 = ""
+    var field1839 = ""
+    var field1840 = ""
+    var field1841 = ""
+    var field1842 = ""
+    var field1843 = ""
+    var field1844 = ""
+    var field1845 = ""
+    var field1846 = ""
+    var field1847 = ""
+    var field1848 = ""
+    var field1849 = ""
+    var field1850 = ""
+    var field1851 = ""
+    var field1852 = ""
+    var field1853 = ""
+    var field1854 = ""
+    var field1855 = ""
+    var field1856 = ""
+    var field1857 = ""
+    var field1858 = ""
+    var field1859 = ""
+    var field1860 = ""
+    var field1861 = ""
+    var field1862 = ""
+    var field1863 = ""
+    var field1864 = ""
+    var field1865 = ""
+    var field1866 = ""
+    var field1867 = ""
+    var field1868 = ""
+    var field1869 = ""
+    var field1870 = ""
+    var field1871 = ""
+    var field1872 = ""
+    var field1873 = ""
+    var field1874 = ""
+    var field1875 = ""
+    var field1876 = ""
+    var field1877 = ""
+    var field1878 = ""
+    var field1879 = ""
+    var field1880 = ""
+    var field1881 = ""
+    var field1882 = ""
+    var field1883 = ""
+    var field1884 = ""
+    var field1885 = ""
+    var field1886 = ""
+    var field1887 = ""
+    var field1888 = ""
+    var field1889 = ""
+    var field1890 = ""
+    var field1891 = ""
+    var field1892 = ""
+    var field1893 = ""
+    var field1894 = ""
+    var field1895 = ""
+    var field1896 = ""
+    var field1897 = ""
+    var field1898 = ""
+    var field1899 = ""
+    var field1900 = ""
+    var field1901 = ""
+    var field1902 = ""
+    var field1903 = ""
+    var field1904 = ""
+    var field1905 = ""
+    var field1906 = ""
+    var field1907 = ""
+    var field1908 = ""
+    var field1909 = ""
+    var field1910 = ""
+    var field1911 = ""
+    var field1912 = ""
+    var field1913 = ""
+    var field1914 = ""
+    var field1915 = ""
+    var field1916 = ""
+    var field1917 = ""
+    var field1918 = ""
+    var field1919 = ""
+    var field1920 = ""
+    var field1921 = ""
+    var field1922 = ""
+    var field1923 = ""
+    var field1924 = ""
+    var field1925 = ""
+    var field1926 = ""
+    var field1927 = ""
+    var field1928 = ""
+    var field1929 = ""
+    var field1930 = ""
+    var field1931 = ""
+    var field1932 = ""
+    var field1933 = ""
+    var field1934 = ""
+    var field1935 = ""
+    var field1936 = ""
+    var field1937 = ""
+    var field1938 = ""
+    var field1939 = ""
+    var field1940 = ""
+    var field1941 = ""
+    var field1942 = ""
+    var field1943 = ""
+    var field1944 = ""
+    var field1945 = ""
+    var field1946 = ""
+    var field1947 = ""
+    var field1948 = ""
+    var field1949 = ""
+    var field1950 = ""
+    var field1951 = ""
+    var field1952 = ""
+    var field1953 = ""
+    var field1954 = ""
+    var field1955 = ""
+    var field1956 = ""
+    var field1957 = ""
+    var field1958 = ""
+    var field1959 = ""
+    var field1960 = ""
+    var field1961 = ""
+    var field1962 = ""
+    var field1963 = ""
+    var field1964 = ""
+    var field1965 = ""
+    var field1966 = ""
+    var field1967 = ""
+    var field1968 = ""
+    var field1969 = ""
+    var field1970 = ""
+    var field1971 = ""
+    var field1972 = ""
+    var field1973 = ""
+    var field1974 = ""
+    var field1975 = ""
+    var field1976 = ""
+    var field1977 = ""
+    var field1978 = ""
+    var field1979 = ""
+    var field1980 = ""
+    var field1981 = ""
+    var field1982 = ""
+    var field1983 = ""
+    var field1984 = ""
+    var field1985 = ""
+    var field1986 = ""
+    var field1987 = ""
+    var field1988 = ""
+    var field1989 = ""
+    var field1990 = ""
+    var field1991 = ""
+    var field1992 = ""
+    var field1993 = ""
+    var field1994 = ""
+    var field1995 = ""
+    var field1996 = ""
+    var field1997 = ""
+    var field1998 = ""
+    var field1999 = ""
+
+    val unknownFields = u.readMessage(this) { _fieldNumber, _fieldValue ->
+        when (_fieldNumber) {
+            1000 -> field1000 = _fieldValue as String
+            1001 -> field1001 = _fieldValue as String
+            1002 -> field1002 = _fieldValue as String
+            1003 -> field1003 = _fieldValue as String
+            1004 -> field1004 = _fieldValue as String
+            1005 -> field1005 = _fieldValue as String
+            1006 -> field1006 = _fieldValue as String
+            1007 -> field1007 = _fieldValue as String
+            1008 -> field1008 = _fieldValue as String
+            1009 -> field1009 = _fieldValue as String
+            1010 -> field1010 = _fieldValue as String
+            1011 -> field1011 = _fieldValue as String
+            1012 -> field1012 = _fieldValue as String
+            1013 -> field1013 = _fieldValue as String
+            1014 -> field1014 = _fieldValue as String
+            1015 -> field1015 = _fieldValue as String
+            1016 -> field1016 = _fieldValue as String
+            1017 -> field1017 = _fieldValue as String
+            1018 -> field1018 = _fieldValue as String
+            1019 -> field1019 = _fieldValue as String
+            1020 -> field1020 = _fieldValue as String
+            1021 -> field1021 = _fieldValue as String
+            1022 -> field1022 = _fieldValue as String
+            1023 -> field1023 = _fieldValue as String
+            1024 -> field1024 = _fieldValue as String
+            1025 -> field1025 = _fieldValue as String
+            1026 -> field1026 = _fieldValue as String
+            1027 -> field1027 = _fieldValue as String
+            1028 -> field1028 = _fieldValue as String
+            1029 -> field1029 = _fieldValue as String
+            1030 -> field1030 = _fieldValue as String
+            1031 -> field1031 = _fieldValue as String
+            1032 -> field1032 = _fieldValue as String
+            1033 -> field1033 = _fieldValue as String
+            1034 -> field1034 = _fieldValue as String
+            1035 -> field1035 = _fieldValue as String
+            1036 -> field1036 = _fieldValue as String
+            1037 -> field1037 = _fieldValue as String
+            1038 -> field1038 = _fieldValue as String
+            1039 -> field1039 = _fieldValue as String
+            1040 -> field1040 = _fieldValue as String
+            1041 -> field1041 = _fieldValue as String
+            1042 -> field1042 = _fieldValue as String
+            1043 -> field1043 = _fieldValue as String
+            1044 -> field1044 = _fieldValue as String
+            1045 -> field1045 = _fieldValue as String
+            1046 -> field1046 = _fieldValue as String
+            1047 -> field1047 = _fieldValue as String
+            1048 -> field1048 = _fieldValue as String
+            1049 -> field1049 = _fieldValue as String
+            1050 -> field1050 = _fieldValue as String
+            1051 -> field1051 = _fieldValue as String
+            1052 -> field1052 = _fieldValue as String
+            1053 -> field1053 = _fieldValue as String
+            1054 -> field1054 = _fieldValue as String
+            1055 -> field1055 = _fieldValue as String
+            1056 -> field1056 = _fieldValue as String
+            1057 -> field1057 = _fieldValue as String
+            1058 -> field1058 = _fieldValue as String
+            1059 -> field1059 = _fieldValue as String
+            1060 -> field1060 = _fieldValue as String
+            1061 -> field1061 = _fieldValue as String
+            1062 -> field1062 = _fieldValue as String
+            1063 -> field1063 = _fieldValue as String
+            1064 -> field1064 = _fieldValue as String
+            1065 -> field1065 = _fieldValue as String
+            1066 -> field1066 = _fieldValue as String
+            1067 -> field1067 = _fieldValue as String
+            1068 -> field1068 = _fieldValue as String
+            1069 -> field1069 = _fieldValue as String
+            1070 -> field1070 = _fieldValue as String
+            1071 -> field1071 = _fieldValue as String
+            1072 -> field1072 = _fieldValue as String
+            1073 -> field1073 = _fieldValue as String
+            1074 -> field1074 = _fieldValue as String
+            1075 -> field1075 = _fieldValue as String
+            1076 -> field1076 = _fieldValue as String
+            1077 -> field1077 = _fieldValue as String
+            1078 -> field1078 = _fieldValue as String
+            1079 -> field1079 = _fieldValue as String
+            1080 -> field1080 = _fieldValue as String
+            1081 -> field1081 = _fieldValue as String
+            1082 -> field1082 = _fieldValue as String
+            1083 -> field1083 = _fieldValue as String
+            1084 -> field1084 = _fieldValue as String
+            1085 -> field1085 = _fieldValue as String
+            1086 -> field1086 = _fieldValue as String
+            1087 -> field1087 = _fieldValue as String
+            1088 -> field1088 = _fieldValue as String
+            1089 -> field1089 = _fieldValue as String
+            1090 -> field1090 = _fieldValue as String
+            1091 -> field1091 = _fieldValue as String
+            1092 -> field1092 = _fieldValue as String
+            1093 -> field1093 = _fieldValue as String
+            1094 -> field1094 = _fieldValue as String
+            1095 -> field1095 = _fieldValue as String
+            1096 -> field1096 = _fieldValue as String
+            1097 -> field1097 = _fieldValue as String
+            1098 -> field1098 = _fieldValue as String
+            1099 -> field1099 = _fieldValue as String
+            1100 -> field1100 = _fieldValue as String
+            1101 -> field1101 = _fieldValue as String
+            1102 -> field1102 = _fieldValue as String
+            1103 -> field1103 = _fieldValue as String
+            1104 -> field1104 = _fieldValue as String
+            1105 -> field1105 = _fieldValue as String
+            1106 -> field1106 = _fieldValue as String
+            1107 -> field1107 = _fieldValue as String
+            1108 -> field1108 = _fieldValue as String
+            1109 -> field1109 = _fieldValue as String
+            1110 -> field1110 = _fieldValue as String
+            1111 -> field1111 = _fieldValue as String
+            1112 -> field1112 = _fieldValue as String
+            1113 -> field1113 = _fieldValue as String
+            1114 -> field1114 = _fieldValue as String
+            1115 -> field1115 = _fieldValue as String
+            1116 -> field1116 = _fieldValue as String
+            1117 -> field1117 = _fieldValue as String
+            1118 -> field1118 = _fieldValue as String
+            1119 -> field1119 = _fieldValue as String
+            1120 -> field1120 = _fieldValue as String
+            1121 -> field1121 = _fieldValue as String
+            1122 -> field1122 = _fieldValue as String
+            1123 -> field1123 = _fieldValue as String
+            1124 -> field1124 = _fieldValue as String
+            1125 -> field1125 = _fieldValue as String
+            1126 -> field1126 = _fieldValue as String
+            1127 -> field1127 = _fieldValue as String
+            1128 -> field1128 = _fieldValue as String
+            1129 -> field1129 = _fieldValue as String
+            1130 -> field1130 = _fieldValue as String
+            1131 -> field1131 = _fieldValue as String
+            1132 -> field1132 = _fieldValue as String
+            1133 -> field1133 = _fieldValue as String
+            1134 -> field1134 = _fieldValue as String
+            1135 -> field1135 = _fieldValue as String
+            1136 -> field1136 = _fieldValue as String
+            1137 -> field1137 = _fieldValue as String
+            1138 -> field1138 = _fieldValue as String
+            1139 -> field1139 = _fieldValue as String
+            1140 -> field1140 = _fieldValue as String
+            1141 -> field1141 = _fieldValue as String
+            1142 -> field1142 = _fieldValue as String
+            1143 -> field1143 = _fieldValue as String
+            1144 -> field1144 = _fieldValue as String
+            1145 -> field1145 = _fieldValue as String
+            1146 -> field1146 = _fieldValue as String
+            1147 -> field1147 = _fieldValue as String
+            1148 -> field1148 = _fieldValue as String
+            1149 -> field1149 = _fieldValue as String
+            1150 -> field1150 = _fieldValue as String
+            1151 -> field1151 = _fieldValue as String
+            1152 -> field1152 = _fieldValue as String
+            1153 -> field1153 = _fieldValue as String
+            1154 -> field1154 = _fieldValue as String
+            1155 -> field1155 = _fieldValue as String
+            1156 -> field1156 = _fieldValue as String
+            1157 -> field1157 = _fieldValue as String
+            1158 -> field1158 = _fieldValue as String
+            1159 -> field1159 = _fieldValue as String
+            1160 -> field1160 = _fieldValue as String
+            1161 -> field1161 = _fieldValue as String
+            1162 -> field1162 = _fieldValue as String
+            1163 -> field1163 = _fieldValue as String
+            1164 -> field1164 = _fieldValue as String
+            1165 -> field1165 = _fieldValue as String
+            1166 -> field1166 = _fieldValue as String
+            1167 -> field1167 = _fieldValue as String
+            1168 -> field1168 = _fieldValue as String
+            1169 -> field1169 = _fieldValue as String
+            1170 -> field1170 = _fieldValue as String
+            1171 -> field1171 = _fieldValue as String
+            1172 -> field1172 = _fieldValue as String
+            1173 -> field1173 = _fieldValue as String
+            1174 -> field1174 = _fieldValue as String
+            1175 -> field1175 = _fieldValue as String
+            1176 -> field1176 = _fieldValue as String
+            1177 -> field1177 = _fieldValue as String
+            1178 -> field1178 = _fieldValue as String
+            1179 -> field1179 = _fieldValue as String
+            1180 -> field1180 = _fieldValue as String
+            1181 -> field1181 = _fieldValue as String
+            1182 -> field1182 = _fieldValue as String
+            1183 -> field1183 = _fieldValue as String
+            1184 -> field1184 = _fieldValue as String
+            1185 -> field1185 = _fieldValue as String
+            1186 -> field1186 = _fieldValue as String
+            1187 -> field1187 = _fieldValue as String
+            1188 -> field1188 = _fieldValue as String
+            1189 -> field1189 = _fieldValue as String
+            1190 -> field1190 = _fieldValue as String
+            1191 -> field1191 = _fieldValue as String
+            1192 -> field1192 = _fieldValue as String
+            1193 -> field1193 = _fieldValue as String
+            1194 -> field1194 = _fieldValue as String
+            1195 -> field1195 = _fieldValue as String
+            1196 -> field1196 = _fieldValue as String
+            1197 -> field1197 = _fieldValue as String
+            1198 -> field1198 = _fieldValue as String
+            1199 -> field1199 = _fieldValue as String
+            1200 -> field1200 = _fieldValue as String
+            1201 -> field1201 = _fieldValue as String
+            1202 -> field1202 = _fieldValue as String
+            1203 -> field1203 = _fieldValue as String
+            1204 -> field1204 = _fieldValue as String
+            1205 -> field1205 = _fieldValue as String
+            1206 -> field1206 = _fieldValue as String
+            1207 -> field1207 = _fieldValue as String
+            1208 -> field1208 = _fieldValue as String
+            1209 -> field1209 = _fieldValue as String
+            1210 -> field1210 = _fieldValue as String
+            1211 -> field1211 = _fieldValue as String
+            1212 -> field1212 = _fieldValue as String
+            1213 -> field1213 = _fieldValue as String
+            1214 -> field1214 = _fieldValue as String
+            1215 -> field1215 = _fieldValue as String
+            1216 -> field1216 = _fieldValue as String
+            1217 -> field1217 = _fieldValue as String
+            1218 -> field1218 = _fieldValue as String
+            1219 -> field1219 = _fieldValue as String
+            1220 -> field1220 = _fieldValue as String
+            1221 -> field1221 = _fieldValue as String
+            1222 -> field1222 = _fieldValue as String
+            1223 -> field1223 = _fieldValue as String
+            1224 -> field1224 = _fieldValue as String
+            1225 -> field1225 = _fieldValue as String
+            1226 -> field1226 = _fieldValue as String
+            1227 -> field1227 = _fieldValue as String
+            1228 -> field1228 = _fieldValue as String
+            1229 -> field1229 = _fieldValue as String
+            1230 -> field1230 = _fieldValue as String
+            1231 -> field1231 = _fieldValue as String
+            1232 -> field1232 = _fieldValue as String
+            1233 -> field1233 = _fieldValue as String
+            1234 -> field1234 = _fieldValue as String
+            1235 -> field1235 = _fieldValue as String
+            1236 -> field1236 = _fieldValue as String
+            1237 -> field1237 = _fieldValue as String
+            1238 -> field1238 = _fieldValue as String
+            1239 -> field1239 = _fieldValue as String
+            1240 -> field1240 = _fieldValue as String
+            1241 -> field1241 = _fieldValue as String
+            1242 -> field1242 = _fieldValue as String
+            1243 -> field1243 = _fieldValue as String
+            1244 -> field1244 = _fieldValue as String
+            1245 -> field1245 = _fieldValue as String
+            1246 -> field1246 = _fieldValue as String
+            1247 -> field1247 = _fieldValue as String
+            1248 -> field1248 = _fieldValue as String
+            1249 -> field1249 = _fieldValue as String
+            1250 -> field1250 = _fieldValue as String
+            1251 -> field1251 = _fieldValue as String
+            1252 -> field1252 = _fieldValue as String
+            1253 -> field1253 = _fieldValue as String
+            1254 -> field1254 = _fieldValue as String
+            1255 -> field1255 = _fieldValue as String
+            1256 -> field1256 = _fieldValue as String
+            1257 -> field1257 = _fieldValue as String
+            1258 -> field1258 = _fieldValue as String
+            1259 -> field1259 = _fieldValue as String
+            1260 -> field1260 = _fieldValue as String
+            1261 -> field1261 = _fieldValue as String
+            1262 -> field1262 = _fieldValue as String
+            1263 -> field1263 = _fieldValue as String
+            1264 -> field1264 = _fieldValue as String
+            1265 -> field1265 = _fieldValue as String
+            1266 -> field1266 = _fieldValue as String
+            1267 -> field1267 = _fieldValue as String
+            1268 -> field1268 = _fieldValue as String
+            1269 -> field1269 = _fieldValue as String
+            1270 -> field1270 = _fieldValue as String
+            1271 -> field1271 = _fieldValue as String
+            1272 -> field1272 = _fieldValue as String
+            1273 -> field1273 = _fieldValue as String
+            1274 -> field1274 = _fieldValue as String
+            1275 -> field1275 = _fieldValue as String
+            1276 -> field1276 = _fieldValue as String
+            1277 -> field1277 = _fieldValue as String
+            1278 -> field1278 = _fieldValue as String
+            1279 -> field1279 = _fieldValue as String
+            1280 -> field1280 = _fieldValue as String
+            1281 -> field1281 = _fieldValue as String
+            1282 -> field1282 = _fieldValue as String
+            1283 -> field1283 = _fieldValue as String
+            1284 -> field1284 = _fieldValue as String
+            1285 -> field1285 = _fieldValue as String
+            1286 -> field1286 = _fieldValue as String
+            1287 -> field1287 = _fieldValue as String
+            1288 -> field1288 = _fieldValue as String
+            1289 -> field1289 = _fieldValue as String
+            1290 -> field1290 = _fieldValue as String
+            1291 -> field1291 = _fieldValue as String
+            1292 -> field1292 = _fieldValue as String
+            1293 -> field1293 = _fieldValue as String
+            1294 -> field1294 = _fieldValue as String
+            1295 -> field1295 = _fieldValue as String
+            1296 -> field1296 = _fieldValue as String
+            1297 -> field1297 = _fieldValue as String
+            1298 -> field1298 = _fieldValue as String
+            1299 -> field1299 = _fieldValue as String
+            1300 -> field1300 = _fieldValue as String
+            1301 -> field1301 = _fieldValue as String
+            1302 -> field1302 = _fieldValue as String
+            1303 -> field1303 = _fieldValue as String
+            1304 -> field1304 = _fieldValue as String
+            1305 -> field1305 = _fieldValue as String
+            1306 -> field1306 = _fieldValue as String
+            1307 -> field1307 = _fieldValue as String
+            1308 -> field1308 = _fieldValue as String
+            1309 -> field1309 = _fieldValue as String
+            1310 -> field1310 = _fieldValue as String
+            1311 -> field1311 = _fieldValue as String
+            1312 -> field1312 = _fieldValue as String
+            1313 -> field1313 = _fieldValue as String
+            1314 -> field1314 = _fieldValue as String
+            1315 -> field1315 = _fieldValue as String
+            1316 -> field1316 = _fieldValue as String
+            1317 -> field1317 = _fieldValue as String
+            1318 -> field1318 = _fieldValue as String
+            1319 -> field1319 = _fieldValue as String
+            1320 -> field1320 = _fieldValue as String
+            1321 -> field1321 = _fieldValue as String
+            1322 -> field1322 = _fieldValue as String
+            1323 -> field1323 = _fieldValue as String
+            1324 -> field1324 = _fieldValue as String
+            1325 -> field1325 = _fieldValue as String
+            1326 -> field1326 = _fieldValue as String
+            1327 -> field1327 = _fieldValue as String
+            1328 -> field1328 = _fieldValue as String
+            1329 -> field1329 = _fieldValue as String
+            1330 -> field1330 = _fieldValue as String
+            1331 -> field1331 = _fieldValue as String
+            1332 -> field1332 = _fieldValue as String
+            1333 -> field1333 = _fieldValue as String
+            1334 -> field1334 = _fieldValue as String
+            1335 -> field1335 = _fieldValue as String
+            1336 -> field1336 = _fieldValue as String
+            1337 -> field1337 = _fieldValue as String
+            1338 -> field1338 = _fieldValue as String
+            1339 -> field1339 = _fieldValue as String
+            1340 -> field1340 = _fieldValue as String
+            1341 -> field1341 = _fieldValue as String
+            1342 -> field1342 = _fieldValue as String
+            1343 -> field1343 = _fieldValue as String
+            1344 -> field1344 = _fieldValue as String
+            1345 -> field1345 = _fieldValue as String
+            1346 -> field1346 = _fieldValue as String
+            1347 -> field1347 = _fieldValue as String
+            1348 -> field1348 = _fieldValue as String
+            1349 -> field1349 = _fieldValue as String
+            1350 -> field1350 = _fieldValue as String
+            1351 -> field1351 = _fieldValue as String
+            1352 -> field1352 = _fieldValue as String
+            1353 -> field1353 = _fieldValue as String
+            1354 -> field1354 = _fieldValue as String
+            1355 -> field1355 = _fieldValue as String
+            1356 -> field1356 = _fieldValue as String
+            1357 -> field1357 = _fieldValue as String
+            1358 -> field1358 = _fieldValue as String
+            1359 -> field1359 = _fieldValue as String
+            1360 -> field1360 = _fieldValue as String
+            1361 -> field1361 = _fieldValue as String
+            1362 -> field1362 = _fieldValue as String
+            1363 -> field1363 = _fieldValue as String
+            1364 -> field1364 = _fieldValue as String
+            1365 -> field1365 = _fieldValue as String
+            1366 -> field1366 = _fieldValue as String
+            1367 -> field1367 = _fieldValue as String
+            1368 -> field1368 = _fieldValue as String
+            1369 -> field1369 = _fieldValue as String
+            1370 -> field1370 = _fieldValue as String
+            1371 -> field1371 = _fieldValue as String
+            1372 -> field1372 = _fieldValue as String
+            1373 -> field1373 = _fieldValue as String
+            1374 -> field1374 = _fieldValue as String
+            1375 -> field1375 = _fieldValue as String
+            1376 -> field1376 = _fieldValue as String
+            1377 -> field1377 = _fieldValue as String
+            1378 -> field1378 = _fieldValue as String
+            1379 -> field1379 = _fieldValue as String
+            1380 -> field1380 = _fieldValue as String
+            1381 -> field1381 = _fieldValue as String
+            1382 -> field1382 = _fieldValue as String
+            1383 -> field1383 = _fieldValue as String
+            1384 -> field1384 = _fieldValue as String
+            1385 -> field1385 = _fieldValue as String
+            1386 -> field1386 = _fieldValue as String
+            1387 -> field1387 = _fieldValue as String
+            1388 -> field1388 = _fieldValue as String
+            1389 -> field1389 = _fieldValue as String
+            1390 -> field1390 = _fieldValue as String
+            1391 -> field1391 = _fieldValue as String
+            1392 -> field1392 = _fieldValue as String
+            1393 -> field1393 = _fieldValue as String
+            1394 -> field1394 = _fieldValue as String
+            1395 -> field1395 = _fieldValue as String
+            1396 -> field1396 = _fieldValue as String
+            1397 -> field1397 = _fieldValue as String
+            1398 -> field1398 = _fieldValue as String
+            1399 -> field1399 = _fieldValue as String
+            1400 -> field1400 = _fieldValue as String
+            1401 -> field1401 = _fieldValue as String
+            1402 -> field1402 = _fieldValue as String
+            1403 -> field1403 = _fieldValue as String
+            1404 -> field1404 = _fieldValue as String
+            1405 -> field1405 = _fieldValue as String
+            1406 -> field1406 = _fieldValue as String
+            1407 -> field1407 = _fieldValue as String
+            1408 -> field1408 = _fieldValue as String
+            1409 -> field1409 = _fieldValue as String
+            1410 -> field1410 = _fieldValue as String
+            1411 -> field1411 = _fieldValue as String
+            1412 -> field1412 = _fieldValue as String
+            1413 -> field1413 = _fieldValue as String
+            1414 -> field1414 = _fieldValue as String
+            1415 -> field1415 = _fieldValue as String
+            1416 -> field1416 = _fieldValue as String
+            1417 -> field1417 = _fieldValue as String
+            1418 -> field1418 = _fieldValue as String
+            1419 -> field1419 = _fieldValue as String
+            1420 -> field1420 = _fieldValue as String
+            1421 -> field1421 = _fieldValue as String
+            1422 -> field1422 = _fieldValue as String
+            1423 -> field1423 = _fieldValue as String
+            1424 -> field1424 = _fieldValue as String
+            1425 -> field1425 = _fieldValue as String
+            1426 -> field1426 = _fieldValue as String
+            1427 -> field1427 = _fieldValue as String
+            1428 -> field1428 = _fieldValue as String
+            1429 -> field1429 = _fieldValue as String
+            1430 -> field1430 = _fieldValue as String
+            1431 -> field1431 = _fieldValue as String
+            1432 -> field1432 = _fieldValue as String
+            1433 -> field1433 = _fieldValue as String
+            1434 -> field1434 = _fieldValue as String
+            1435 -> field1435 = _fieldValue as String
+            1436 -> field1436 = _fieldValue as String
+            1437 -> field1437 = _fieldValue as String
+            1438 -> field1438 = _fieldValue as String
+            1439 -> field1439 = _fieldValue as String
+            1440 -> field1440 = _fieldValue as String
+            1441 -> field1441 = _fieldValue as String
+            1442 -> field1442 = _fieldValue as String
+            1443 -> field1443 = _fieldValue as String
+            1444 -> field1444 = _fieldValue as String
+            1445 -> field1445 = _fieldValue as String
+            1446 -> field1446 = _fieldValue as String
+            1447 -> field1447 = _fieldValue as String
+            1448 -> field1448 = _fieldValue as String
+            1449 -> field1449 = _fieldValue as String
+            1450 -> field1450 = _fieldValue as String
+            1451 -> field1451 = _fieldValue as String
+            1452 -> field1452 = _fieldValue as String
+            1453 -> field1453 = _fieldValue as String
+            1454 -> field1454 = _fieldValue as String
+            1455 -> field1455 = _fieldValue as String
+            1456 -> field1456 = _fieldValue as String
+            1457 -> field1457 = _fieldValue as String
+            1458 -> field1458 = _fieldValue as String
+            1459 -> field1459 = _fieldValue as String
+            1460 -> field1460 = _fieldValue as String
+            1461 -> field1461 = _fieldValue as String
+            1462 -> field1462 = _fieldValue as String
+            1463 -> field1463 = _fieldValue as String
+            1464 -> field1464 = _fieldValue as String
+            1465 -> field1465 = _fieldValue as String
+            1466 -> field1466 = _fieldValue as String
+            1467 -> field1467 = _fieldValue as String
+            1468 -> field1468 = _fieldValue as String
+            1469 -> field1469 = _fieldValue as String
+            1470 -> field1470 = _fieldValue as String
+            1471 -> field1471 = _fieldValue as String
+            1472 -> field1472 = _fieldValue as String
+            1473 -> field1473 = _fieldValue as String
+            1474 -> field1474 = _fieldValue as String
+            1475 -> field1475 = _fieldValue as String
+            1476 -> field1476 = _fieldValue as String
+            1477 -> field1477 = _fieldValue as String
+            1478 -> field1478 = _fieldValue as String
+            1479 -> field1479 = _fieldValue as String
+            1480 -> field1480 = _fieldValue as String
+            1481 -> field1481 = _fieldValue as String
+            1482 -> field1482 = _fieldValue as String
+            1483 -> field1483 = _fieldValue as String
+            1484 -> field1484 = _fieldValue as String
+            1485 -> field1485 = _fieldValue as String
+            1486 -> field1486 = _fieldValue as String
+            1487 -> field1487 = _fieldValue as String
+            1488 -> field1488 = _fieldValue as String
+            1489 -> field1489 = _fieldValue as String
+            1490 -> field1490 = _fieldValue as String
+            1491 -> field1491 = _fieldValue as String
+            1492 -> field1492 = _fieldValue as String
+            1493 -> field1493 = _fieldValue as String
+            1494 -> field1494 = _fieldValue as String
+            1495 -> field1495 = _fieldValue as String
+            1496 -> field1496 = _fieldValue as String
+            1497 -> field1497 = _fieldValue as String
+            1498 -> field1498 = _fieldValue as String
+            1499 -> field1499 = _fieldValue as String
+            1500 -> field1500 = _fieldValue as String
+            1501 -> field1501 = _fieldValue as String
+            1502 -> field1502 = _fieldValue as String
+            1503 -> field1503 = _fieldValue as String
+            1504 -> field1504 = _fieldValue as String
+            1505 -> field1505 = _fieldValue as String
+            1506 -> field1506 = _fieldValue as String
+            1507 -> field1507 = _fieldValue as String
+            1508 -> field1508 = _fieldValue as String
+            1509 -> field1509 = _fieldValue as String
+            1510 -> field1510 = _fieldValue as String
+            1511 -> field1511 = _fieldValue as String
+            1512 -> field1512 = _fieldValue as String
+            1513 -> field1513 = _fieldValue as String
+            1514 -> field1514 = _fieldValue as String
+            1515 -> field1515 = _fieldValue as String
+            1516 -> field1516 = _fieldValue as String
+            1517 -> field1517 = _fieldValue as String
+            1518 -> field1518 = _fieldValue as String
+            1519 -> field1519 = _fieldValue as String
+            1520 -> field1520 = _fieldValue as String
+            1521 -> field1521 = _fieldValue as String
+            1522 -> field1522 = _fieldValue as String
+            1523 -> field1523 = _fieldValue as String
+            1524 -> field1524 = _fieldValue as String
+            1525 -> field1525 = _fieldValue as String
+            1526 -> field1526 = _fieldValue as String
+            1527 -> field1527 = _fieldValue as String
+            1528 -> field1528 = _fieldValue as String
+            1529 -> field1529 = _fieldValue as String
+            1530 -> field1530 = _fieldValue as String
+            1531 -> field1531 = _fieldValue as String
+            1532 -> field1532 = _fieldValue as String
+            1533 -> field1533 = _fieldValue as String
+            1534 -> field1534 = _fieldValue as String
+            1535 -> field1535 = _fieldValue as String
+            1536 -> field1536 = _fieldValue as String
+            1537 -> field1537 = _fieldValue as String
+            1538 -> field1538 = _fieldValue as String
+            1539 -> field1539 = _fieldValue as String
+            1540 -> field1540 = _fieldValue as String
+            1541 -> field1541 = _fieldValue as String
+            1542 -> field1542 = _fieldValue as String
+            1543 -> field1543 = _fieldValue as String
+            1544 -> field1544 = _fieldValue as String
+            1545 -> field1545 = _fieldValue as String
+            1546 -> field1546 = _fieldValue as String
+            1547 -> field1547 = _fieldValue as String
+            1548 -> field1548 = _fieldValue as String
+            1549 -> field1549 = _fieldValue as String
+            1550 -> field1550 = _fieldValue as String
+            1551 -> field1551 = _fieldValue as String
+            1552 -> field1552 = _fieldValue as String
+            1553 -> field1553 = _fieldValue as String
+            1554 -> field1554 = _fieldValue as String
+            1555 -> field1555 = _fieldValue as String
+            1556 -> field1556 = _fieldValue as String
+            1557 -> field1557 = _fieldValue as String
+            1558 -> field1558 = _fieldValue as String
+            1559 -> field1559 = _fieldValue as String
+            1560 -> field1560 = _fieldValue as String
+            1561 -> field1561 = _fieldValue as String
+            1562 -> field1562 = _fieldValue as String
+            1563 -> field1563 = _fieldValue as String
+            1564 -> field1564 = _fieldValue as String
+            1565 -> field1565 = _fieldValue as String
+            1566 -> field1566 = _fieldValue as String
+            1567 -> field1567 = _fieldValue as String
+            1568 -> field1568 = _fieldValue as String
+            1569 -> field1569 = _fieldValue as String
+            1570 -> field1570 = _fieldValue as String
+            1571 -> field1571 = _fieldValue as String
+            1572 -> field1572 = _fieldValue as String
+            1573 -> field1573 = _fieldValue as String
+            1574 -> field1574 = _fieldValue as String
+            1575 -> field1575 = _fieldValue as String
+            1576 -> field1576 = _fieldValue as String
+            1577 -> field1577 = _fieldValue as String
+            1578 -> field1578 = _fieldValue as String
+            1579 -> field1579 = _fieldValue as String
+            1580 -> field1580 = _fieldValue as String
+            1581 -> field1581 = _fieldValue as String
+            1582 -> field1582 = _fieldValue as String
+            1583 -> field1583 = _fieldValue as String
+            1584 -> field1584 = _fieldValue as String
+            1585 -> field1585 = _fieldValue as String
+            1586 -> field1586 = _fieldValue as String
+            1587 -> field1587 = _fieldValue as String
+            1588 -> field1588 = _fieldValue as String
+            1589 -> field1589 = _fieldValue as String
+            1590 -> field1590 = _fieldValue as String
+            1591 -> field1591 = _fieldValue as String
+            1592 -> field1592 = _fieldValue as String
+            1593 -> field1593 = _fieldValue as String
+            1594 -> field1594 = _fieldValue as String
+            1595 -> field1595 = _fieldValue as String
+            1596 -> field1596 = _fieldValue as String
+            1597 -> field1597 = _fieldValue as String
+            1598 -> field1598 = _fieldValue as String
+            1599 -> field1599 = _fieldValue as String
+            1600 -> field1600 = _fieldValue as String
+            1601 -> field1601 = _fieldValue as String
+            1602 -> field1602 = _fieldValue as String
+            1603 -> field1603 = _fieldValue as String
+            1604 -> field1604 = _fieldValue as String
+            1605 -> field1605 = _fieldValue as String
+            1606 -> field1606 = _fieldValue as String
+            1607 -> field1607 = _fieldValue as String
+            1608 -> field1608 = _fieldValue as String
+            1609 -> field1609 = _fieldValue as String
+            1610 -> field1610 = _fieldValue as String
+            1611 -> field1611 = _fieldValue as String
+            1612 -> field1612 = _fieldValue as String
+            1613 -> field1613 = _fieldValue as String
+            1614 -> field1614 = _fieldValue as String
+            1615 -> field1615 = _fieldValue as String
+            1616 -> field1616 = _fieldValue as String
+            1617 -> field1617 = _fieldValue as String
+            1618 -> field1618 = _fieldValue as String
+            1619 -> field1619 = _fieldValue as String
+            1620 -> field1620 = _fieldValue as String
+            1621 -> field1621 = _fieldValue as String
+            1622 -> field1622 = _fieldValue as String
+            1623 -> field1623 = _fieldValue as String
+            1624 -> field1624 = _fieldValue as String
+            1625 -> field1625 = _fieldValue as String
+            1626 -> field1626 = _fieldValue as String
+            1627 -> field1627 = _fieldValue as String
+            1628 -> field1628 = _fieldValue as String
+            1629 -> field1629 = _fieldValue as String
+            1630 -> field1630 = _fieldValue as String
+            1631 -> field1631 = _fieldValue as String
+            1632 -> field1632 = _fieldValue as String
+            1633 -> field1633 = _fieldValue as String
+            1634 -> field1634 = _fieldValue as String
+            1635 -> field1635 = _fieldValue as String
+            1636 -> field1636 = _fieldValue as String
+            1637 -> field1637 = _fieldValue as String
+            1638 -> field1638 = _fieldValue as String
+            1639 -> field1639 = _fieldValue as String
+            1640 -> field1640 = _fieldValue as String
+            1641 -> field1641 = _fieldValue as String
+            1642 -> field1642 = _fieldValue as String
+            1643 -> field1643 = _fieldValue as String
+            1644 -> field1644 = _fieldValue as String
+            1645 -> field1645 = _fieldValue as String
+            1646 -> field1646 = _fieldValue as String
+            1647 -> field1647 = _fieldValue as String
+            1648 -> field1648 = _fieldValue as String
+            1649 -> field1649 = _fieldValue as String
+            1650 -> field1650 = _fieldValue as String
+            1651 -> field1651 = _fieldValue as String
+            1652 -> field1652 = _fieldValue as String
+            1653 -> field1653 = _fieldValue as String
+            1654 -> field1654 = _fieldValue as String
+            1655 -> field1655 = _fieldValue as String
+            1656 -> field1656 = _fieldValue as String
+            1657 -> field1657 = _fieldValue as String
+            1658 -> field1658 = _fieldValue as String
+            1659 -> field1659 = _fieldValue as String
+            1660 -> field1660 = _fieldValue as String
+            1661 -> field1661 = _fieldValue as String
+            1662 -> field1662 = _fieldValue as String
+            1663 -> field1663 = _fieldValue as String
+            1664 -> field1664 = _fieldValue as String
+            1665 -> field1665 = _fieldValue as String
+            1666 -> field1666 = _fieldValue as String
+            1667 -> field1667 = _fieldValue as String
+            1668 -> field1668 = _fieldValue as String
+            1669 -> field1669 = _fieldValue as String
+            1670 -> field1670 = _fieldValue as String
+            1671 -> field1671 = _fieldValue as String
+            1672 -> field1672 = _fieldValue as String
+            1673 -> field1673 = _fieldValue as String
+            1674 -> field1674 = _fieldValue as String
+            1675 -> field1675 = _fieldValue as String
+            1676 -> field1676 = _fieldValue as String
+            1677 -> field1677 = _fieldValue as String
+            1678 -> field1678 = _fieldValue as String
+            1679 -> field1679 = _fieldValue as String
+            1680 -> field1680 = _fieldValue as String
+            1681 -> field1681 = _fieldValue as String
+            1682 -> field1682 = _fieldValue as String
+            1683 -> field1683 = _fieldValue as String
+            1684 -> field1684 = _fieldValue as String
+            1685 -> field1685 = _fieldValue as String
+            1686 -> field1686 = _fieldValue as String
+            1687 -> field1687 = _fieldValue as String
+            1688 -> field1688 = _fieldValue as String
+            1689 -> field1689 = _fieldValue as String
+            1690 -> field1690 = _fieldValue as String
+            1691 -> field1691 = _fieldValue as String
+            1692 -> field1692 = _fieldValue as String
+            1693 -> field1693 = _fieldValue as String
+            1694 -> field1694 = _fieldValue as String
+            1695 -> field1695 = _fieldValue as String
+            1696 -> field1696 = _fieldValue as String
+            1697 -> field1697 = _fieldValue as String
+            1698 -> field1698 = _fieldValue as String
+            1699 -> field1699 = _fieldValue as String
+            1700 -> field1700 = _fieldValue as String
+            1701 -> field1701 = _fieldValue as String
+            1702 -> field1702 = _fieldValue as String
+            1703 -> field1703 = _fieldValue as String
+            1704 -> field1704 = _fieldValue as String
+            1705 -> field1705 = _fieldValue as String
+            1706 -> field1706 = _fieldValue as String
+            1707 -> field1707 = _fieldValue as String
+            1708 -> field1708 = _fieldValue as String
+            1709 -> field1709 = _fieldValue as String
+            1710 -> field1710 = _fieldValue as String
+            1711 -> field1711 = _fieldValue as String
+            1712 -> field1712 = _fieldValue as String
+            1713 -> field1713 = _fieldValue as String
+            1714 -> field1714 = _fieldValue as String
+            1715 -> field1715 = _fieldValue as String
+            1716 -> field1716 = _fieldValue as String
+            1717 -> field1717 = _fieldValue as String
+            1718 -> field1718 = _fieldValue as String
+            1719 -> field1719 = _fieldValue as String
+            1720 -> field1720 = _fieldValue as String
+            1721 -> field1721 = _fieldValue as String
+            1722 -> field1722 = _fieldValue as String
+            1723 -> field1723 = _fieldValue as String
+            1724 -> field1724 = _fieldValue as String
+            1725 -> field1725 = _fieldValue as String
+            1726 -> field1726 = _fieldValue as String
+            1727 -> field1727 = _fieldValue as String
+            1728 -> field1728 = _fieldValue as String
+            1729 -> field1729 = _fieldValue as String
+            1730 -> field1730 = _fieldValue as String
+            1731 -> field1731 = _fieldValue as String
+            1732 -> field1732 = _fieldValue as String
+            1733 -> field1733 = _fieldValue as String
+            1734 -> field1734 = _fieldValue as String
+            1735 -> field1735 = _fieldValue as String
+            1736 -> field1736 = _fieldValue as String
+            1737 -> field1737 = _fieldValue as String
+            1738 -> field1738 = _fieldValue as String
+            1739 -> field1739 = _fieldValue as String
+            1740 -> field1740 = _fieldValue as String
+            1741 -> field1741 = _fieldValue as String
+            1742 -> field1742 = _fieldValue as String
+            1743 -> field1743 = _fieldValue as String
+            1744 -> field1744 = _fieldValue as String
+            1745 -> field1745 = _fieldValue as String
+            1746 -> field1746 = _fieldValue as String
+            1747 -> field1747 = _fieldValue as String
+            1748 -> field1748 = _fieldValue as String
+            1749 -> field1749 = _fieldValue as String
+            1750 -> field1750 = _fieldValue as String
+            1751 -> field1751 = _fieldValue as String
+            1752 -> field1752 = _fieldValue as String
+            1753 -> field1753 = _fieldValue as String
+            1754 -> field1754 = _fieldValue as String
+            1755 -> field1755 = _fieldValue as String
+            1756 -> field1756 = _fieldValue as String
+            1757 -> field1757 = _fieldValue as String
+            1758 -> field1758 = _fieldValue as String
+            1759 -> field1759 = _fieldValue as String
+            1760 -> field1760 = _fieldValue as String
+            1761 -> field1761 = _fieldValue as String
+            1762 -> field1762 = _fieldValue as String
+            1763 -> field1763 = _fieldValue as String
+            1764 -> field1764 = _fieldValue as String
+            1765 -> field1765 = _fieldValue as String
+            1766 -> field1766 = _fieldValue as String
+            1767 -> field1767 = _fieldValue as String
+            1768 -> field1768 = _fieldValue as String
+            1769 -> field1769 = _fieldValue as String
+            1770 -> field1770 = _fieldValue as String
+            1771 -> field1771 = _fieldValue as String
+            1772 -> field1772 = _fieldValue as String
+            1773 -> field1773 = _fieldValue as String
+            1774 -> field1774 = _fieldValue as String
+            1775 -> field1775 = _fieldValue as String
+            1776 -> field1776 = _fieldValue as String
+            1777 -> field1777 = _fieldValue as String
+            1778 -> field1778 = _fieldValue as String
+            1779 -> field1779 = _fieldValue as String
+            1780 -> field1780 = _fieldValue as String
+            1781 -> field1781 = _fieldValue as String
+            1782 -> field1782 = _fieldValue as String
+            1783 -> field1783 = _fieldValue as String
+            1784 -> field1784 = _fieldValue as String
+            1785 -> field1785 = _fieldValue as String
+            1786 -> field1786 = _fieldValue as String
+            1787 -> field1787 = _fieldValue as String
+            1788 -> field1788 = _fieldValue as String
+            1789 -> field1789 = _fieldValue as String
+            1790 -> field1790 = _fieldValue as String
+            1791 -> field1791 = _fieldValue as String
+            1792 -> field1792 = _fieldValue as String
+            1793 -> field1793 = _fieldValue as String
+            1794 -> field1794 = _fieldValue as String
+            1795 -> field1795 = _fieldValue as String
+            1796 -> field1796 = _fieldValue as String
+            1797 -> field1797 = _fieldValue as String
+            1798 -> field1798 = _fieldValue as String
+            1799 -> field1799 = _fieldValue as String
+            1800 -> field1800 = _fieldValue as String
+            1801 -> field1801 = _fieldValue as String
+            1802 -> field1802 = _fieldValue as String
+            1803 -> field1803 = _fieldValue as String
+            1804 -> field1804 = _fieldValue as String
+            1805 -> field1805 = _fieldValue as String
+            1806 -> field1806 = _fieldValue as String
+            1807 -> field1807 = _fieldValue as String
+            1808 -> field1808 = _fieldValue as String
+            1809 -> field1809 = _fieldValue as String
+            1810 -> field1810 = _fieldValue as String
+            1811 -> field1811 = _fieldValue as String
+            1812 -> field1812 = _fieldValue as String
+            1813 -> field1813 = _fieldValue as String
+            1814 -> field1814 = _fieldValue as String
+            1815 -> field1815 = _fieldValue as String
+            1816 -> field1816 = _fieldValue as String
+            1817 -> field1817 = _fieldValue as String
+            1818 -> field1818 = _fieldValue as String
+            1819 -> field1819 = _fieldValue as String
+            1820 -> field1820 = _fieldValue as String
+            1821 -> field1821 = _fieldValue as String
+            1822 -> field1822 = _fieldValue as String
+            1823 -> field1823 = _fieldValue as String
+            1824 -> field1824 = _fieldValue as String
+            1825 -> field1825 = _fieldValue as String
+            1826 -> field1826 = _fieldValue as String
+            1827 -> field1827 = _fieldValue as String
+            1828 -> field1828 = _fieldValue as String
+            1829 -> field1829 = _fieldValue as String
+            1830 -> field1830 = _fieldValue as String
+            1831 -> field1831 = _fieldValue as String
+            1832 -> field1832 = _fieldValue as String
+            1833 -> field1833 = _fieldValue as String
+            1834 -> field1834 = _fieldValue as String
+            1835 -> field1835 = _fieldValue as String
+            1836 -> field1836 = _fieldValue as String
+            1837 -> field1837 = _fieldValue as String
+            1838 -> field1838 = _fieldValue as String
+            1839 -> field1839 = _fieldValue as String
+            1840 -> field1840 = _fieldValue as String
+            1841 -> field1841 = _fieldValue as String
+            1842 -> field1842 = _fieldValue as String
+            1843 -> field1843 = _fieldValue as String
+            1844 -> field1844 = _fieldValue as String
+            1845 -> field1845 = _fieldValue as String
+            1846 -> field1846 = _fieldValue as String
+            1847 -> field1847 = _fieldValue as String
+            1848 -> field1848 = _fieldValue as String
+            1849 -> field1849 = _fieldValue as String
+            1850 -> field1850 = _fieldValue as String
+            1851 -> field1851 = _fieldValue as String
+            1852 -> field1852 = _fieldValue as String
+            1853 -> field1853 = _fieldValue as String
+            1854 -> field1854 = _fieldValue as String
+            1855 -> field1855 = _fieldValue as String
+            1856 -> field1856 = _fieldValue as String
+            1857 -> field1857 = _fieldValue as String
+            1858 -> field1858 = _fieldValue as String
+            1859 -> field1859 = _fieldValue as String
+            1860 -> field1860 = _fieldValue as String
+            1861 -> field1861 = _fieldValue as String
+            1862 -> field1862 = _fieldValue as String
+            1863 -> field1863 = _fieldValue as String
+            1864 -> field1864 = _fieldValue as String
+            1865 -> field1865 = _fieldValue as String
+            1866 -> field1866 = _fieldValue as String
+            1867 -> field1867 = _fieldValue as String
+            1868 -> field1868 = _fieldValue as String
+            1869 -> field1869 = _fieldValue as String
+            1870 -> field1870 = _fieldValue as String
+            1871 -> field1871 = _fieldValue as String
+            1872 -> field1872 = _fieldValue as String
+            1873 -> field1873 = _fieldValue as String
+            1874 -> field1874 = _fieldValue as String
+            1875 -> field1875 = _fieldValue as String
+            1876 -> field1876 = _fieldValue as String
+            1877 -> field1877 = _fieldValue as String
+            1878 -> field1878 = _fieldValue as String
+            1879 -> field1879 = _fieldValue as String
+            1880 -> field1880 = _fieldValue as String
+            1881 -> field1881 = _fieldValue as String
+            1882 -> field1882 = _fieldValue as String
+            1883 -> field1883 = _fieldValue as String
+            1884 -> field1884 = _fieldValue as String
+            1885 -> field1885 = _fieldValue as String
+            1886 -> field1886 = _fieldValue as String
+            1887 -> field1887 = _fieldValue as String
+            1888 -> field1888 = _fieldValue as String
+            1889 -> field1889 = _fieldValue as String
+            1890 -> field1890 = _fieldValue as String
+            1891 -> field1891 = _fieldValue as String
+            1892 -> field1892 = _fieldValue as String
+            1893 -> field1893 = _fieldValue as String
+            1894 -> field1894 = _fieldValue as String
+            1895 -> field1895 = _fieldValue as String
+            1896 -> field1896 = _fieldValue as String
+            1897 -> field1897 = _fieldValue as String
+            1898 -> field1898 = _fieldValue as String
+            1899 -> field1899 = _fieldValue as String
+            1900 -> field1900 = _fieldValue as String
+            1901 -> field1901 = _fieldValue as String
+            1902 -> field1902 = _fieldValue as String
+            1903 -> field1903 = _fieldValue as String
+            1904 -> field1904 = _fieldValue as String
+            1905 -> field1905 = _fieldValue as String
+            1906 -> field1906 = _fieldValue as String
+            1907 -> field1907 = _fieldValue as String
+            1908 -> field1908 = _fieldValue as String
+            1909 -> field1909 = _fieldValue as String
+            1910 -> field1910 = _fieldValue as String
+            1911 -> field1911 = _fieldValue as String
+            1912 -> field1912 = _fieldValue as String
+            1913 -> field1913 = _fieldValue as String
+            1914 -> field1914 = _fieldValue as String
+            1915 -> field1915 = _fieldValue as String
+            1916 -> field1916 = _fieldValue as String
+            1917 -> field1917 = _fieldValue as String
+            1918 -> field1918 = _fieldValue as String
+            1919 -> field1919 = _fieldValue as String
+            1920 -> field1920 = _fieldValue as String
+            1921 -> field1921 = _fieldValue as String
+            1922 -> field1922 = _fieldValue as String
+            1923 -> field1923 = _fieldValue as String
+            1924 -> field1924 = _fieldValue as String
+            1925 -> field1925 = _fieldValue as String
+            1926 -> field1926 = _fieldValue as String
+            1927 -> field1927 = _fieldValue as String
+            1928 -> field1928 = _fieldValue as String
+            1929 -> field1929 = _fieldValue as String
+            1930 -> field1930 = _fieldValue as String
+            1931 -> field1931 = _fieldValue as String
+            1932 -> field1932 = _fieldValue as String
+            1933 -> field1933 = _fieldValue as String
+            1934 -> field1934 = _fieldValue as String
+            1935 -> field1935 = _fieldValue as String
+            1936 -> field1936 = _fieldValue as String
+            1937 -> field1937 = _fieldValue as String
+            1938 -> field1938 = _fieldValue as String
+            1939 -> field1939 = _fieldValue as String
+            1940 -> field1940 = _fieldValue as String
+            1941 -> field1941 = _fieldValue as String
+            1942 -> field1942 = _fieldValue as String
+            1943 -> field1943 = _fieldValue as String
+            1944 -> field1944 = _fieldValue as String
+            1945 -> field1945 = _fieldValue as String
+            1946 -> field1946 = _fieldValue as String
+            1947 -> field1947 = _fieldValue as String
+            1948 -> field1948 = _fieldValue as String
+            1949 -> field1949 = _fieldValue as String
+            1950 -> field1950 = _fieldValue as String
+            1951 -> field1951 = _fieldValue as String
+            1952 -> field1952 = _fieldValue as String
+            1953 -> field1953 = _fieldValue as String
+            1954 -> field1954 = _fieldValue as String
+            1955 -> field1955 = _fieldValue as String
+            1956 -> field1956 = _fieldValue as String
+            1957 -> field1957 = _fieldValue as String
+            1958 -> field1958 = _fieldValue as String
+            1959 -> field1959 = _fieldValue as String
+            1960 -> field1960 = _fieldValue as String
+            1961 -> field1961 = _fieldValue as String
+            1962 -> field1962 = _fieldValue as String
+            1963 -> field1963 = _fieldValue as String
+            1964 -> field1964 = _fieldValue as String
+            1965 -> field1965 = _fieldValue as String
+            1966 -> field1966 = _fieldValue as String
+            1967 -> field1967 = _fieldValue as String
+            1968 -> field1968 = _fieldValue as String
+            1969 -> field1969 = _fieldValue as String
+            1970 -> field1970 = _fieldValue as String
+            1971 -> field1971 = _fieldValue as String
+            1972 -> field1972 = _fieldValue as String
+            1973 -> field1973 = _fieldValue as String
+            1974 -> field1974 = _fieldValue as String
+            1975 -> field1975 = _fieldValue as String
+            1976 -> field1976 = _fieldValue as String
+            1977 -> field1977 = _fieldValue as String
+            1978 -> field1978 = _fieldValue as String
+            1979 -> field1979 = _fieldValue as String
+            1980 -> field1980 = _fieldValue as String
+            1981 -> field1981 = _fieldValue as String
+            1982 -> field1982 = _fieldValue as String
+            1983 -> field1983 = _fieldValue as String
+            1984 -> field1984 = _fieldValue as String
+            1985 -> field1985 = _fieldValue as String
+            1986 -> field1986 = _fieldValue as String
+            1987 -> field1987 = _fieldValue as String
+            1988 -> field1988 = _fieldValue as String
+            1989 -> field1989 = _fieldValue as String
+            1990 -> field1990 = _fieldValue as String
+            1991 -> field1991 = _fieldValue as String
+            1992 -> field1992 = _fieldValue as String
+            1993 -> field1993 = _fieldValue as String
+            1994 -> field1994 = _fieldValue as String
+            1995 -> field1995 = _fieldValue as String
+            1996 -> field1996 = _fieldValue as String
+            1997 -> field1997 = _fieldValue as String
+            1998 -> field1998 = _fieldValue as String
+            1999 -> field1999 = _fieldValue as String
+        }
+    }
+    return MessageWithLotsOfFields(field1000, field1001, field1002, field1003,
+        field1004, field1005, field1006, field1007,
+        field1008, field1009, field1010, field1011,
+        field1012, field1013, field1014, field1015,
+        field1016, field1017, field1018, field1019,
+        field1020, field1021, field1022, field1023,
+        field1024, field1025, field1026, field1027,
+        field1028, field1029, field1030, field1031,
+        field1032, field1033, field1034, field1035,
+        field1036, field1037, field1038, field1039,
+        field1040, field1041, field1042, field1043,
+        field1044, field1045, field1046, field1047,
+        field1048, field1049, field1050, field1051,
+        field1052, field1053, field1054, field1055,
+        field1056, field1057, field1058, field1059,
+        field1060, field1061, field1062, field1063,
+        field1064, field1065, field1066, field1067,
+        field1068, field1069, field1070, field1071,
+        field1072, field1073, field1074, field1075,
+        field1076, field1077, field1078, field1079,
+        field1080, field1081, field1082, field1083,
+        field1084, field1085, field1086, field1087,
+        field1088, field1089, field1090, field1091,
+        field1092, field1093, field1094, field1095,
+        field1096, field1097, field1098, field1099,
+        field1100, field1101, field1102, field1103,
+        field1104, field1105, field1106, field1107,
+        field1108, field1109, field1110, field1111,
+        field1112, field1113, field1114, field1115,
+        field1116, field1117, field1118, field1119,
+        field1120, field1121, field1122, field1123,
+        field1124, field1125, field1126, field1127,
+        field1128, field1129, field1130, field1131,
+        field1132, field1133, field1134, field1135,
+        field1136, field1137, field1138, field1139,
+        field1140, field1141, field1142, field1143,
+        field1144, field1145, field1146, field1147,
+        field1148, field1149, field1150, field1151,
+        field1152, field1153, field1154, field1155,
+        field1156, field1157, field1158, field1159,
+        field1160, field1161, field1162, field1163,
+        field1164, field1165, field1166, field1167,
+        field1168, field1169, field1170, field1171,
+        field1172, field1173, field1174, field1175,
+        field1176, field1177, field1178, field1179,
+        field1180, field1181, field1182, field1183,
+        field1184, field1185, field1186, field1187,
+        field1188, field1189, field1190, field1191,
+        field1192, field1193, field1194, field1195,
+        field1196, field1197, field1198, field1199,
+        field1200, field1201, field1202, field1203,
+        field1204, field1205, field1206, field1207,
+        field1208, field1209, field1210, field1211,
+        field1212, field1213, field1214, field1215,
+        field1216, field1217, field1218, field1219,
+        field1220, field1221, field1222, field1223,
+        field1224, field1225, field1226, field1227,
+        field1228, field1229, field1230, field1231,
+        field1232, field1233, field1234, field1235,
+        field1236, field1237, field1238, field1239,
+        field1240, field1241, field1242, field1243,
+        field1244, field1245, field1246, field1247,
+        field1248, field1249, field1250, field1251,
+        field1252, field1253, field1254, field1255,
+        field1256, field1257, field1258, field1259,
+        field1260, field1261, field1262, field1263,
+        field1264, field1265, field1266, field1267,
+        field1268, field1269, field1270, field1271,
+        field1272, field1273, field1274, field1275,
+        field1276, field1277, field1278, field1279,
+        field1280, field1281, field1282, field1283,
+        field1284, field1285, field1286, field1287,
+        field1288, field1289, field1290, field1291,
+        field1292, field1293, field1294, field1295,
+        field1296, field1297, field1298, field1299,
+        field1300, field1301, field1302, field1303,
+        field1304, field1305, field1306, field1307,
+        field1308, field1309, field1310, field1311,
+        field1312, field1313, field1314, field1315,
+        field1316, field1317, field1318, field1319,
+        field1320, field1321, field1322, field1323,
+        field1324, field1325, field1326, field1327,
+        field1328, field1329, field1330, field1331,
+        field1332, field1333, field1334, field1335,
+        field1336, field1337, field1338, field1339,
+        field1340, field1341, field1342, field1343,
+        field1344, field1345, field1346, field1347,
+        field1348, field1349, field1350, field1351,
+        field1352, field1353, field1354, field1355,
+        field1356, field1357, field1358, field1359,
+        field1360, field1361, field1362, field1363,
+        field1364, field1365, field1366, field1367,
+        field1368, field1369, field1370, field1371,
+        field1372, field1373, field1374, field1375,
+        field1376, field1377, field1378, field1379,
+        field1380, field1381, field1382, field1383,
+        field1384, field1385, field1386, field1387,
+        field1388, field1389, field1390, field1391,
+        field1392, field1393, field1394, field1395,
+        field1396, field1397, field1398, field1399,
+        field1400, field1401, field1402, field1403,
+        field1404, field1405, field1406, field1407,
+        field1408, field1409, field1410, field1411,
+        field1412, field1413, field1414, field1415,
+        field1416, field1417, field1418, field1419,
+        field1420, field1421, field1422, field1423,
+        field1424, field1425, field1426, field1427,
+        field1428, field1429, field1430, field1431,
+        field1432, field1433, field1434, field1435,
+        field1436, field1437, field1438, field1439,
+        field1440, field1441, field1442, field1443,
+        field1444, field1445, field1446, field1447,
+        field1448, field1449, field1450, field1451,
+        field1452, field1453, field1454, field1455,
+        field1456, field1457, field1458, field1459,
+        field1460, field1461, field1462, field1463,
+        field1464, field1465, field1466, field1467,
+        field1468, field1469, field1470, field1471,
+        field1472, field1473, field1474, field1475,
+        field1476, field1477, field1478, field1479,
+        field1480, field1481, field1482, field1483,
+        field1484, field1485, field1486, field1487,
+        field1488, field1489, field1490, field1491,
+        field1492, field1493, field1494, field1495,
+        field1496, field1497, field1498, field1499,
+        field1500, field1501, field1502, field1503,
+        field1504, field1505, field1506, field1507,
+        field1508, field1509, field1510, field1511,
+        field1512, field1513, field1514, field1515,
+        field1516, field1517, field1518, field1519,
+        field1520, field1521, field1522, field1523,
+        field1524, field1525, field1526, field1527,
+        field1528, field1529, field1530, field1531,
+        field1532, field1533, field1534, field1535,
+        field1536, field1537, field1538, field1539,
+        field1540, field1541, field1542, field1543,
+        field1544, field1545, field1546, field1547,
+        field1548, field1549, field1550, field1551,
+        field1552, field1553, field1554, field1555,
+        field1556, field1557, field1558, field1559,
+        field1560, field1561, field1562, field1563,
+        field1564, field1565, field1566, field1567,
+        field1568, field1569, field1570, field1571,
+        field1572, field1573, field1574, field1575,
+        field1576, field1577, field1578, field1579,
+        field1580, field1581, field1582, field1583,
+        field1584, field1585, field1586, field1587,
+        field1588, field1589, field1590, field1591,
+        field1592, field1593, field1594, field1595,
+        field1596, field1597, field1598, field1599,
+        field1600, field1601, field1602, field1603,
+        field1604, field1605, field1606, field1607,
+        field1608, field1609, field1610, field1611,
+        field1612, field1613, field1614, field1615,
+        field1616, field1617, field1618, field1619,
+        field1620, field1621, field1622, field1623,
+        field1624, field1625, field1626, field1627,
+        field1628, field1629, field1630, field1631,
+        field1632, field1633, field1634, field1635,
+        field1636, field1637, field1638, field1639,
+        field1640, field1641, field1642, field1643,
+        field1644, field1645, field1646, field1647,
+        field1648, field1649, field1650, field1651,
+        field1652, field1653, field1654, field1655,
+        field1656, field1657, field1658, field1659,
+        field1660, field1661, field1662, field1663,
+        field1664, field1665, field1666, field1667,
+        field1668, field1669, field1670, field1671,
+        field1672, field1673, field1674, field1675,
+        field1676, field1677, field1678, field1679,
+        field1680, field1681, field1682, field1683,
+        field1684, field1685, field1686, field1687,
+        field1688, field1689, field1690, field1691,
+        field1692, field1693, field1694, field1695,
+        field1696, field1697, field1698, field1699,
+        field1700, field1701, field1702, field1703,
+        field1704, field1705, field1706, field1707,
+        field1708, field1709, field1710, field1711,
+        field1712, field1713, field1714, field1715,
+        field1716, field1717, field1718, field1719,
+        field1720, field1721, field1722, field1723,
+        field1724, field1725, field1726, field1727,
+        field1728, field1729, field1730, field1731,
+        field1732, field1733, field1734, field1735,
+        field1736, field1737, field1738, field1739,
+        field1740, field1741, field1742, field1743,
+        field1744, field1745, field1746, field1747,
+        field1748, field1749, field1750, field1751,
+        field1752, field1753, field1754, field1755,
+        field1756, field1757, field1758, field1759,
+        field1760, field1761, field1762, field1763,
+        field1764, field1765, field1766, field1767,
+        field1768, field1769, field1770, field1771,
+        field1772, field1773, field1774, field1775,
+        field1776, field1777, field1778, field1779,
+        field1780, field1781, field1782, field1783,
+        field1784, field1785, field1786, field1787,
+        field1788, field1789, field1790, field1791,
+        field1792, field1793, field1794, field1795,
+        field1796, field1797, field1798, field1799,
+        field1800, field1801, field1802, field1803,
+        field1804, field1805, field1806, field1807,
+        field1808, field1809, field1810, field1811,
+        field1812, field1813, field1814, field1815,
+        field1816, field1817, field1818, field1819,
+        field1820, field1821, field1822, field1823,
+        field1824, field1825, field1826, field1827,
+        field1828, field1829, field1830, field1831,
+        field1832, field1833, field1834, field1835,
+        field1836, field1837, field1838, field1839,
+        field1840, field1841, field1842, field1843,
+        field1844, field1845, field1846, field1847,
+        field1848, field1849, field1850, field1851,
+        field1852, field1853, field1854, field1855,
+        field1856, field1857, field1858, field1859,
+        field1860, field1861, field1862, field1863,
+        field1864, field1865, field1866, field1867,
+        field1868, field1869, field1870, field1871,
+        field1872, field1873, field1874, field1875,
+        field1876, field1877, field1878, field1879,
+        field1880, field1881, field1882, field1883,
+        field1884, field1885, field1886, field1887,
+        field1888, field1889, field1890, field1891,
+        field1892, field1893, field1894, field1895,
+        field1896, field1897, field1898, field1899,
+        field1900, field1901, field1902, field1903,
+        field1904, field1905, field1906, field1907,
+        field1908, field1909, field1910, field1911,
+        field1912, field1913, field1914, field1915,
+        field1916, field1917, field1918, field1919,
+        field1920, field1921, field1922, field1923,
+        field1924, field1925, field1926, field1927,
+        field1928, field1929, field1930, field1931,
+        field1932, field1933, field1934, field1935,
+        field1936, field1937, field1938, field1939,
+        field1940, field1941, field1942, field1943,
+        field1944, field1945, field1946, field1947,
+        field1948, field1949, field1950, field1951,
+        field1952, field1953, field1954, field1955,
+        field1956, field1957, field1958, field1959,
+        field1960, field1961, field1962, field1963,
+        field1964, field1965, field1966, field1967,
+        field1968, field1969, field1970, field1971,
+        field1972, field1973, field1974, field1975,
+        field1976, field1977, field1978, field1979,
+        field1980, field1981, field1982, field1983,
+        field1984, field1985, field1986, field1987,
+        field1988, field1989, field1990, field1991,
+        field1992, field1993, field1994, field1995,
+        field1996, field1997, field1998, field1999, unknownFields)
 }
 
 fun MessageWithHugeOneof?.orDefault() = this ?: MessageWithHugeOneof.defaultInstance

--- a/runtime/src/commonTest/proto/pbandk/testpb/test_compiler_limits.proto
+++ b/runtime/src/commonTest/proto/pbandk/testpb/test_compiler_limits.proto
@@ -12,9 +12,6 @@ syntax = "proto3";
 
 package pbandk.testpb;
 
-/* XXX: This message causes a StackOverflowError in Kotlin/Native 1.3.70 (only
- * on Native, on JVM and JS this compiles fine). It is resolved in Kotlin 1.4
- * and can be uncommented once pbandk upgrades to Kotlin 1.4.
 message MessageWithLotsOfFields {
     string field_1000 = 1000;
     string field_1001 = 1001;
@@ -1017,7 +1014,6 @@ message MessageWithLotsOfFields {
     string field_1998 = 1998;
     string field_1999 = 1999;
 }
-*/
 
 message MessageWithHugeOneof {
     oneof huge_oneof {

--- a/runtime/src/jsMain/kotlin/pbandk/internal/Util.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/internal/Util.kt
@@ -4,7 +4,7 @@ import org.khronos.webgl.Int8Array
 import org.khronos.webgl.Uint8Array
 import pbandk.PbandkInternal
 
-actual typealias Util = pbandk.protobufjs.Util
+internal actual typealias Util = pbandk.protobufjs.Util
 
 @PbandkInternal
 @Suppress("NOTHING_TO_INLINE")

--- a/runtime/src/jsMain/kotlin/pbandk/protobufjs/Util.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/protobufjs/Util.kt
@@ -19,13 +19,7 @@ internal fun Long.Companion.fromProtobufjsLong(l: dynamic): Long {
     }
 }
 
-object Util : AbstractUtil() {
-    fun stringToUtf8(str: String): ByteArray = ByteArray(util.utf8.length(str)).also {
-        util.utf8.write(str, it.asUint8Array(), 0)
-    }
-
-    fun utf8ToString(bytes: ByteArray): String = bytes.asUint8Array().let { util.utf8.read(it, 0, it.length) }
-
+internal object Util : AbstractUtil() {
     override fun base64ToBytes(str: String): ByteArray = ByteArray(util.base64.length(str)).also {
         util.base64.decode(str, it.asUint8Array(), 0)
     }

--- a/runtime/src/jvmMain/kotlin/pbandk/internal/Util.kt
+++ b/runtime/src/jvmMain/kotlin/pbandk/internal/Util.kt
@@ -2,10 +2,7 @@ package pbandk.internal
 
 import java.util.*
 
-actual object Util : AbstractUtil() {
-    actual fun stringToUtf8(str: String) = str.toByteArray()
-    actual fun utf8ToString(bytes: ByteArray) = bytes.toString(Charsets.UTF_8)
-
+internal actual object Util : AbstractUtil() {
     actual override fun base64ToBytes(str: String): ByteArray = Base64.getDecoder().decode(str)
     actual override fun bytesToBase64(bytes: ByteArray): String = Base64.getEncoder().encodeToString(bytes)
 }

--- a/runtime/src/jvmTest/kotlin/pbandk/wkt/WellKnownTypesTest.kt
+++ b/runtime/src/jvmTest/kotlin/pbandk/wkt/WellKnownTypesTest.kt
@@ -9,7 +9,6 @@ import pbandk.UnknownField
 import pbandk.internal.binary.WireType
 import pbandk.decodeFromByteArray
 import pbandk.encodeToByteArray
-import pbandk.internal.Util
 import pbandk.testpb.Wrappers
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -46,7 +45,7 @@ class WellKnownTypesTest {
                         listOf(
                             UnknownField.Value(
                                 WireType.LENGTH_DELIMITED.value,
-                                byteArrayOf(3) + Util.stringToUtf8("baz")
+                                byteArrayOf(3) + "baz".encodeToByteArray()
                             )
                         )
                     )

--- a/runtime/src/nativeMain/kotlin/pbandk/internal/Util.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/internal/Util.kt
@@ -6,8 +6,4 @@ internal class PosixException(val errno: Int) : RuntimeException(
     strerror(errno)?.toString() ?: "Error with unknown errno: $errno"
 )
 
-actual object Util : AbstractUtil() {
-    actual fun stringToUtf8(str: String): ByteArray = str.encodeToByteArray()
-
-    actual fun utf8ToString(bytes: ByteArray): String = bytes.decodeToString()
-}
+internal actual object Util : AbstractUtil()

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,18 +10,16 @@ pluginManagement {
 
 rootProject.name = "pbandk"
 
-enableFeaturePreview("GRADLE_METADATA")
+include(":runtime")
 
-include ":runtime"
-
-include ":protoc-gen-kotlin:lib"
+include(":protoc-gen-kotlin:lib")
 project(":protoc-gen-kotlin:lib").name = "protoc-gen-kotlin-lib"
-include ":protoc-gen-kotlin:jvm"
+include(":protoc-gen-kotlin:jvm")
 project(":protoc-gen-kotlin:jvm").name = "protoc-gen-kotlin-jvm"
 
-include ":conformance:lib"
+include(":conformance:lib")
 project(":conformance:lib").name = "conformance-lib"
-include ":conformance:jvm"
+include(":conformance:jvm")
 project(":conformance:jvm").name = "conformance-jvm"
-include ":conformance:native"
+include(":conformance:native")
 project(":conformance:native").name = "conformance-native"


### PR DESCRIPTION
Aside from updates and simplifcations related to Kotlin 1.4, the other major source of changes in this commit is the update of the
kotlinx-serialization library (required by the Kotlin 1.4 update). As part of releasing v1.0, kotlinx-serialization made a bunch of changes to their public API.

Also updated to newer versions of gradle, protobufjs, and the Spring Boot Gradle Plugin.

Fixes #86 