### PR TITLE
Some Android updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is built to work across multiple Kotlin platforms.
 **Features**
 
 * Clean data class generation
-* Works for JVM and JS, with experimental support for Native
+* Works for JVM, Android, and JS, with experimental support for Native
 * Support for proto2 and proto3 syntaxes
 * JSON serialization/deserialization following the [proto3 JSON spec](https://developers.google.com/protocol-buffers/docs/proto3#json) (see https://github.com/streem/pbandk/issues/72 for some corner cases and Well-Known Types that are not handled yet)
 * Oneof's are properly handled as sealed classes
@@ -326,7 +326,7 @@ protoc \
 
 ### Runtime Library
 
-Pbandk's runtime library is a thin layer over the preferred Protobuf library for each platform. The libraries are
+Pbandk's runtime library provides a Kotlin layer over the preferred Protobuf library for each platform. The libraries are
 present on JCenter. Using Gradle:
 
 ```
@@ -342,7 +342,7 @@ dependencies {
     implementation("pro.streem.pbandk:pbandk-runtime-jvm:0.10.0-SNAPSHOT")
 
     // For Android sourcesets/projects:
-    implementation("pro.streem.pbandk:pbandk-runtime-android:0.10.0-SNAPSHOT")
+    implementation("pro.streem.pbandk:pbandk-runtime:0.10.0-SNAPSHOT")
 
     // For Kotlin/JS sourcesets/projects:
     implementation("pro.streem.pbandk:pbandk-runtime-js:0.10.0-SNAPSHOT")
@@ -352,7 +352,12 @@ dependencies {
 }
 ```
 
-It has a dependency on the Google Protobuf Java library. The Android artifact supports SDK 21 or higher.
+Pbandk has a dependency on the preferred Protobuf library on each platform:
+
+- JVM: Google Protobuf Java library.
+- Android: Google Protobuf Javalite library. The Android artifact supports SDK 21 or higher.
+- JS: protobuf.js.
+- Native: Pbandk uses its own pure-Kotlin protobuf implementation that is heavily based on the Google Protobuf Java library.
 
 In addition, support for [Kotlin's `@OptIn` annotation](https://kotlinlang.org/docs/reference/opt-in-requirements.html)
 should be enabled in order to avoid compiler warnings in the generated code:

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -4,7 +4,7 @@ object Versions {
     const val kotlinCoroutines = "1.4.2"
     const val kotlinSerialization = "1.1.0"
     const val protoc = "3.10.1"
-    const val protobufJava = "3.11.1"
+    const val protobufJava = "3.15.5"
     const val protobufJs = "6.10.2"
     const val springBootGradlePlugin = "2.3.7.RELEASE"
     const val osDetectorGradlePlugin = "1.6.2"

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -13,7 +13,7 @@ repositories {
 kotlin {
 
     android {
-        publishLibraryVariants("release")
+        publishAllLibraryVariants()
     }
 
     jvm()

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,10 +6,13 @@ pluginManagement {
     }
     resolutionStrategy {
         eachPlugin {
-            if (requested.id.id == "binary-compatibility-validator") {
-                useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
-            } else if (requested.id.id == "com.android.application" || requested.id.id == "com.android.library") {
-                useModule("com.android.tools.build:gradle:${requested.version}")
+            when (requested.id.id) {
+                "binary-compatibility-validator" -> {
+                    useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
+                }
+                "com.android.application", "com.android.library" -> {
+                    useModule("com.android.tools.build:gradle:${requested.version}")
+                }
             }
         }
     }


### PR DESCRIPTION
As discussed on #131 

- Convert `settings.gradle` to Kotlin
- Update `protobuf-java(lite)` dependency: newer version includes `duration.proto`
- Also publish debug Android builds for easier use by consuming projects
