### PR TITLE
Some documentation and minor dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 * Updated to Kotlin 1.4. Projects that are still on Kotlin 1.3 should be able to continue using pbandk, but this configuration is only supported on a best-effort basis (please file a GitHub issue with any problems). Projects are encouraged to update to Kotlin 1.4. (PR [#114], fixes [#86])
 * **[BREAKING CHANGE]** The API and implementation of `UnknownField` changed significantly. If you access the contents of unknown fields in your code, you will need to update to the new API. The unknown field no longer provides access to a decoded version of the field's wire type. Instead it only provides access to the raw binary encoding of the field. (PR [#103])
-* Android now uses `protobuf-javalite` (instead of `protobuf-java`) to avoid dependency conflicts with other Android libraries such as `com.google.firebase:firebase-perf`. (PR [#124], fixes [#91]) (thanks @jeroenmols)
+* `pbandk-runtime` on Android now uses `protobuf-javalite` (instead of `protobuf-java`) to avoid dependency conflicts with other Android libraries such as `com.google.firebase:firebase-perf`. (PR [#124], fixes [#91]) (thanks @jeroenmols)
+* Updated `pbandk-runtime-js` dependency on `protobuf.js` to `6.10.2`.
+* Updated `pbandk-runtime-jvm` dependency on `protobuf-java` to `3.15.5`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -335,20 +335,9 @@ repositories {
 }
 
 dependencies {
-    // For the `common` sourceset in a Kotlin Multiplatform project:
-    implementation("pro.streem.pbandk:pbandk-runtime-common:0.10.0-SNAPSHOT")
-
-    // For Kotlin/JVM sourcesets/projects:
-    implementation("pro.streem.pbandk:pbandk-runtime-jvm:0.10.0-SNAPSHOT")
-
-    // For Android sourcesets/projects:
+    // Can be used from the `common` sourceset in a Kotlin Multiplatform project,
+    // or from platform-specific JVM, Android, JS, or Native sourcesets/projects.
     implementation("pro.streem.pbandk:pbandk-runtime:0.10.0-SNAPSHOT")
-
-    // For Kotlin/JS sourcesets/projects:
-    implementation("pro.streem.pbandk:pbandk-runtime-js:0.10.0-SNAPSHOT")
-
-    // For Kotlin/Native sourcesets/projects:
-    implementation("pro.streem.pbandk:pbandk-runtime-native:0.10.0-SNAPSHOT")
 }
 ```
 
@@ -379,7 +368,7 @@ runtime:
 
 ```
 dependencies {
-    compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib-jvm:0.10.0-SNAPSHOT")
+    compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib:0.10.0-SNAPSHOT")
 }
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,12 +15,9 @@ plugins {
 
 configure<ApiValidationExtension> {
     ignoredProjects.addAll(
-        project.subprojects.map { it.name }.minus(
-            listOf(
-                "runtime"
-            )
-        )
+        project.subprojects.map { it.name }.minus(listOf("runtime"))
     )
+    nonPublicMarkers.add("pbandk.PbandkInternal")
 }
 
 allprojects {

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,16 +1,16 @@
 object Versions {
-    const val binaryCompatibilityValidatorGradlePlugin = "0.2.3"
+    const val androidGradlePlugin = "4.1.2"
+    const val androidMinSdk = 21
+    const val androidTargetSdk = 30
+    const val binaryCompatibilityValidatorGradlePlugin = "0.2.4"
+    const val junit = "4.12"
     const val kotlin = "1.4.31"
-    const val kotlinCoroutines = "1.4.2"
+    const val kotlinCoroutines = "1.4.3"
     const val kotlinSerialization = "1.1.0"
+    const val robolectric = "10-robolectric-5803371" // Only update when Android Studio supports Java 11 (11-x requires Java 9)
+    const val osDetectorGradlePlugin = "1.6.2"
     const val protoc = "3.10.1"
     const val protobufJava = "3.15.5"
     const val protobufJs = "6.10.2"
     const val springBootGradlePlugin = "2.3.7.RELEASE"
-    const val osDetectorGradlePlugin = "1.6.2"
-    const val robolectric = "10-robolectric-5803371" // Only update when Android Studio supports Java 11 (11-x requires Java 9)
-    const val junit = "4.12"
-    const val androidGradlePlugin = "4.1.2"
-    const val androidMinSdk = 21
-    const val androidTargetSdk = 30
 }

--- a/examples/browser-js/app/build.gradle.kts
+++ b/examples/browser-js/app/build.gradle.kts
@@ -7,7 +7,7 @@ val protobufjsVersion = "^6.10.2"
 
 dependencies {
     implementation(kotlin("stdlib-js"))
-    implementation("pro.streem.pbandk:pbandk-runtime-js:$pbandkVersion")
+    implementation("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
     implementation(npm("protobufjs", protobufjsVersion))
 }
 

--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -18,7 +18,7 @@ application {
 
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
-    implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
+    implementation("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
 }
 
 protobuf {

--- a/examples/custom-service-gen/generator/build.gradle.kts
+++ b/examples/custom-service-gen/generator/build.gradle.kts
@@ -5,6 +5,6 @@ plugins {
 val pbandkVersion: String by rootProject.extra
 
 dependencies {
-    compileOnly("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
-    compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib-jvm:$pbandkVersion")
+    compileOnly("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
+    compileOnly("pro.streem.pbandk:protoc-gen-kotlin-lib:$pbandkVersion")
 }

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -23,7 +23,7 @@ application {
 }
 
 dependencies {
-    implementation("pro.streem.pbandk:pbandk-runtime-jvm:$pbandkVersion")
+    implementation("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
 }
 
 protobuf {

--- a/runtime/src/commonMain/kotlin/pbandk/internal/Util.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/Util.kt
@@ -1,6 +1,5 @@
 package pbandk.internal
 
-import pbandk.PbandkInternal
 import pbandk.wkt.Duration
 import pbandk.wkt.Timestamp
 


### PR DESCRIPTION
- Update docs & examples to use generic pbandk artifacts: Kotlin 1.4 added a mechanism for gradle to automatically figure out the correct platform-specific dependency to use for a multi-platform dependency. So now all platforms can depend on `pbandk-runtime` instead of having to explicitly specify `pbandk-runtime-jvm`, `pbandk-runtime-js`, etc.

- Minor dependency updates: Update the `binary-compatibility-validator` gradle plugin so we can use `nonPublicMarkers` to exclude internal APIs from our public API compatibility contract; and bump Kotlin Coroutines to latest patch version update. The rest of the changes in `Versions.kt` is just sorting the entries alphabetically.