### PR TITLE
Only use maven central dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ configure<ApiValidationExtension> {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     tasks.withType<AbstractTestTask> {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
-        jcenter()
+        mavenCentral()
         google()
     }
     resolutionStrategy {


### PR DESCRIPTION
Since JCenter will go offline, `pbandk` should no longer use any dependencies from JCenter.
This was fairly easy, as all dependencies already are available on Maven Central.

Relates to: https://github.com/streem/pbandk/issues/120