### PR TITLE
Use GitHub Actions instead of CircleCI for PR tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,32 +263,42 @@ workflows:
     jobs:
       - build:
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v[0-9]+(\.[0-9]+)+([-+].+)*/
       - conformance_jvm:
           requires:
             - build
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v[0-9]+(\.[0-9]+)+([-+].+)*/
       - conformance_js:
           requires:
             - build
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v[0-9]+(\.[0-9]+)+([-+].+)*/
       - conformance_native:
           requires:
             - build
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v[0-9]+(\.[0-9]+)+([-+].+)*/
       - build_examples:
           requires:
             - build
           filters:
+            branches:
+              ignore: /.*/
             tags:
-              only: /.*/
+              only: /^v[0-9]+(\.[0-9]+)+([-+].+)*/
       - publish:
           requires:
             - build

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,11 +1,216 @@
 name: Test Changes
 
-on: [pull_request]
+env:
+  GRADLE_OPTS: '-Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process'
+  JAVA_VERSION: 11
+  NODEJS_VERSION: 14
+  PROTOBUF_VERSION: 3.10.1
+
+on:
+  pull_request:
+    paths-ignore:
+      - '*.md'
+
+  push:
+    branches:
+      - master
+      - v[0-9]+.[0-9]+.x
 
 jobs:
   build:
     runs-on: ubuntu-18.04
 
     steps:
-      - name: Dummy job
-        run: echo "Hello world"
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Cache gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.konan
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Build project and run tests
+        run: ./gradlew build --stacktrace
+
+      - name: Cache protobuf ${{ env.PROTOBUF_VERSION }}
+        uses: actions/cache@v2
+        id: cache-protobuf
+        with:
+          path: ~/protobuf
+          key: ${{ runner.os }}-protobuf-${{ env.PROTOBUF_VERSION }}
+
+      - name: Build protoc and protobuf conformance-test-runner
+        if: steps.cache-protobuf.outputs.cache-hit != 'true'
+        run: |
+          cd ~
+          curl -sSLO https://github.com/protocolbuffers/protobuf/releases/download/v${{ env.PROTOBUF_VERSION }}/protobuf-all-${{ env.PROTOBUF_VERSION }}.tar.gz
+          tar xzvf protobuf-all-${{ env.PROTOBUF_VERSION }}.tar.gz
+          mv protobuf-${{ env.PROTOBUF_VERSION }} protobuf
+          cd protobuf
+          ./configure --prefix="$(pwd)/install"
+          make
+          make install
+          cd conformance
+          make
+
+      - name: Ensure bundled types are up-to-date
+        run: |
+          export PATH="$PATH:$HOME/protobuf/install/bin"
+          ./gradlew -Dprotoc.path=$HOME/protobuf/install \
+            :runtime:generateWellKnownTypes \
+            :runtime:generateTestTypes \
+            :protoc-gen-kotlin:protoc-gen-kotlin-lib:generateProto \
+            :conformance:conformance-lib:generateProto
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Found uncommitted changes to bundled types"
+            git status
+            exit 1
+          else
+            exit 0
+          fi
+
+      - name: Publish artifacts to local maven repository
+        run: |
+          ./gradlew publishToMavenLocal
+          echo "Published files:"
+          find $HOME/.m2/repository -type f
+
+      - name: Upload maven artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: maven-artifacts
+          path: ~/.m2/repository
+
+      - name: Build conformance test suite
+        run: |
+          ./gradlew \
+            :conformance:conformance-lib:assemble \
+            :conformance:conformance-jvm:installDist \
+            :conformance:conformance-native:build
+
+      - name: Package files necessary to run conformance tests
+        run: |
+          tar -cvf conformance-test-files.tar \
+            conformance/test-conformance.sh \
+            conformance/jvm/build/install/conformance \
+            conformance/jvm/failing_tests.txt \
+            build/js \
+            conformance/js/failing_tests.txt \
+            conformance/js/run.sh \
+            conformance/native/build/bin/linux/conformanceReleaseExecutable/conformance.kexe \
+            conformance/native/failing_tests.txt
+
+      - name: Upload files necessary to run conformance tests
+        uses: actions/upload-artifact@v2
+        with:
+          name: conformance-test-files
+          path: conformance-test-files.tar
+
+      - name: Bundle the build report
+        if: failure()
+        run: find . -type d -name 'reports' | zip -@ -r build-reports.zip
+
+      - name: Upload the build report
+        if: failure()
+        uses: actions/upload-artifact@v2
+        with:
+          name: error-report
+          path: build-reports.zip
+
+  conformance:
+    needs: build
+    strategy:
+      matrix:
+        platform: [jvm, js, linux]
+      fail-fast: false
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Install Java ${{ env.JAVA_VERSION }}
+        if: matrix.platform == 'jvm'
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Install Node.js ${{ env.NODEJS_VERSION }}
+        if: matrix.platform == 'js'
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ env.NODEJS_VERSION }}
+
+      - name: Cache protobuf ${{ env.PROTOBUF_VERSION }}
+        uses: actions/cache@v2
+        with:
+          path: ~/protobuf
+          key: ${{ runner.os }}-protobuf-${{ env.PROTOBUF_VERSION }}
+
+      - name: Download conformance test files
+        uses: actions/download-artifact@v2
+        with:
+          name: conformance-test-files
+
+      - name: Extract conformance test files
+        run: tar -xvf conformance-test-files.tar
+
+      - name: Run ${{ matrix.platform }} conformance tests
+        run: |
+          export CONF_TEST_PATH=~/protobuf/conformance/conformance-test-runner
+          ./conformance/test-conformance.sh ${{ matrix.platform }}
+
+  build-examples:
+    needs: build
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Download maven artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: maven-artifacts
+          path: ~/.m2/repository
+
+      - name: Cache gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-examples-${{ hashFiles('examples/**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-examples-
+
+      - name: Install Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - name: Build all examples
+        run: |
+          for d in examples/*; do
+            set -e
+            [ -d "$d" ] || continue
+            echo "::group::Build $d"
+            pushd "$d" >/dev/null
+            ../../gradlew build
+            popd >/dev/null
+            echo "::endgroup::"
+          done


### PR DESCRIPTION
This migrates the CI jobs that get run pre-merge and post-merge for PRs. It's mostly a copy of the job definitions from CircleCI, with slight tweaks to run under GitHub Actions. The CI job for releasing a new version of pbandk to Bintray will be migrated later.

With the update to Kotlin 1.4, we were hitting memory limits under CircleCI. GitHub Actions has higher memory limits (and Streem also has a paid account there).