### PR TITLE
Fix the tag filter used by the release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ on:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
-      - v[0-9]+.[0-9]+.[0-9]+[-+]*
+      - v[0-9]+.[0-9]+.[0-9]+-*
 
 # All jobs, except publish, need to be kept in sync with their counterparts in pull-request.yaml
 jobs:


### PR DESCRIPTION
GitHub Actions doesn't allow `+` characters inside of character ranges and also doesn't provide any way for escaping the `+` character when used in a tag filter: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

For now we'll just disable the release job for semver tags that contain build metadata but are not pre-release versions.
