### PR TITLE
Fix duplicate artifact publishing error

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -14,9 +14,6 @@ kotlin {
 
     android {
         publishLibraryVariants("release")
-        mavenPublication {
-            this.artifactId = "pbandk-$artifactId"
-        }
     }
 
     jvm()
@@ -170,13 +167,16 @@ tasks {
     }
 }
 
-publishing {
-    publications.withType<MavenPublication>().configureEach {
-        artifactId = "pbandk-$artifactId"
-        description = "Library for pbandk runtime protobuf code"
-        pom {
-            configureForPbandk()
+afterEvaluate {
+    // This needs to be inside of `afterEvaluate` to work correctly with the Android Gradle plugin
+    publishing {
+        publications.withType<MavenPublication>().configureEach {
+            artifactId = "pbandk-$artifactId"
+            description = "Library for pbandk runtime protobuf code"
+            pom {
+                configureForPbandk()
+            }
+            addBintrayRepository(project, this)
         }
-        addBintrayRepository(project, this)
     }
 }


### PR DESCRIPTION
Configuring publications before evaluation was conflicting with the Android Gradle plugin. Specifically, it was causing the creation of a duplicate `kotlinMultiplatform` publication. When `publishToBintrayRepository` was run from CI, it would fail with this error:

```
> Task :runtime:publishKotlinMultiplatformPublicationToBintrayPbandkRuntime2Repository

> Task :runtime:publishKotlinMultiplatformPublicationToBintrayPbandkRuntimeRepository FAILED
Publication 'pro.streem.pbandk:pbandk-runtime:0.10.0-beta.1' is
published multiple times to the same location. It is likely that
repository 'bintrayPbandkRuntime' is duplicated.

FAILURE: Build failed with an exception.
Deprecated Gradle features were used in this build, making it
incompatible with Gradle 7.0.

Use '--warning-mode all' to show the individual deprecation warnings.
* What went wrong:
Execution failed for task
':runtime:publishKotlinMultiplatformPublicationToBintrayPbandkRuntimeRepository'.
> Failed to publish publication 'kotlinMultiplatform' to repository 'bintrayPbandkRuntime'
   > Could not PUT 'https://api.bintray.com/maven/streem/pbandk/pro.streem.pbandk:pbandk-runtime/;publish=1/pro/streem/pbandk/pbandk-runtime/0.10.0-beta.1/pbandk-runtime-0.10.0-beta.1.jar'.
   Received status code 409 from server: Conflict
```

Moving the publication configuration inside of `afterEvaluate` prevents the creation of the duplicate `publishKotlinMultiplatformPublicationToBintrayPbandkRuntime2Repository` task.