### PR TITLE
Enable support for Kotlin/JS IR backend and introduce `js_export` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is built to work across multiple Kotlin platforms.
 **Features**
 
 * Clean data class generation
-* Works for JVM, Android, and JS, with experimental support for Native
+* Works for JVM, Android, and JS (both legacy and IR), with experimental support for Native
 * Support for proto2 and proto3 syntaxes
 * JSON serialization/deserialization following the [proto3 JSON spec](https://developers.google.com/protocol-buffers/docs/proto3#json) (see https://github.com/streem/pbandk/issues/72 for some corner cases and Well-Known Types that are not handled yet)
 * Oneof's are properly handled as sealed classes

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -16,7 +16,6 @@ kotlin {
     js(IR) {
         binaries.executable()
         useCommonJs()
-        browser {}
         nodejs {}
     }
 

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -13,7 +13,8 @@ kotlin {
         }
     }
 
-    js {
+    js(IR) {
+        binaries.executable()
         useCommonJs()
         browser {}
         nodejs {}
@@ -27,6 +28,7 @@ kotlin {
     sourceSets {
         all {
             languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
+            languageSettings.useExperimentalAnnotation("kotlin.js.ExperimentalJsExport")
         }
 
         val commonMain by getting {
@@ -78,13 +80,5 @@ tasks {
         outputDir.set(project.file("src/commonMain/kotlin"))
         kotlinPackage.set("pbandk.conformance.pb")
         logLevel.set("debug")
-    }
-
-    // DCE is now enabled by default in Kotlin 1.3.7x
-    // and it doesn't work well with commonJS modules
-    // Use of commonJs could be removed since default module is now UMD
-    // but would require some code change
-    val processDceJsKotlinJs by getting {
-        enabled = false
     }
 }

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/Main.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/Main.kt
@@ -9,6 +9,7 @@ import pbandk.json.encodeToJsonString
 import pbandk.json.decodeFromJsonString
 import pbandk.encodeToByteArray
 import pbandk.decodeFromByteArray
+import kotlin.js.JsExport
 
 var logDebug = false
 
@@ -16,6 +17,7 @@ inline fun debug(fn: () -> String) {
     if (logDebug) Platform.stderrPrintln(fn())
 }
 
+@JsExport
 fun main() = runBlockingMain {
     debug { "Starting conformance test" }
     while (true) {

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/conformance.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/conformance.kt
@@ -2,6 +2,7 @@
 
 package pbandk.conformance.pb
 
+@pbandk.Export
 sealed class WireFormat(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is WireFormat && other.value == value
     override fun hashCode() = value.hashCode()
@@ -21,6 +22,7 @@ sealed class WireFormat(override val value: Int, override val name: String? = nu
     }
 }
 
+@pbandk.Export
 sealed class TestCategory(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is TestCategory && other.value == value
     override fun hashCode() = value.hashCode()
@@ -41,6 +43,7 @@ sealed class TestCategory(override val value: Int, override val name: String? = 
     }
 }
 
+@pbandk.Export
 data class FailureSet(
     val failure: List<String> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -75,6 +78,7 @@ data class FailureSet(
     }
 }
 
+@pbandk.Export
 data class ConformanceRequest(
     val requestedOutputFormat: pbandk.conformance.pb.WireFormat = pbandk.conformance.pb.WireFormat.fromValue(0),
     val messageType: String = "",
@@ -214,6 +218,7 @@ data class ConformanceRequest(
     }
 }
 
+@pbandk.Export
 data class ConformanceResponse(
     val result: Result<*>? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -354,6 +359,7 @@ data class ConformanceResponse(
     }
 }
 
+@pbandk.Export
 data class JspbEncodingConfig(
     val useJspbArrayAnyFormat: Boolean = false,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -388,6 +394,8 @@ data class JspbEncodingConfig(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFailureSet")
 fun FailureSet?.orDefault() = this ?: FailureSet.defaultInstance
 
 private fun FailureSet.protoMergeImpl(plus: pbandk.Message?): FailureSet = (plus as? FailureSet)?.let {
@@ -409,6 +417,8 @@ private fun FailureSet.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Failu
     return FailureSet(pbandk.ListWithSize.Builder.fixed(failure), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForConformanceRequest")
 fun ConformanceRequest?.orDefault() = this ?: ConformanceRequest.defaultInstance
 
 private fun ConformanceRequest.protoMergeImpl(plus: pbandk.Message?): ConformanceRequest = (plus as? ConformanceRequest)?.let {
@@ -445,6 +455,8 @@ private fun ConformanceRequest.Companion.decodeWithImpl(u: pbandk.MessageDecoder
         printUnknownFields, payload, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForConformanceResponse")
 fun ConformanceResponse?.orDefault() = this ?: ConformanceResponse.defaultInstance
 
 private fun ConformanceResponse.protoMergeImpl(plus: pbandk.Message?): ConformanceResponse = (plus as? ConformanceResponse)?.let {
@@ -473,6 +485,8 @@ private fun ConformanceResponse.Companion.decodeWithImpl(u: pbandk.MessageDecode
     return ConformanceResponse(result, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForJspbEncodingConfig")
 fun JspbEncodingConfig?.orDefault() = this ?: JspbEncodingConfig.defaultInstance
 
 private fun JspbEncodingConfig.protoMergeImpl(plus: pbandk.Message?): JspbEncodingConfig = (plus as? JspbEncodingConfig)?.let {

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
@@ -2,6 +2,7 @@
 
 package pbandk.conformance.pb
 
+@pbandk.Export
 sealed class ForeignEnumProto2(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is ForeignEnumProto2 && other.value == value
     override fun hashCode() = value.hashCode()
@@ -19,6 +20,7 @@ sealed class ForeignEnumProto2(override val value: Int, override val name: Strin
     }
 }
 
+@pbandk.Export
 data class TestAllTypesProto2(
     val optionalInt32: Int? = null,
     val optionalInt64: Long? = null,
@@ -2421,6 +2423,7 @@ data class TestAllTypesProto2(
     }
 }
 
+@pbandk.Export
 data class ForeignMessageProto2(
     val c: Int? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -2455,6 +2458,7 @@ data class ForeignMessageProto2(
     }
 }
 
+@pbandk.Export
 data class UnknownToTestAllTypes(
     val optionalInt32: Int? = null,
     val optionalString: String? = null,
@@ -2570,6 +2574,7 @@ data class UnknownToTestAllTypes(
 val pbandk.conformance.pb.TestAllTypesProto2.extensionInt32: Int? 
     get() = getExtension(pbandk.conformance.pb.extensionInt32)
 
+@pbandk.Export
 val extensionInt32 = pbandk.FieldDescriptor(
     messageDescriptor = pbandk.conformance.pb.TestAllTypesProto2.Companion::descriptor,
     name = "extension_int32",
@@ -2579,6 +2584,8 @@ val extensionInt32 = pbandk.FieldDescriptor(
     value = pbandk.conformance.pb.TestAllTypesProto2::extensionInt32
 )
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2")
 fun TestAllTypesProto2?.orDefault() = this ?: TestAllTypesProto2.defaultInstance
 
 private fun TestAllTypesProto2.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2 = (plus as? TestAllTypesProto2)?.let {
@@ -2964,6 +2971,8 @@ private fun TestAllTypesProto2.Companion.decodeWithImpl(u: pbandk.MessageDecoder
         oneofField, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2NestedMessage")
 fun TestAllTypesProto2.NestedMessage?.orDefault() = this ?: TestAllTypesProto2.NestedMessage.defaultInstance
 
 private fun TestAllTypesProto2.NestedMessage.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.NestedMessage = (plus as? TestAllTypesProto2.NestedMessage)?.let {
@@ -2988,6 +2997,8 @@ private fun TestAllTypesProto2.NestedMessage.Companion.decodeWithImpl(u: pbandk.
     return TestAllTypesProto2.NestedMessage(a, corecursive, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapInt32Int32Entry")
 fun TestAllTypesProto2.MapInt32Int32Entry?.orDefault() = this ?: TestAllTypesProto2.MapInt32Int32Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapInt32Int32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapInt32Int32Entry = (plus as? TestAllTypesProto2.MapInt32Int32Entry)?.let {
@@ -3012,6 +3023,8 @@ private fun TestAllTypesProto2.MapInt32Int32Entry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto2.MapInt32Int32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapInt64Int64Entry")
 fun TestAllTypesProto2.MapInt64Int64Entry?.orDefault() = this ?: TestAllTypesProto2.MapInt64Int64Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapInt64Int64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapInt64Int64Entry = (plus as? TestAllTypesProto2.MapInt64Int64Entry)?.let {
@@ -3036,6 +3049,8 @@ private fun TestAllTypesProto2.MapInt64Int64Entry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto2.MapInt64Int64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapUint32Uint32Entry")
 fun TestAllTypesProto2.MapUint32Uint32Entry?.orDefault() = this ?: TestAllTypesProto2.MapUint32Uint32Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapUint32Uint32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapUint32Uint32Entry = (plus as? TestAllTypesProto2.MapUint32Uint32Entry)?.let {
@@ -3060,6 +3075,8 @@ private fun TestAllTypesProto2.MapUint32Uint32Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto2.MapUint32Uint32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapUint64Uint64Entry")
 fun TestAllTypesProto2.MapUint64Uint64Entry?.orDefault() = this ?: TestAllTypesProto2.MapUint64Uint64Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapUint64Uint64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapUint64Uint64Entry = (plus as? TestAllTypesProto2.MapUint64Uint64Entry)?.let {
@@ -3084,6 +3101,8 @@ private fun TestAllTypesProto2.MapUint64Uint64Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto2.MapUint64Uint64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapSint32Sint32Entry")
 fun TestAllTypesProto2.MapSint32Sint32Entry?.orDefault() = this ?: TestAllTypesProto2.MapSint32Sint32Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapSint32Sint32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapSint32Sint32Entry = (plus as? TestAllTypesProto2.MapSint32Sint32Entry)?.let {
@@ -3108,6 +3127,8 @@ private fun TestAllTypesProto2.MapSint32Sint32Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto2.MapSint32Sint32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapSint64Sint64Entry")
 fun TestAllTypesProto2.MapSint64Sint64Entry?.orDefault() = this ?: TestAllTypesProto2.MapSint64Sint64Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapSint64Sint64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapSint64Sint64Entry = (plus as? TestAllTypesProto2.MapSint64Sint64Entry)?.let {
@@ -3132,6 +3153,8 @@ private fun TestAllTypesProto2.MapSint64Sint64Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto2.MapSint64Sint64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapFixed32Fixed32Entry")
 fun TestAllTypesProto2.MapFixed32Fixed32Entry?.orDefault() = this ?: TestAllTypesProto2.MapFixed32Fixed32Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapFixed32Fixed32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapFixed32Fixed32Entry = (plus as? TestAllTypesProto2.MapFixed32Fixed32Entry)?.let {
@@ -3156,6 +3179,8 @@ private fun TestAllTypesProto2.MapFixed32Fixed32Entry.Companion.decodeWithImpl(u
     return TestAllTypesProto2.MapFixed32Fixed32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapFixed64Fixed64Entry")
 fun TestAllTypesProto2.MapFixed64Fixed64Entry?.orDefault() = this ?: TestAllTypesProto2.MapFixed64Fixed64Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapFixed64Fixed64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapFixed64Fixed64Entry = (plus as? TestAllTypesProto2.MapFixed64Fixed64Entry)?.let {
@@ -3180,6 +3205,8 @@ private fun TestAllTypesProto2.MapFixed64Fixed64Entry.Companion.decodeWithImpl(u
     return TestAllTypesProto2.MapFixed64Fixed64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapSfixed32Sfixed32Entry")
 fun TestAllTypesProto2.MapSfixed32Sfixed32Entry?.orDefault() = this ?: TestAllTypesProto2.MapSfixed32Sfixed32Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapSfixed32Sfixed32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapSfixed32Sfixed32Entry = (plus as? TestAllTypesProto2.MapSfixed32Sfixed32Entry)?.let {
@@ -3204,6 +3231,8 @@ private fun TestAllTypesProto2.MapSfixed32Sfixed32Entry.Companion.decodeWithImpl
     return TestAllTypesProto2.MapSfixed32Sfixed32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapSfixed64Sfixed64Entry")
 fun TestAllTypesProto2.MapSfixed64Sfixed64Entry?.orDefault() = this ?: TestAllTypesProto2.MapSfixed64Sfixed64Entry.defaultInstance
 
 private fun TestAllTypesProto2.MapSfixed64Sfixed64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapSfixed64Sfixed64Entry = (plus as? TestAllTypesProto2.MapSfixed64Sfixed64Entry)?.let {
@@ -3228,6 +3257,8 @@ private fun TestAllTypesProto2.MapSfixed64Sfixed64Entry.Companion.decodeWithImpl
     return TestAllTypesProto2.MapSfixed64Sfixed64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapInt32FloatEntry")
 fun TestAllTypesProto2.MapInt32FloatEntry?.orDefault() = this ?: TestAllTypesProto2.MapInt32FloatEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapInt32FloatEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapInt32FloatEntry = (plus as? TestAllTypesProto2.MapInt32FloatEntry)?.let {
@@ -3252,6 +3283,8 @@ private fun TestAllTypesProto2.MapInt32FloatEntry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto2.MapInt32FloatEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapInt32DoubleEntry")
 fun TestAllTypesProto2.MapInt32DoubleEntry?.orDefault() = this ?: TestAllTypesProto2.MapInt32DoubleEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapInt32DoubleEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapInt32DoubleEntry = (plus as? TestAllTypesProto2.MapInt32DoubleEntry)?.let {
@@ -3276,6 +3309,8 @@ private fun TestAllTypesProto2.MapInt32DoubleEntry.Companion.decodeWithImpl(u: p
     return TestAllTypesProto2.MapInt32DoubleEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapBoolBoolEntry")
 fun TestAllTypesProto2.MapBoolBoolEntry?.orDefault() = this ?: TestAllTypesProto2.MapBoolBoolEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapBoolBoolEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapBoolBoolEntry = (plus as? TestAllTypesProto2.MapBoolBoolEntry)?.let {
@@ -3300,6 +3335,8 @@ private fun TestAllTypesProto2.MapBoolBoolEntry.Companion.decodeWithImpl(u: pban
     return TestAllTypesProto2.MapBoolBoolEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapStringStringEntry")
 fun TestAllTypesProto2.MapStringStringEntry?.orDefault() = this ?: TestAllTypesProto2.MapStringStringEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapStringStringEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapStringStringEntry = (plus as? TestAllTypesProto2.MapStringStringEntry)?.let {
@@ -3324,6 +3361,8 @@ private fun TestAllTypesProto2.MapStringStringEntry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto2.MapStringStringEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapStringBytesEntry")
 fun TestAllTypesProto2.MapStringBytesEntry?.orDefault() = this ?: TestAllTypesProto2.MapStringBytesEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapStringBytesEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapStringBytesEntry = (plus as? TestAllTypesProto2.MapStringBytesEntry)?.let {
@@ -3348,6 +3387,8 @@ private fun TestAllTypesProto2.MapStringBytesEntry.Companion.decodeWithImpl(u: p
     return TestAllTypesProto2.MapStringBytesEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapStringNestedMessageEntry")
 fun TestAllTypesProto2.MapStringNestedMessageEntry?.orDefault() = this ?: TestAllTypesProto2.MapStringNestedMessageEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapStringNestedMessageEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapStringNestedMessageEntry = (plus as? TestAllTypesProto2.MapStringNestedMessageEntry)?.let {
@@ -3372,6 +3413,8 @@ private fun TestAllTypesProto2.MapStringNestedMessageEntry.Companion.decodeWithI
     return TestAllTypesProto2.MapStringNestedMessageEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapStringForeignMessageEntry")
 fun TestAllTypesProto2.MapStringForeignMessageEntry?.orDefault() = this ?: TestAllTypesProto2.MapStringForeignMessageEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapStringForeignMessageEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapStringForeignMessageEntry = (plus as? TestAllTypesProto2.MapStringForeignMessageEntry)?.let {
@@ -3396,6 +3439,8 @@ private fun TestAllTypesProto2.MapStringForeignMessageEntry.Companion.decodeWith
     return TestAllTypesProto2.MapStringForeignMessageEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapStringNestedEnumEntry")
 fun TestAllTypesProto2.MapStringNestedEnumEntry?.orDefault() = this ?: TestAllTypesProto2.MapStringNestedEnumEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapStringNestedEnumEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapStringNestedEnumEntry = (plus as? TestAllTypesProto2.MapStringNestedEnumEntry)?.let {
@@ -3420,6 +3465,8 @@ private fun TestAllTypesProto2.MapStringNestedEnumEntry.Companion.decodeWithImpl
     return TestAllTypesProto2.MapStringNestedEnumEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MapStringForeignEnumEntry")
 fun TestAllTypesProto2.MapStringForeignEnumEntry?.orDefault() = this ?: TestAllTypesProto2.MapStringForeignEnumEntry.defaultInstance
 
 private fun TestAllTypesProto2.MapStringForeignEnumEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MapStringForeignEnumEntry = (plus as? TestAllTypesProto2.MapStringForeignEnumEntry)?.let {
@@ -3444,6 +3491,8 @@ private fun TestAllTypesProto2.MapStringForeignEnumEntry.Companion.decodeWithImp
     return TestAllTypesProto2.MapStringForeignEnumEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2Data")
 fun TestAllTypesProto2.Data?.orDefault() = this ?: TestAllTypesProto2.Data.defaultInstance
 
 private fun TestAllTypesProto2.Data.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.Data = (plus as? TestAllTypesProto2.Data)?.let {
@@ -3468,6 +3517,8 @@ private fun TestAllTypesProto2.Data.Companion.decodeWithImpl(u: pbandk.MessageDe
     return TestAllTypesProto2.Data(groupInt32, groupUint32, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MessageSetCorrect")
 fun TestAllTypesProto2.MessageSetCorrect?.orDefault() = this ?: TestAllTypesProto2.MessageSetCorrect.defaultInstance
 
 private fun TestAllTypesProto2.MessageSetCorrect.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MessageSetCorrect = (plus as? TestAllTypesProto2.MessageSetCorrect)?.let {
@@ -3483,6 +3534,8 @@ private fun TestAllTypesProto2.MessageSetCorrect.Companion.decodeWithImpl(u: pba
     return TestAllTypesProto2.MessageSetCorrect(unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MessageSetCorrectExtension1")
 fun TestAllTypesProto2.MessageSetCorrectExtension1?.orDefault() = this ?: TestAllTypesProto2.MessageSetCorrectExtension1.defaultInstance
 
 private fun TestAllTypesProto2.MessageSetCorrectExtension1.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MessageSetCorrectExtension1 = (plus as? TestAllTypesProto2.MessageSetCorrectExtension1)?.let {
@@ -3504,6 +3557,8 @@ private fun TestAllTypesProto2.MessageSetCorrectExtension1.Companion.decodeWithI
     return TestAllTypesProto2.MessageSetCorrectExtension1(str, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto2MessageSetCorrectExtension2")
 fun TestAllTypesProto2.MessageSetCorrectExtension2?.orDefault() = this ?: TestAllTypesProto2.MessageSetCorrectExtension2.defaultInstance
 
 private fun TestAllTypesProto2.MessageSetCorrectExtension2.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto2.MessageSetCorrectExtension2 = (plus as? TestAllTypesProto2.MessageSetCorrectExtension2)?.let {
@@ -3525,6 +3580,8 @@ private fun TestAllTypesProto2.MessageSetCorrectExtension2.Companion.decodeWithI
     return TestAllTypesProto2.MessageSetCorrectExtension2(i, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForForeignMessageProto2")
 fun ForeignMessageProto2?.orDefault() = this ?: ForeignMessageProto2.defaultInstance
 
 private fun ForeignMessageProto2.protoMergeImpl(plus: pbandk.Message?): ForeignMessageProto2 = (plus as? ForeignMessageProto2)?.let {
@@ -3546,6 +3603,8 @@ private fun ForeignMessageProto2.Companion.decodeWithImpl(u: pbandk.MessageDecod
     return ForeignMessageProto2(c, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUnknownToTestAllTypes")
 fun UnknownToTestAllTypes?.orDefault() = this ?: UnknownToTestAllTypes.defaultInstance
 
 private fun UnknownToTestAllTypes.protoMergeImpl(plus: pbandk.Message?): UnknownToTestAllTypes = (plus as? UnknownToTestAllTypes)?.let {
@@ -3580,6 +3639,8 @@ private fun UnknownToTestAllTypes.Companion.decodeWithImpl(u: pbandk.MessageDeco
         pbandk.ListWithSize.Builder.fixed(repeatedInt32), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUnknownToTestAllTypesOptionalGroup")
 fun UnknownToTestAllTypes.OptionalGroup?.orDefault() = this ?: UnknownToTestAllTypes.OptionalGroup.defaultInstance
 
 private fun UnknownToTestAllTypes.OptionalGroup.protoMergeImpl(plus: pbandk.Message?): UnknownToTestAllTypes.OptionalGroup = (plus as? UnknownToTestAllTypes.OptionalGroup)?.let {

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
@@ -2,6 +2,7 @@
 
 package pbandk.conformance.pb
 
+@pbandk.Export
 sealed class ForeignEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is ForeignEnum && other.value == value
     override fun hashCode() = value.hashCode()
@@ -19,6 +20,7 @@ sealed class ForeignEnum(override val value: Int, override val name: String? = n
     }
 }
 
+@pbandk.Export
 data class TestAllTypesProto3(
     val optionalInt32: Int = 0,
     val optionalInt64: Long = 0L,
@@ -2651,6 +2653,7 @@ data class TestAllTypesProto3(
     }
 }
 
+@pbandk.Export
 data class ForeignMessage(
     val c: Int = 0,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -2685,6 +2688,8 @@ data class ForeignMessage(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3")
 fun TestAllTypesProto3?.orDefault() = this ?: TestAllTypesProto3.defaultInstance
 
 private fun TestAllTypesProto3.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3 = (plus as? TestAllTypesProto3)?.let {
@@ -3136,6 +3141,8 @@ private fun TestAllTypesProto3.Companion.decodeWithImpl(u: pbandk.MessageDecoder
         oneofField, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3NestedMessage")
 fun TestAllTypesProto3.NestedMessage?.orDefault() = this ?: TestAllTypesProto3.NestedMessage.defaultInstance
 
 private fun TestAllTypesProto3.NestedMessage.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.NestedMessage = (plus as? TestAllTypesProto3.NestedMessage)?.let {
@@ -3159,6 +3166,8 @@ private fun TestAllTypesProto3.NestedMessage.Companion.decodeWithImpl(u: pbandk.
     return TestAllTypesProto3.NestedMessage(a, corecursive, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt32Int32Entry")
 fun TestAllTypesProto3.MapInt32Int32Entry?.orDefault() = this ?: TestAllTypesProto3.MapInt32Int32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt32Int32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt32Int32Entry = (plus as? TestAllTypesProto3.MapInt32Int32Entry)?.let {
@@ -3181,6 +3190,8 @@ private fun TestAllTypesProto3.MapInt32Int32Entry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto3.MapInt32Int32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt64Int64Entry")
 fun TestAllTypesProto3.MapInt64Int64Entry?.orDefault() = this ?: TestAllTypesProto3.MapInt64Int64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt64Int64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt64Int64Entry = (plus as? TestAllTypesProto3.MapInt64Int64Entry)?.let {
@@ -3203,6 +3214,8 @@ private fun TestAllTypesProto3.MapInt64Int64Entry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto3.MapInt64Int64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapUint32Uint32Entry")
 fun TestAllTypesProto3.MapUint32Uint32Entry?.orDefault() = this ?: TestAllTypesProto3.MapUint32Uint32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapUint32Uint32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapUint32Uint32Entry = (plus as? TestAllTypesProto3.MapUint32Uint32Entry)?.let {
@@ -3225,6 +3238,8 @@ private fun TestAllTypesProto3.MapUint32Uint32Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapUint32Uint32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapUint64Uint64Entry")
 fun TestAllTypesProto3.MapUint64Uint64Entry?.orDefault() = this ?: TestAllTypesProto3.MapUint64Uint64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapUint64Uint64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapUint64Uint64Entry = (plus as? TestAllTypesProto3.MapUint64Uint64Entry)?.let {
@@ -3247,6 +3262,8 @@ private fun TestAllTypesProto3.MapUint64Uint64Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapUint64Uint64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSint32Sint32Entry")
 fun TestAllTypesProto3.MapSint32Sint32Entry?.orDefault() = this ?: TestAllTypesProto3.MapSint32Sint32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSint32Sint32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSint32Sint32Entry = (plus as? TestAllTypesProto3.MapSint32Sint32Entry)?.let {
@@ -3269,6 +3286,8 @@ private fun TestAllTypesProto3.MapSint32Sint32Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapSint32Sint32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSint64Sint64Entry")
 fun TestAllTypesProto3.MapSint64Sint64Entry?.orDefault() = this ?: TestAllTypesProto3.MapSint64Sint64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSint64Sint64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSint64Sint64Entry = (plus as? TestAllTypesProto3.MapSint64Sint64Entry)?.let {
@@ -3291,6 +3310,8 @@ private fun TestAllTypesProto3.MapSint64Sint64Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapSint64Sint64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapFixed32Fixed32Entry")
 fun TestAllTypesProto3.MapFixed32Fixed32Entry?.orDefault() = this ?: TestAllTypesProto3.MapFixed32Fixed32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapFixed32Fixed32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapFixed32Fixed32Entry = (plus as? TestAllTypesProto3.MapFixed32Fixed32Entry)?.let {
@@ -3313,6 +3334,8 @@ private fun TestAllTypesProto3.MapFixed32Fixed32Entry.Companion.decodeWithImpl(u
     return TestAllTypesProto3.MapFixed32Fixed32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapFixed64Fixed64Entry")
 fun TestAllTypesProto3.MapFixed64Fixed64Entry?.orDefault() = this ?: TestAllTypesProto3.MapFixed64Fixed64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapFixed64Fixed64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapFixed64Fixed64Entry = (plus as? TestAllTypesProto3.MapFixed64Fixed64Entry)?.let {
@@ -3335,6 +3358,8 @@ private fun TestAllTypesProto3.MapFixed64Fixed64Entry.Companion.decodeWithImpl(u
     return TestAllTypesProto3.MapFixed64Fixed64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSfixed32Sfixed32Entry")
 fun TestAllTypesProto3.MapSfixed32Sfixed32Entry?.orDefault() = this ?: TestAllTypesProto3.MapSfixed32Sfixed32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSfixed32Sfixed32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSfixed32Sfixed32Entry = (plus as? TestAllTypesProto3.MapSfixed32Sfixed32Entry)?.let {
@@ -3357,6 +3382,8 @@ private fun TestAllTypesProto3.MapSfixed32Sfixed32Entry.Companion.decodeWithImpl
     return TestAllTypesProto3.MapSfixed32Sfixed32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSfixed64Sfixed64Entry")
 fun TestAllTypesProto3.MapSfixed64Sfixed64Entry?.orDefault() = this ?: TestAllTypesProto3.MapSfixed64Sfixed64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSfixed64Sfixed64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSfixed64Sfixed64Entry = (plus as? TestAllTypesProto3.MapSfixed64Sfixed64Entry)?.let {
@@ -3379,6 +3406,8 @@ private fun TestAllTypesProto3.MapSfixed64Sfixed64Entry.Companion.decodeWithImpl
     return TestAllTypesProto3.MapSfixed64Sfixed64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt32FloatEntry")
 fun TestAllTypesProto3.MapInt32FloatEntry?.orDefault() = this ?: TestAllTypesProto3.MapInt32FloatEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt32FloatEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt32FloatEntry = (plus as? TestAllTypesProto3.MapInt32FloatEntry)?.let {
@@ -3401,6 +3430,8 @@ private fun TestAllTypesProto3.MapInt32FloatEntry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto3.MapInt32FloatEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt32DoubleEntry")
 fun TestAllTypesProto3.MapInt32DoubleEntry?.orDefault() = this ?: TestAllTypesProto3.MapInt32DoubleEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt32DoubleEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt32DoubleEntry = (plus as? TestAllTypesProto3.MapInt32DoubleEntry)?.let {
@@ -3423,6 +3454,8 @@ private fun TestAllTypesProto3.MapInt32DoubleEntry.Companion.decodeWithImpl(u: p
     return TestAllTypesProto3.MapInt32DoubleEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapBoolBoolEntry")
 fun TestAllTypesProto3.MapBoolBoolEntry?.orDefault() = this ?: TestAllTypesProto3.MapBoolBoolEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapBoolBoolEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapBoolBoolEntry = (plus as? TestAllTypesProto3.MapBoolBoolEntry)?.let {
@@ -3445,6 +3478,8 @@ private fun TestAllTypesProto3.MapBoolBoolEntry.Companion.decodeWithImpl(u: pban
     return TestAllTypesProto3.MapBoolBoolEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringStringEntry")
 fun TestAllTypesProto3.MapStringStringEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringStringEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringStringEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringStringEntry = (plus as? TestAllTypesProto3.MapStringStringEntry)?.let {
@@ -3467,6 +3502,8 @@ private fun TestAllTypesProto3.MapStringStringEntry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapStringStringEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringBytesEntry")
 fun TestAllTypesProto3.MapStringBytesEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringBytesEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringBytesEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringBytesEntry = (plus as? TestAllTypesProto3.MapStringBytesEntry)?.let {
@@ -3489,6 +3526,8 @@ private fun TestAllTypesProto3.MapStringBytesEntry.Companion.decodeWithImpl(u: p
     return TestAllTypesProto3.MapStringBytesEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringNestedMessageEntry")
 fun TestAllTypesProto3.MapStringNestedMessageEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringNestedMessageEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringNestedMessageEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringNestedMessageEntry = (plus as? TestAllTypesProto3.MapStringNestedMessageEntry)?.let {
@@ -3512,6 +3551,8 @@ private fun TestAllTypesProto3.MapStringNestedMessageEntry.Companion.decodeWithI
     return TestAllTypesProto3.MapStringNestedMessageEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringForeignMessageEntry")
 fun TestAllTypesProto3.MapStringForeignMessageEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringForeignMessageEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringForeignMessageEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringForeignMessageEntry = (plus as? TestAllTypesProto3.MapStringForeignMessageEntry)?.let {
@@ -3535,6 +3576,8 @@ private fun TestAllTypesProto3.MapStringForeignMessageEntry.Companion.decodeWith
     return TestAllTypesProto3.MapStringForeignMessageEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringNestedEnumEntry")
 fun TestAllTypesProto3.MapStringNestedEnumEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringNestedEnumEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringNestedEnumEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringNestedEnumEntry = (plus as? TestAllTypesProto3.MapStringNestedEnumEntry)?.let {
@@ -3557,6 +3600,8 @@ private fun TestAllTypesProto3.MapStringNestedEnumEntry.Companion.decodeWithImpl
     return TestAllTypesProto3.MapStringNestedEnumEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringForeignEnumEntry")
 fun TestAllTypesProto3.MapStringForeignEnumEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringForeignEnumEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringForeignEnumEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringForeignEnumEntry = (plus as? TestAllTypesProto3.MapStringForeignEnumEntry)?.let {
@@ -3579,6 +3624,8 @@ private fun TestAllTypesProto3.MapStringForeignEnumEntry.Companion.decodeWithImp
     return TestAllTypesProto3.MapStringForeignEnumEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForForeignMessage")
 fun ForeignMessage?.orDefault() = this ?: ForeignMessage.defaultInstance
 
 private fun ForeignMessage.protoMergeImpl(plus: pbandk.Message?): ForeignMessage = (plus as? ForeignMessage)?.let {

--- a/examples/browser-js/app/build.gradle.kts
+++ b/examples/browser-js/app/build.gradle.kts
@@ -26,7 +26,7 @@ kotlin {
 }
 
 tasks {
-    named<KotlinJsCompile>("compileKotlinJs") {
+    val compileKotlinJs by getting(KotlinJsCompile::class) {
         kotlinOptions {
             sourceMap = true
             moduleKind = "commonjs"
@@ -37,7 +37,7 @@ tasks {
     // Generate the protobuf files before compilation
     project(":lib-proto").tasks
         .matching { it.name == "generateProto" }
-        .all { named<KotlinJsCompile>("compileKotlinJs").get().dependsOn(this) }
+        .all { compileKotlinJs.dependsOn(this) }
 }
 
 // This is required for consuming a Kotlin/JS library compiled with Kotlin 1.4

--- a/examples/browser-js/app/build.gradle.kts
+++ b/examples/browser-js/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinJsCompile
+
 plugins {
     kotlin("js")
 }
@@ -12,7 +14,9 @@ dependencies {
 }
 
 kotlin {
-    target.browser {}
+    js(LEGACY) {
+        browser {}
+    }
 
     sourceSets {
         main {
@@ -22,7 +26,7 @@ kotlin {
 }
 
 tasks {
-    compileKotlinJs {
+    named<KotlinJsCompile>("compileKotlinJs") {
         kotlinOptions {
             sourceMap = true
             moduleKind = "commonjs"
@@ -33,7 +37,7 @@ tasks {
     // Generate the protobuf files before compilation
     project(":lib-proto").tasks
         .matching { it.name == "generateProto" }
-        .all { compileKotlinJs.get().dependsOn(this) }
+        .all { named<KotlinJsCompile>("compileKotlinJs").get().dependsOn(this) }
 }
 
 // This is required for consuming a Kotlin/JS library compiled with Kotlin 1.4

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("js") version "1.3.72" apply false
+    kotlin("js") version "1.4.32" apply false
     id("com.google.protobuf") version "0.8.12" apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 # removed when/if this is resolved on the gradle side.
 #
 # Gradle also needs more heap space to build this project than the default 1GB.
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -Xmx2048m
+#
+# IR compiler backend for Kotlin/JS requires a higher than default (1MB) stack
+# size. Otherwise, there is a high chance of build crashing with stack overflow.
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=512m -Xmx2048m -Xss32m

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -12,7 +12,8 @@ open class CodeGenerator(
     protected var indent = ""
 
     fun generate(): String {
-        line("@file:OptIn(pbandk.PublicForGeneratedCode::class)").line()
+        line("@file:OptIn(pbandk.PublicForGeneratedCode::class, kotlin.js.ExperimentalJsExport::class)")
+        line("@file:kotlin.js.JsExport").line()
         file.kotlinPackageName?.let { line("package $it") }
         file.types.forEach { writeType(it) }
         file.extensions.forEach { writeExtension(it) }

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -275,6 +275,13 @@ open class CodeGenerator(
         fullTypeName: String
     ) {
         line()
+        // There can be multiple differently-typed `orDefault` functions in the same scope which
+        // Kotlin/JS cannot handle unfortunately. We have to annotate each of them with a unique
+        // name so that Kotlin/JS knows which name to choose.
+        //
+        // Also, if current type is an inner class, `fullTypeName` will contains dots which we
+        // have to get rid of (i.e. `Person.AddressBook` becomes `PersonAddressBook`).
+        line("@pbandk.Name(\"orDefaultFor${fullTypeName.replace(".", "")}\")")
         line("fun $fullTypeName?.orDefault() = this ?: $fullTypeName.defaultInstance")
     }
 

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -12,8 +12,8 @@ open class CodeGenerator(
     protected var indent = ""
 
     fun generate(): String {
-        line("@file:OptIn(pbandk.PublicForGeneratedCode::class, kotlin.js.ExperimentalJsExport::class)")
-        line("@file:kotlin.js.JsExport").line()
+        line("@file:OptIn(pbandk.PublicForGeneratedCode::class)")
+        line("@file:pbandk.Export").line()
         file.kotlinPackageName?.let { line("package $it") }
         file.types.forEach { writeType(it) }
         file.extensions.forEach { writeExtension(it) }

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -281,7 +281,7 @@ open class CodeGenerator(
         //
         // Also, if current type is an inner class, `fullTypeName` will contains dots which we
         // have to get rid of (i.e. `Person.AddressBook` becomes `PersonAddressBook`).
-        line("@pbandk.Name(\"orDefaultFor${fullTypeName.replace(".", "")}\")")
+        line("@pbandk.JsName(\"orDefaultFor${fullTypeName.replace(".", "")}\")")
         line("fun $fullTypeName?.orDefault() = this ?: $fullTypeName.defaultInstance")
     }
 

--- a/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/pb/plugin.kt
+++ b/protoc-gen-kotlin/lib/src/commonMain/kotlin/pbandk/gen/pb/plugin.kt
@@ -2,6 +2,7 @@
 
 package pbandk.gen.pb
 
+@pbandk.Export
 data class Version(
     val major: Int? = null,
     val minor: Int? = null,
@@ -69,6 +70,7 @@ data class Version(
     }
 }
 
+@pbandk.Export
 data class CodeGeneratorRequest(
     val fileToGenerate: List<String> = emptyList(),
     val parameter: String? = null,
@@ -136,6 +138,7 @@ data class CodeGeneratorRequest(
     }
 }
 
+@pbandk.Export
 data class CodeGeneratorResponse(
     val error: String? = null,
     val supportedFeatures: Long? = null,
@@ -275,6 +278,8 @@ data class CodeGeneratorResponse(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForVersion")
 fun Version?.orDefault() = this ?: Version.defaultInstance
 
 private fun Version.protoMergeImpl(plus: pbandk.Message?): Version = (plus as? Version)?.let {
@@ -305,6 +310,8 @@ private fun Version.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Version 
     return Version(major, minor, patch, suffix, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForCodeGeneratorRequest")
 fun CodeGeneratorRequest?.orDefault() = this ?: CodeGeneratorRequest.defaultInstance
 
 private fun CodeGeneratorRequest.protoMergeImpl(plus: pbandk.Message?): CodeGeneratorRequest = (plus as? CodeGeneratorRequest)?.let {
@@ -335,6 +342,8 @@ private fun CodeGeneratorRequest.Companion.decodeWithImpl(u: pbandk.MessageDecod
     return CodeGeneratorRequest(pbandk.ListWithSize.Builder.fixed(fileToGenerate), parameter, pbandk.ListWithSize.Builder.fixed(protoFile), compilerVersion, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForCodeGeneratorResponse")
 fun CodeGeneratorResponse?.orDefault() = this ?: CodeGeneratorResponse.defaultInstance
 
 private fun CodeGeneratorResponse.protoMergeImpl(plus: pbandk.Message?): CodeGeneratorResponse = (plus as? CodeGeneratorResponse)?.let {
@@ -362,6 +371,8 @@ private fun CodeGeneratorResponse.Companion.decodeWithImpl(u: pbandk.MessageDeco
     return CodeGeneratorResponse(error, supportedFeatures, pbandk.ListWithSize.Builder.fixed(file), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForCodeGeneratorResponseFile")
 fun CodeGeneratorResponse.File?.orDefault() = this ?: CodeGeneratorResponse.File.defaultInstance
 
 private fun CodeGeneratorResponse.File.protoMergeImpl(plus: pbandk.Message?): CodeGeneratorResponse.File = (plus as? CodeGeneratorResponse.File)?.let {

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -17,6 +17,9 @@ public abstract interface annotation class pbandk/ExperimentalProtoJson : java/l
 public abstract interface annotation class pbandk/ExperimentalProtoReflection : java/lang/annotation/Annotation {
 }
 
+public abstract interface annotation class pbandk/Export : java/lang/annotation/Annotation {
+}
+
 public abstract interface class pbandk/ExtendableMessage : pbandk/Message {
 	public abstract fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
 	public abstract fun getExtensionFields ()Lpbandk/ExtensionFieldSet;

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -332,6 +332,10 @@ public final class pbandk/MessageMap$Entry$Companion : pbandk/Message$Companion 
 	public fun getDescriptor ()Lpbandk/MessageDescriptor;
 }
 
+public abstract interface annotation class pbandk/Name : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+}
+
 public abstract interface annotation class pbandk/PbandkInternal : java/lang/annotation/Annotation {
 }
 

--- a/runtime/api/runtime.api
+++ b/runtime/api/runtime.api
@@ -161,6 +161,10 @@ public final class pbandk/InvalidProtocolBufferException : java/lang/RuntimeExce
 	public static final field Companion Lpbandk/InvalidProtocolBufferException$Companion;
 }
 
+public abstract interface annotation class pbandk/JsName : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+}
+
 public final class pbandk/ListWithSize : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
 	public static final field Companion Lpbandk/ListWithSize$Companion;
 	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
@@ -330,10 +334,6 @@ public final class pbandk/MessageMap$Entry$Companion : pbandk/Message$Companion 
 	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
 	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/MessageMap$Entry;
 	public fun getDescriptor ()Lpbandk/MessageDescriptor;
-}
-
-public abstract interface annotation class pbandk/Name : java/lang/annotation/Annotation {
-	public abstract fun name ()Ljava/lang/String;
 }
 
 public abstract interface annotation class pbandk/PbandkInternal : java/lang/annotation/Annotation {

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -20,7 +20,7 @@ kotlin {
 
     jvm()
 
-    js {
+    js(BOTH) {
         useCommonJs()
         browser {}
         nodejs {}
@@ -158,14 +158,6 @@ tasks {
 
     val generateTestTypes by registering {
         dependsOn(generateKotlinTestTypes, generateJavaTestTypes)
-    }
-
-    // DCE is now enabled by default in Kotlin 1.3.7x
-    // and it doesn't work well with commonJS modules
-    // Use of commonJs could be removed since default module is now UMD
-    // but would require some code change
-    val processDceJsKotlinJs by getting {
-        enabled = false
     }
 }
 

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
             languageSettings.useExperimentalAnnotation("pbandk.PbandkInternal")
             languageSettings.useExperimentalAnnotation("pbandk.PublicForGeneratedCode")
             languageSettings.useExperimentalAnnotation("kotlin.RequiresOptIn")
+            languageSettings.useExperimentalAnnotation("kotlin.js.ExperimentalJsExport")
         }
 
         val commonMain by getting {

--- a/runtime/src/commonJvmAndroid/kotlin/pbandk/Export.kt
+++ b/runtime/src/commonJvmAndroid/kotlin/pbandk/Export.kt
@@ -1,0 +1,4 @@
+package pbandk
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
+actual annotation class Export()

--- a/runtime/src/commonJvmAndroid/kotlin/pbandk/Export.kt
+++ b/runtime/src/commonJvmAndroid/kotlin/pbandk/Export.kt
@@ -11,4 +11,4 @@ actual annotation class Export()
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
-actual annotation class Name(actual val name: String)
+actual annotation class JsName(actual val name: String)

--- a/runtime/src/commonJvmAndroid/kotlin/pbandk/Export.kt
+++ b/runtime/src/commonJvmAndroid/kotlin/pbandk/Export.kt
@@ -2,3 +2,13 @@ package pbandk
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
 actual annotation class Export()
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER
+)
+actual annotation class Name(actual val name: String)

--- a/runtime/src/commonMain/kotlin/pbandk/ByteArr.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ByteArr.kt
@@ -1,5 +1,8 @@
 package pbandk
 
+import kotlin.js.JsExport
+
+@JsExport
 class ByteArr(val array: ByteArray) {
     override fun equals(other: Any?) = other is ByteArr && array.contentEquals(other.array)
     override fun hashCode() = array.contentHashCode()

--- a/runtime/src/commonMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/Export.kt
@@ -1,0 +1,4 @@
+package pbandk
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
+expect annotation class Export()

--- a/runtime/src/commonMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/Export.kt
@@ -2,3 +2,13 @@ package pbandk
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
 expect annotation class Export()
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER
+)
+expect annotation class Name(val name: String)

--- a/runtime/src/commonMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/Export.kt
@@ -1,6 +1,7 @@
 package pbandk
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
+@PublicForGeneratedCode
 expect annotation class Export()
 
 @Target(
@@ -11,4 +12,5 @@ expect annotation class Export()
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
-expect annotation class Name(val name: String)
+@PublicForGeneratedCode
+expect annotation class JsName(val name: String)

--- a/runtime/src/commonMain/kotlin/pbandk/ExtendableMessage.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ExtendableMessage.kt
@@ -1,5 +1,8 @@
 package pbandk
 
+import kotlin.js.JsExport
+
+@JsExport
 interface ExtendableMessage : Message {
     @PublicForGeneratedCode
     val extensionFields: ExtensionFieldSet

--- a/runtime/src/commonMain/kotlin/pbandk/FieldDescriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/FieldDescriptor.kt
@@ -2,9 +2,11 @@ package pbandk
 
 import pbandk.internal.binary.WireType
 import pbandk.wkt.FieldOptions
+import kotlin.js.JsExport
 import kotlin.reflect.KProperty0
 import kotlin.reflect.KProperty1
 
+@JsExport
 class FieldDescriptor<M : Message, T> @PublicForGeneratedCode constructor(
     messageDescriptor: KProperty0<MessageDescriptor<M>>,
     @ExperimentalProtoReflection

--- a/runtime/src/commonMain/kotlin/pbandk/InvalidProtocolBufferException.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/InvalidProtocolBufferException.kt
@@ -1,5 +1,9 @@
 package pbandk
 
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
+@JsExport
 class InvalidProtocolBufferException : RuntimeException {
     internal constructor(message: String) : super(message)
     internal constructor(message: String, cause: Throwable) : super(message, cause)

--- a/runtime/src/commonMain/kotlin/pbandk/ListWithSize.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ListWithSize.kt
@@ -1,7 +1,12 @@
 package pbandk
 
+import kotlin.js.JsExport
+import kotlin.js.JsName
+
 @PublicForGeneratedCode
+@JsExport
 class ListWithSize<T> internal constructor(val list: List<T>, val protoSize: Int?) : List<T> by list {
+    @JsName("initWithSizeFn")
     constructor(list: List<T>, sizeFn: (T) -> Int) : this(list, list.sumBy(sizeFn))
 
     override fun equals(other: Any?) = list == other
@@ -10,6 +15,7 @@ class ListWithSize<T> internal constructor(val list: List<T>, val protoSize: Int
 
     @PublicForGeneratedCode
     class Builder<T> private constructor(val list: ArrayList<T>): MutableList<T> by list {
+        @JsName("init")
         constructor() : this(ArrayList())
 
         fun fixed() = ListWithSize(list.also { it.trimToSize() }, protoSize = null)

--- a/runtime/src/commonMain/kotlin/pbandk/Message.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/Message.kt
@@ -5,8 +5,11 @@ import pbandk.internal.binary.BinaryMessageEncoder
 import pbandk.internal.binary.BinaryMessageDecoder
 import pbandk.internal.binary.allocate
 import pbandk.internal.binary.fromByteArray
+import kotlin.js.ExperimentalJsExport
+import kotlin.js.JsExport
 import kotlin.reflect.KProperty1
 
+@JsExport
 interface Message {
     val unknownFields: Map<Int, UnknownField>
 
@@ -43,21 +46,25 @@ interface Message {
 
 }
 
+@JsExport
 fun <T : Message> T.encodeWith(m: MessageEncoder): Unit = m.writeMessage(this)
 
 /**
  * Encode this message to a ByteArray using the protocol buffer binary encoding.
  */
+@JsExport
 fun <T : Message> T.encodeToByteArray(): ByteArray =
     BinaryMessageEncoder.allocate(protoSize).also { encodeWith(it) }.toByteArray()
 
 /**
  * Decode a binary protocol buffer message from [arr].
  */
+@JsExport
 fun <T : Message> Message.Companion<T>.decodeFromByteArray(arr: ByteArray): T =
     decodeWith(BinaryMessageDecoder.fromByteArray(arr))
 
 @Suppress("UNCHECKED_CAST")
+@JsExport
 operator fun <T : Message> T?.plus(other: T?): T? = this?.plus(other) as T? ?: other
 
 /**

--- a/runtime/src/commonMain/kotlin/pbandk/MessageDecoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageDecoder.kt
@@ -1,5 +1,8 @@
 package pbandk
 
+import kotlin.js.JsExport
+
+@JsExport
 interface MessageDecoder {
     fun <T : Message> readMessage(
         messageCompanion: Message.Companion<T>,

--- a/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
@@ -1,7 +1,9 @@
 package pbandk
 
+import kotlin.js.JsExport
 import kotlin.reflect.KClass
 
+@JsExport
 class MessageDescriptor<T : Message> @PublicForGeneratedCode constructor(
     internal val messageClass: KClass<T>,
     @ExperimentalProtoReflection

--- a/runtime/src/commonMain/kotlin/pbandk/MessageEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageEncoder.kt
@@ -1,5 +1,8 @@
 package pbandk
 
+import kotlin.js.JsExport
+
+@JsExport
 interface MessageEncoder {
     fun <T : Message> writeMessage(message: T)
 }

--- a/runtime/src/commonMain/kotlin/pbandk/MessageMap.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageMap.kt
@@ -1,8 +1,10 @@
 package pbandk
 
+import kotlin.js.JsExport
 import kotlin.reflect.KClass
 
 @PublicForGeneratedCode
+@JsExport
 class MessageMap<K, V> internal constructor(override val entries: Set<Entry<K, V>>) : AbstractMap<K, V>() {
     @PublicForGeneratedCode
     class Builder<K, V> {

--- a/runtime/src/commonMain/kotlin/pbandk/UnknownField.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/UnknownField.kt
@@ -7,13 +7,17 @@ import pbandk.internal.binary.allowedWireType
 import pbandk.internal.binary.binaryReadFn
 import pbandk.internal.binary.kotlin.ByteArrayWireReader
 import pbandk.internal.binary.kotlin.KotlinBinaryWireDecoder
+import kotlin.js.JsExport
+import kotlin.js.JsName
 
+@JsExport
 data class UnknownField @PublicForGeneratedCode constructor(val fieldNum: Int, val values: List<Value>) {
 
     internal val size get() = (Sizer.tagSize(fieldNum) * values.size) + values.sumBy { it.size }
 
     data class Value @PublicForGeneratedCode constructor(val wireType: Int, val rawBytes: ByteArr) {
         @PublicForGeneratedCode
+        @JsName("fromByteArray")
         constructor(wireType: Int, rawBytes: ByteArray) : this(wireType, ByteArr(rawBytes))
 
         internal val size get() = rawBytes.array.size

--- a/runtime/src/commonMain/kotlin/pbandk/json/JsonConfig.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/json/JsonConfig.kt
@@ -3,8 +3,10 @@ package pbandk.json
 import pbandk.ExperimentalProtoJson
 import pbandk.FieldDescriptor
 import pbandk.internal.underscoreToCamelCase
+import kotlin.js.JsExport
 
 @ExperimentalProtoJson
+@JsExport
 data class JsonConfig(
     /**
      * By default the JSON name of a field is the field's proto name converted to lowerCamelCase. If this option is

--- a/runtime/src/commonMain/kotlin/pbandk/json/MessageExtensions.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/json/MessageExtensions.kt
@@ -4,11 +4,13 @@ import pbandk.ExperimentalProtoJson
 import pbandk.Message
 import pbandk.internal.json.JsonMessageEncoder
 import pbandk.internal.json.JsonMessageDecoder
+import kotlin.js.JsExport
 
 /**
  * Encode this message to a String using the protocol buffer JSON encoding.
  */
 @ExperimentalProtoJson
+@JsExport
 fun <T : Message> T.encodeToJsonString(jsonConfig: JsonConfig = JsonConfig.DEFAULT): String =
     JsonMessageEncoder(jsonConfig).also { it.writeMessage(this) }.toJsonString()
 
@@ -16,6 +18,7 @@ fun <T : Message> T.encodeToJsonString(jsonConfig: JsonConfig = JsonConfig.DEFAU
  * Decode a JSON protocol buffer message from [data].
  */
 @ExperimentalProtoJson
+@JsExport
 fun <T : Message> Message.Companion<T>.decodeFromJsonString(
     data: String,
     jsonConfig: JsonConfig = JsonConfig.DEFAULT

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/any.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/any.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class Any(
     val typeUrl: String = "",
     val value: pbandk.ByteArr = pbandk.ByteArr.empty,
@@ -47,6 +48,8 @@ data class Any(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForAny")
 fun Any?.orDefault() = this ?: Any.defaultInstance
 
 private fun Any.protoMergeImpl(plus: pbandk.Message?): Any = (plus as? Any)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/api.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/api.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class Api(
     val name: String = "",
     val methods: List<pbandk.wkt.Method> = emptyList(),
@@ -102,6 +103,7 @@ data class Api(
     }
 }
 
+@pbandk.Export
 data class Method(
     val name: String = "",
     val requestTypeUrl: String = "",
@@ -202,6 +204,7 @@ data class Method(
     }
 }
 
+@pbandk.Export
 data class Mixin(
     val name: String = "",
     val root: String = "",
@@ -247,6 +250,8 @@ data class Mixin(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForApi")
 fun Api?.orDefault() = this ?: Api.defaultInstance
 
 private fun Api.protoMergeImpl(plus: pbandk.Message?): Api = (plus as? Api)?.let {
@@ -284,6 +289,8 @@ private fun Api.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Api {
         sourceContext, pbandk.ListWithSize.Builder.fixed(mixins), syntax, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMethod")
 fun Method?.orDefault() = this ?: Method.defaultInstance
 
 private fun Method.protoMergeImpl(plus: pbandk.Message?): Method = (plus as? Method)?.let {
@@ -318,6 +325,8 @@ private fun Method.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Method {
         responseStreaming, pbandk.ListWithSize.Builder.fixed(options), syntax, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMixin")
 fun Mixin?.orDefault() = this ?: Mixin.defaultInstance
 
 private fun Mixin.protoMergeImpl(plus: pbandk.Message?): Mixin = (plus as? Mixin)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class FileDescriptorSet(
     val file: List<pbandk.wkt.FileDescriptorProto> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -36,6 +37,7 @@ data class FileDescriptorSet(
     }
 }
 
+@pbandk.Export
 data class FileDescriptorProto(
     val name: String? = null,
     val `package`: String? = null,
@@ -191,6 +193,7 @@ data class FileDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class DescriptorProto(
     val name: String? = null,
     val field: List<pbandk.wkt.FieldDescriptorProto> = emptyList(),
@@ -425,6 +428,7 @@ data class DescriptorProto(
     }
 }
 
+@pbandk.Export
 data class ExtensionRangeOptions(
     val uninterpretedOption: List<pbandk.wkt.UninterpretedOption> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap(),
@@ -462,6 +466,7 @@ data class ExtensionRangeOptions(
     }
 }
 
+@pbandk.Export
 data class FieldDescriptorProto(
     val name: String? = null,
     val number: Int? = null,
@@ -655,6 +660,7 @@ data class FieldDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class OneofDescriptorProto(
     val name: String? = null,
     val options: pbandk.wkt.OneofOptions? = null,
@@ -700,6 +706,7 @@ data class OneofDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class EnumDescriptorProto(
     val name: String? = null,
     val value: List<pbandk.wkt.EnumValueDescriptorProto> = emptyList(),
@@ -823,6 +830,7 @@ data class EnumDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class EnumValueDescriptorProto(
     val name: String? = null,
     val number: Int? = null,
@@ -879,6 +887,7 @@ data class EnumValueDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class ServiceDescriptorProto(
     val name: String? = null,
     val method: List<pbandk.wkt.MethodDescriptorProto> = emptyList(),
@@ -935,6 +944,7 @@ data class ServiceDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class MethodDescriptorProto(
     val name: String? = null,
     val inputType: String? = null,
@@ -1024,6 +1034,7 @@ data class MethodDescriptorProto(
     }
 }
 
+@pbandk.Export
 data class FileOptions(
     val javaPackage: String? = null,
     val javaOuterClassname: String? = null,
@@ -1301,6 +1312,7 @@ data class FileOptions(
     }
 }
 
+@pbandk.Export
 data class MessageOptions(
     val messageSetWireFormat: Boolean? = null,
     val noStandardDescriptorAccessor: Boolean? = null,
@@ -1382,6 +1394,7 @@ data class MessageOptions(
     }
 }
 
+@pbandk.Export
 data class FieldOptions(
     val ctype: pbandk.wkt.FieldOptions.CType? = null,
     val packed: Boolean? = null,
@@ -1519,6 +1532,7 @@ data class FieldOptions(
     }
 }
 
+@pbandk.Export
 data class OneofOptions(
     val uninterpretedOption: List<pbandk.wkt.UninterpretedOption> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap(),
@@ -1556,6 +1570,7 @@ data class OneofOptions(
     }
 }
 
+@pbandk.Export
 data class EnumOptions(
     val allowAlias: Boolean? = null,
     val deprecated: Boolean? = null,
@@ -1615,6 +1630,7 @@ data class EnumOptions(
     }
 }
 
+@pbandk.Export
 data class EnumValueOptions(
     val deprecated: Boolean? = null,
     val uninterpretedOption: List<pbandk.wkt.UninterpretedOption> = emptyList(),
@@ -1663,6 +1679,7 @@ data class EnumValueOptions(
     }
 }
 
+@pbandk.Export
 data class ServiceOptions(
     val deprecated: Boolean? = null,
     val uninterpretedOption: List<pbandk.wkt.UninterpretedOption> = emptyList(),
@@ -1711,6 +1728,7 @@ data class ServiceOptions(
     }
 }
 
+@pbandk.Export
 data class MethodOptions(
     val deprecated: Boolean? = null,
     val idempotencyLevel: pbandk.wkt.MethodOptions.IdempotencyLevel? = null,
@@ -1787,6 +1805,7 @@ data class MethodOptions(
     }
 }
 
+@pbandk.Export
 data class UninterpretedOption(
     val name: List<pbandk.wkt.UninterpretedOption.NamePart> = emptyList(),
     val identifierValue: String? = null,
@@ -1932,6 +1951,7 @@ data class UninterpretedOption(
     }
 }
 
+@pbandk.Export
 data class SourceCodeInfo(
     val location: List<pbandk.wkt.SourceCodeInfo.Location> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -2044,6 +2064,7 @@ data class SourceCodeInfo(
     }
 }
 
+@pbandk.Export
 data class GeneratedCodeInfo(
     val annotation: List<pbandk.wkt.GeneratedCodeInfo.Annotation> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -2145,6 +2166,8 @@ data class GeneratedCodeInfo(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFileDescriptorSet")
 fun FileDescriptorSet?.orDefault() = this ?: FileDescriptorSet.defaultInstance
 
 private fun FileDescriptorSet.protoMergeImpl(plus: pbandk.Message?): FileDescriptorSet = (plus as? FileDescriptorSet)?.let {
@@ -2166,6 +2189,8 @@ private fun FileDescriptorSet.Companion.decodeWithImpl(u: pbandk.MessageDecoder)
     return FileDescriptorSet(pbandk.ListWithSize.Builder.fixed(file), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFileDescriptorProto")
 fun FileDescriptorProto?.orDefault() = this ?: FileDescriptorProto.defaultInstance
 
 private fun FileDescriptorProto.protoMergeImpl(plus: pbandk.Message?): FileDescriptorProto = (plus as? FileDescriptorProto)?.let {
@@ -2222,6 +2247,8 @@ private fun FileDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDecode
         pbandk.ListWithSize.Builder.fixed(extension), options, sourceCodeInfo, syntax, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDescriptorProto")
 fun DescriptorProto?.orDefault() = this ?: DescriptorProto.defaultInstance
 
 private fun DescriptorProto.protoMergeImpl(plus: pbandk.Message?): DescriptorProto = (plus as? DescriptorProto)?.let {
@@ -2272,6 +2299,8 @@ private fun DescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDecoder): 
         pbandk.ListWithSize.Builder.fixed(reservedRange), pbandk.ListWithSize.Builder.fixed(reservedName), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDescriptorProtoExtensionRange")
 fun DescriptorProto.ExtensionRange?.orDefault() = this ?: DescriptorProto.ExtensionRange.defaultInstance
 
 private fun DescriptorProto.ExtensionRange.protoMergeImpl(plus: pbandk.Message?): DescriptorProto.ExtensionRange = (plus as? DescriptorProto.ExtensionRange)?.let {
@@ -2299,6 +2328,8 @@ private fun DescriptorProto.ExtensionRange.Companion.decodeWithImpl(u: pbandk.Me
     return DescriptorProto.ExtensionRange(start, end, options, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDescriptorProtoReservedRange")
 fun DescriptorProto.ReservedRange?.orDefault() = this ?: DescriptorProto.ReservedRange.defaultInstance
 
 private fun DescriptorProto.ReservedRange.protoMergeImpl(plus: pbandk.Message?): DescriptorProto.ReservedRange = (plus as? DescriptorProto.ReservedRange)?.let {
@@ -2323,6 +2354,8 @@ private fun DescriptorProto.ReservedRange.Companion.decodeWithImpl(u: pbandk.Mes
     return DescriptorProto.ReservedRange(start, end, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForExtensionRangeOptions")
 fun ExtensionRangeOptions?.orDefault() = this ?: ExtensionRangeOptions.defaultInstance
 
 private fun ExtensionRangeOptions.protoMergeImpl(plus: pbandk.Message?): ExtensionRangeOptions = (plus as? ExtensionRangeOptions)?.let {
@@ -2344,6 +2377,8 @@ private fun ExtensionRangeOptions.Companion.decodeWithImpl(u: pbandk.MessageDeco
     return ExtensionRangeOptions(pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFieldDescriptorProto")
 fun FieldDescriptorProto?.orDefault() = this ?: FieldDescriptorProto.defaultInstance
 
 private fun FieldDescriptorProto.protoMergeImpl(plus: pbandk.Message?): FieldDescriptorProto = (plus as? FieldDescriptorProto)?.let {
@@ -2397,6 +2432,8 @@ private fun FieldDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDecod
         jsonName, options, proto3Optional, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForOneofDescriptorProto")
 fun OneofDescriptorProto?.orDefault() = this ?: OneofDescriptorProto.defaultInstance
 
 private fun OneofDescriptorProto.protoMergeImpl(plus: pbandk.Message?): OneofDescriptorProto = (plus as? OneofDescriptorProto)?.let {
@@ -2421,6 +2458,8 @@ private fun OneofDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDecod
     return OneofDescriptorProto(name, options, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumDescriptorProto")
 fun EnumDescriptorProto?.orDefault() = this ?: EnumDescriptorProto.defaultInstance
 
 private fun EnumDescriptorProto.protoMergeImpl(plus: pbandk.Message?): EnumDescriptorProto = (plus as? EnumDescriptorProto)?.let {
@@ -2455,6 +2494,8 @@ private fun EnumDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDecode
         pbandk.ListWithSize.Builder.fixed(reservedName), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumDescriptorProtoEnumReservedRange")
 fun EnumDescriptorProto.EnumReservedRange?.orDefault() = this ?: EnumDescriptorProto.EnumReservedRange.defaultInstance
 
 private fun EnumDescriptorProto.EnumReservedRange.protoMergeImpl(plus: pbandk.Message?): EnumDescriptorProto.EnumReservedRange = (plus as? EnumDescriptorProto.EnumReservedRange)?.let {
@@ -2479,6 +2520,8 @@ private fun EnumDescriptorProto.EnumReservedRange.Companion.decodeWithImpl(u: pb
     return EnumDescriptorProto.EnumReservedRange(start, end, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumValueDescriptorProto")
 fun EnumValueDescriptorProto?.orDefault() = this ?: EnumValueDescriptorProto.defaultInstance
 
 private fun EnumValueDescriptorProto.protoMergeImpl(plus: pbandk.Message?): EnumValueDescriptorProto = (plus as? EnumValueDescriptorProto)?.let {
@@ -2506,6 +2549,8 @@ private fun EnumValueDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageD
     return EnumValueDescriptorProto(name, number, options, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForServiceDescriptorProto")
 fun ServiceDescriptorProto?.orDefault() = this ?: ServiceDescriptorProto.defaultInstance
 
 private fun ServiceDescriptorProto.protoMergeImpl(plus: pbandk.Message?): ServiceDescriptorProto = (plus as? ServiceDescriptorProto)?.let {
@@ -2533,6 +2578,8 @@ private fun ServiceDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDec
     return ServiceDescriptorProto(name, pbandk.ListWithSize.Builder.fixed(method), options, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMethodDescriptorProto")
 fun MethodDescriptorProto?.orDefault() = this ?: MethodDescriptorProto.defaultInstance
 
 private fun MethodDescriptorProto.protoMergeImpl(plus: pbandk.Message?): MethodDescriptorProto = (plus as? MethodDescriptorProto)?.let {
@@ -2570,6 +2617,8 @@ private fun MethodDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDeco
         clientStreaming, serverStreaming, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFileOptions")
 fun FileOptions?.orDefault() = this ?: FileOptions.defaultInstance
 
 private fun FileOptions.protoMergeImpl(plus: pbandk.Message?): FileOptions = (plus as? FileOptions)?.let {
@@ -2656,6 +2705,8 @@ private fun FileOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): File
         pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMessageOptions")
 fun MessageOptions?.orDefault() = this ?: MessageOptions.defaultInstance
 
 private fun MessageOptions.protoMergeImpl(plus: pbandk.Message?): MessageOptions = (plus as? MessageOptions)?.let {
@@ -2690,6 +2741,8 @@ private fun MessageOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): M
         pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFieldOptions")
 fun FieldOptions?.orDefault() = this ?: FieldOptions.defaultInstance
 
 private fun FieldOptions.protoMergeImpl(plus: pbandk.Message?): FieldOptions = (plus as? FieldOptions)?.let {
@@ -2730,6 +2783,8 @@ private fun FieldOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Fie
         deprecated, weak, pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForOneofOptions")
 fun OneofOptions?.orDefault() = this ?: OneofOptions.defaultInstance
 
 private fun OneofOptions.protoMergeImpl(plus: pbandk.Message?): OneofOptions = (plus as? OneofOptions)?.let {
@@ -2751,6 +2806,8 @@ private fun OneofOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): One
     return OneofOptions(pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumOptions")
 fun EnumOptions?.orDefault() = this ?: EnumOptions.defaultInstance
 
 private fun EnumOptions.protoMergeImpl(plus: pbandk.Message?): EnumOptions = (plus as? EnumOptions)?.let {
@@ -2778,6 +2835,8 @@ private fun EnumOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Enum
     return EnumOptions(allowAlias, deprecated, pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumValueOptions")
 fun EnumValueOptions?.orDefault() = this ?: EnumValueOptions.defaultInstance
 
 private fun EnumValueOptions.protoMergeImpl(plus: pbandk.Message?): EnumValueOptions = (plus as? EnumValueOptions)?.let {
@@ -2802,6 +2861,8 @@ private fun EnumValueOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder):
     return EnumValueOptions(deprecated, pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForServiceOptions")
 fun ServiceOptions?.orDefault() = this ?: ServiceOptions.defaultInstance
 
 private fun ServiceOptions.protoMergeImpl(plus: pbandk.Message?): ServiceOptions = (plus as? ServiceOptions)?.let {
@@ -2826,6 +2887,8 @@ private fun ServiceOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): S
     return ServiceOptions(deprecated, pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMethodOptions")
 fun MethodOptions?.orDefault() = this ?: MethodOptions.defaultInstance
 
 private fun MethodOptions.protoMergeImpl(plus: pbandk.Message?): MethodOptions = (plus as? MethodOptions)?.let {
@@ -2853,6 +2916,8 @@ private fun MethodOptions.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Me
     return MethodOptions(deprecated, idempotencyLevel, pbandk.ListWithSize.Builder.fixed(uninterpretedOption), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUninterpretedOption")
 fun UninterpretedOption?.orDefault() = this ?: UninterpretedOption.defaultInstance
 
 private fun UninterpretedOption.protoMergeImpl(plus: pbandk.Message?): UninterpretedOption = (plus as? UninterpretedOption)?.let {
@@ -2893,6 +2958,8 @@ private fun UninterpretedOption.Companion.decodeWithImpl(u: pbandk.MessageDecode
         doubleValue, stringValue, aggregateValue, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUninterpretedOptionNamePart")
 fun UninterpretedOption.NamePart?.orDefault() = this ?: UninterpretedOption.NamePart.defaultInstance
 
 private fun UninterpretedOption.NamePart.protoMergeImpl(plus: pbandk.Message?): UninterpretedOption.NamePart = (plus as? UninterpretedOption.NamePart)?.let {
@@ -2915,6 +2982,8 @@ private fun UninterpretedOption.NamePart.Companion.decodeWithImpl(u: pbandk.Mess
     return UninterpretedOption.NamePart(namePart, isExtension, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSourceCodeInfo")
 fun SourceCodeInfo?.orDefault() = this ?: SourceCodeInfo.defaultInstance
 
 private fun SourceCodeInfo.protoMergeImpl(plus: pbandk.Message?): SourceCodeInfo = (plus as? SourceCodeInfo)?.let {
@@ -2936,6 +3005,8 @@ private fun SourceCodeInfo.Companion.decodeWithImpl(u: pbandk.MessageDecoder): S
     return SourceCodeInfo(pbandk.ListWithSize.Builder.fixed(location), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSourceCodeInfoLocation")
 fun SourceCodeInfo.Location?.orDefault() = this ?: SourceCodeInfo.Location.defaultInstance
 
 private fun SourceCodeInfo.Location.protoMergeImpl(plus: pbandk.Message?): SourceCodeInfo.Location = (plus as? SourceCodeInfo.Location)?.let {
@@ -2970,6 +3041,8 @@ private fun SourceCodeInfo.Location.Companion.decodeWithImpl(u: pbandk.MessageDe
         pbandk.ListWithSize.Builder.fixed(leadingDetachedComments), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForGeneratedCodeInfo")
 fun GeneratedCodeInfo?.orDefault() = this ?: GeneratedCodeInfo.defaultInstance
 
 private fun GeneratedCodeInfo.protoMergeImpl(plus: pbandk.Message?): GeneratedCodeInfo = (plus as? GeneratedCodeInfo)?.let {
@@ -2991,6 +3064,8 @@ private fun GeneratedCodeInfo.Companion.decodeWithImpl(u: pbandk.MessageDecoder)
     return GeneratedCodeInfo(pbandk.ListWithSize.Builder.fixed(annotation), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForGeneratedCodeInfoAnnotation")
 fun GeneratedCodeInfo.Annotation?.orDefault() = this ?: GeneratedCodeInfo.Annotation.defaultInstance
 
 private fun GeneratedCodeInfo.Annotation.protoMergeImpl(plus: pbandk.Message?): GeneratedCodeInfo.Annotation = (plus as? GeneratedCodeInfo.Annotation)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/duration.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/duration.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class Duration(
     val seconds: Long = 0L,
     val nanos: Int = 0,
@@ -47,6 +48,8 @@ data class Duration(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDuration")
 fun Duration?.orDefault() = this ?: Duration.defaultInstance
 
 private fun Duration.protoMergeImpl(plus: pbandk.Message?): Duration = (plus as? Duration)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/empty.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/empty.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class Empty(
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {
@@ -25,6 +26,8 @@ data class Empty(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEmpty")
 fun Empty?.orDefault() = this ?: Empty.defaultInstance
 
 private fun Empty.protoMergeImpl(plus: pbandk.Message?): Empty = (plus as? Empty)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/field_mask.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/field_mask.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class FieldMask(
     val paths: List<String> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -36,6 +37,8 @@ data class FieldMask(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFieldMask")
 fun FieldMask?.orDefault() = this ?: FieldMask.defaultInstance
 
 private fun FieldMask.protoMergeImpl(plus: pbandk.Message?): FieldMask = (plus as? FieldMask)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/source_context.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/source_context.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class SourceContext(
     val fileName: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -36,6 +37,8 @@ data class SourceContext(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSourceContext")
 fun SourceContext?.orDefault() = this ?: SourceContext.defaultInstance
 
 private fun SourceContext.protoMergeImpl(plus: pbandk.Message?): SourceContext = (plus as? SourceContext)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/struct.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/struct.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 sealed class NullValue(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is NullValue && other.value == value
     override fun hashCode() = value.hashCode()
@@ -17,6 +18,7 @@ sealed class NullValue(override val value: Int, override val name: String? = nul
     }
 }
 
+@pbandk.Export
 data class Struct(
     val fields: Map<String, pbandk.wkt.Value?> = emptyMap(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -96,6 +98,7 @@ data class Struct(
     }
 }
 
+@pbandk.Export
 data class Value(
     val kind: Kind<*>? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -208,6 +211,7 @@ data class Value(
     }
 }
 
+@pbandk.Export
 data class ListValue(
     val values: List<pbandk.wkt.Value> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -242,6 +246,8 @@ data class ListValue(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForStruct")
 fun Struct?.orDefault() = this ?: Struct.defaultInstance
 
 private fun Struct.protoMergeImpl(plus: pbandk.Message?): Struct = (plus as? Struct)?.let {
@@ -263,6 +269,8 @@ private fun Struct.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Struct {
     return Struct(pbandk.MessageMap.Builder.fixed(fields), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForStructFieldsEntry")
 fun Struct.FieldsEntry?.orDefault() = this ?: Struct.FieldsEntry.defaultInstance
 
 private fun Struct.FieldsEntry.protoMergeImpl(plus: pbandk.Message?): Struct.FieldsEntry = (plus as? Struct.FieldsEntry)?.let {
@@ -286,6 +294,8 @@ private fun Struct.FieldsEntry.Companion.decodeWithImpl(u: pbandk.MessageDecoder
     return Struct.FieldsEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForValue")
 fun Value?.orDefault() = this ?: Value.defaultInstance
 
 private fun Value.protoMergeImpl(plus: pbandk.Message?): Value = (plus as? Value)?.let {
@@ -319,6 +329,8 @@ private fun Value.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Value {
     return Value(kind, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForListValue")
 fun ListValue?.orDefault() = this ?: ListValue.defaultInstance
 
 private fun ListValue.protoMergeImpl(plus: pbandk.Message?): ListValue = (plus as? ListValue)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/timestamp.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/timestamp.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class Timestamp(
     val seconds: Long = 0L,
     val nanos: Int = 0,
@@ -47,6 +48,8 @@ data class Timestamp(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTimestamp")
 fun Timestamp?.orDefault() = this ?: Timestamp.defaultInstance
 
 private fun Timestamp.protoMergeImpl(plus: pbandk.Message?): Timestamp = (plus as? Timestamp)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/type.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/type.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 sealed class Syntax(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is Syntax && other.value == value
     override fun hashCode() = value.hashCode()
@@ -18,6 +19,7 @@ sealed class Syntax(override val value: Int, override val name: String? = null) 
     }
 }
 
+@pbandk.Export
 data class Type(
     val name: String = "",
     val fields: List<pbandk.wkt.Field> = emptyList(),
@@ -107,6 +109,7 @@ data class Type(
     }
 }
 
+@pbandk.Export
 data class Field(
     val kind: pbandk.wkt.Field.Kind = pbandk.wkt.Field.Kind.fromValue(0),
     val cardinality: pbandk.wkt.Field.Cardinality = pbandk.wkt.Field.Cardinality.fromValue(0),
@@ -291,6 +294,7 @@ data class Field(
     }
 }
 
+@pbandk.Export
 data class Enum(
     val name: String = "",
     val enumvalue: List<pbandk.wkt.EnumValue> = emptyList(),
@@ -369,6 +373,7 @@ data class Enum(
     }
 }
 
+@pbandk.Export
 data class EnumValue(
     val name: String = "",
     val number: Int = 0,
@@ -425,6 +430,7 @@ data class EnumValue(
     }
 }
 
+@pbandk.Export
 data class Option(
     val name: String = "",
     val value: pbandk.wkt.Any? = null,
@@ -470,6 +476,8 @@ data class Option(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForType")
 fun Type?.orDefault() = this ?: Type.defaultInstance
 
 private fun Type.protoMergeImpl(plus: pbandk.Message?): Type = (plus as? Type)?.let {
@@ -505,6 +513,8 @@ private fun Type.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Type {
         sourceContext, syntax, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForField")
 fun Field?.orDefault() = this ?: Field.defaultInstance
 
 private fun Field.protoMergeImpl(plus: pbandk.Message?): Field = (plus as? Field)?.let {
@@ -546,6 +556,8 @@ private fun Field.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Field {
         jsonName, defaultValue, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnum")
 fun Enum?.orDefault() = this ?: Enum.defaultInstance
 
 private fun Enum.protoMergeImpl(plus: pbandk.Message?): Enum = (plus as? Enum)?.let {
@@ -578,6 +590,8 @@ private fun Enum.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Enum {
         syntax, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumValue")
 fun EnumValue?.orDefault() = this ?: EnumValue.defaultInstance
 
 private fun EnumValue.protoMergeImpl(plus: pbandk.Message?): EnumValue = (plus as? EnumValue)?.let {
@@ -603,6 +617,8 @@ private fun EnumValue.Companion.decodeWithImpl(u: pbandk.MessageDecoder): EnumVa
     return EnumValue(name, number, pbandk.ListWithSize.Builder.fixed(options), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForOption")
 fun Option?.orDefault() = this ?: Option.defaultInstance
 
 private fun Option.protoMergeImpl(plus: pbandk.Message?): Option = (plus as? Option)?.let {

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/wrappers.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/wrappers.kt
@@ -2,6 +2,7 @@
 
 package pbandk.wkt
 
+@pbandk.Export
 data class DoubleValue(
     val value: Double = 0.0,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -36,6 +37,7 @@ data class DoubleValue(
     }
 }
 
+@pbandk.Export
 data class FloatValue(
     val value: Float = 0.0F,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -70,6 +72,7 @@ data class FloatValue(
     }
 }
 
+@pbandk.Export
 data class Int64Value(
     val value: Long = 0L,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -104,6 +107,7 @@ data class Int64Value(
     }
 }
 
+@pbandk.Export
 data class UInt64Value(
     val value: Long = 0L,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -138,6 +142,7 @@ data class UInt64Value(
     }
 }
 
+@pbandk.Export
 data class Int32Value(
     val value: Int = 0,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -172,6 +177,7 @@ data class Int32Value(
     }
 }
 
+@pbandk.Export
 data class UInt32Value(
     val value: Int = 0,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -206,6 +212,7 @@ data class UInt32Value(
     }
 }
 
+@pbandk.Export
 data class BoolValue(
     val value: Boolean = false,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -240,6 +247,7 @@ data class BoolValue(
     }
 }
 
+@pbandk.Export
 data class StringValue(
     val value: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -274,6 +282,7 @@ data class StringValue(
     }
 }
 
+@pbandk.Export
 data class BytesValue(
     val value: pbandk.ByteArr = pbandk.ByteArr.empty,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -308,6 +317,8 @@ data class BytesValue(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDoubleValue")
 fun DoubleValue?.orDefault() = this ?: DoubleValue.defaultInstance
 
 private fun DoubleValue.protoMergeImpl(plus: pbandk.Message?): DoubleValue = (plus as? DoubleValue)?.let {
@@ -328,6 +339,8 @@ private fun DoubleValue.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Doub
     return DoubleValue(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFloatValue")
 fun FloatValue?.orDefault() = this ?: FloatValue.defaultInstance
 
 private fun FloatValue.protoMergeImpl(plus: pbandk.Message?): FloatValue = (plus as? FloatValue)?.let {
@@ -348,6 +361,8 @@ private fun FloatValue.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Float
     return FloatValue(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForInt64Value")
 fun Int64Value?.orDefault() = this ?: Int64Value.defaultInstance
 
 private fun Int64Value.protoMergeImpl(plus: pbandk.Message?): Int64Value = (plus as? Int64Value)?.let {
@@ -368,6 +383,8 @@ private fun Int64Value.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Int64
     return Int64Value(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUInt64Value")
 fun UInt64Value?.orDefault() = this ?: UInt64Value.defaultInstance
 
 private fun UInt64Value.protoMergeImpl(plus: pbandk.Message?): UInt64Value = (plus as? UInt64Value)?.let {
@@ -388,6 +405,8 @@ private fun UInt64Value.Companion.decodeWithImpl(u: pbandk.MessageDecoder): UInt
     return UInt64Value(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForInt32Value")
 fun Int32Value?.orDefault() = this ?: Int32Value.defaultInstance
 
 private fun Int32Value.protoMergeImpl(plus: pbandk.Message?): Int32Value = (plus as? Int32Value)?.let {
@@ -408,6 +427,8 @@ private fun Int32Value.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Int32
     return Int32Value(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUInt32Value")
 fun UInt32Value?.orDefault() = this ?: UInt32Value.defaultInstance
 
 private fun UInt32Value.protoMergeImpl(plus: pbandk.Message?): UInt32Value = (plus as? UInt32Value)?.let {
@@ -428,6 +449,8 @@ private fun UInt32Value.Companion.decodeWithImpl(u: pbandk.MessageDecoder): UInt
     return UInt32Value(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForBoolValue")
 fun BoolValue?.orDefault() = this ?: BoolValue.defaultInstance
 
 private fun BoolValue.protoMergeImpl(plus: pbandk.Message?): BoolValue = (plus as? BoolValue)?.let {
@@ -448,6 +471,8 @@ private fun BoolValue.Companion.decodeWithImpl(u: pbandk.MessageDecoder): BoolVa
     return BoolValue(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForStringValue")
 fun StringValue?.orDefault() = this ?: StringValue.defaultInstance
 
 private fun StringValue.protoMergeImpl(plus: pbandk.Message?): StringValue = (plus as? StringValue)?.let {
@@ -468,6 +493,8 @@ private fun StringValue.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Stri
     return StringValue(value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForBytesValue")
 fun BytesValue?.orDefault() = this ?: BytesValue.defaultInstance
 
 private fun BytesValue.protoMergeImpl(plus: pbandk.Message?): BytesValue = (plus as? BytesValue)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
@@ -2,6 +2,7 @@
 
 package pbandk.testpb
 
+@pbandk.Export
 data class SingleRequiredCustomOption(
     val single: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -46,6 +47,7 @@ data class SingleRequiredCustomOption(
     }
 }
 
+@pbandk.Export
 data class MultipleCustomOptions(
     val multiple: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -91,6 +93,7 @@ data class MultipleCustomOptions(
     }
 }
 
+@pbandk.Export
 data class MultipleCustomOptionsPlusDeprecated(
     val multipleDeprecated: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -137,6 +140,8 @@ data class MultipleCustomOptionsPlusDeprecated(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSingleRequiredCustomOption")
 fun SingleRequiredCustomOption?.orDefault() = this ?: SingleRequiredCustomOption.defaultInstance
 
 private fun SingleRequiredCustomOption.protoMergeImpl(plus: pbandk.Message?): SingleRequiredCustomOption = (plus as? SingleRequiredCustomOption)?.let {
@@ -157,6 +162,8 @@ private fun SingleRequiredCustomOption.Companion.decodeWithImpl(u: pbandk.Messag
     return SingleRequiredCustomOption(single, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMultipleCustomOptions")
 fun MultipleCustomOptions?.orDefault() = this ?: MultipleCustomOptions.defaultInstance
 
 private fun MultipleCustomOptions.protoMergeImpl(plus: pbandk.Message?): MultipleCustomOptions = (plus as? MultipleCustomOptions)?.let {
@@ -177,6 +184,8 @@ private fun MultipleCustomOptions.Companion.decodeWithImpl(u: pbandk.MessageDeco
     return MultipleCustomOptions(multiple, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMultipleCustomOptionsPlusDeprecated")
 fun MultipleCustomOptionsPlusDeprecated?.orDefault() = this ?: MultipleCustomOptionsPlusDeprecated.defaultInstance
 
 private fun MultipleCustomOptionsPlusDeprecated.protoMergeImpl(plus: pbandk.Message?): MultipleCustomOptionsPlusDeprecated = (plus as? MultipleCustomOptionsPlusDeprecated)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test.kt
@@ -2,6 +2,7 @@
 
 package pbandk.testpb
 
+@pbandk.Export
 data class Foo(
     val `val`: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -36,6 +37,7 @@ data class Foo(
     }
 }
 
+@pbandk.Export
 data class Bar(
     val foos: List<pbandk.testpb.Foo> = emptyList(),
     val singleFoo: pbandk.testpb.Foo? = null,
@@ -81,6 +83,7 @@ data class Bar(
     }
 }
 
+@pbandk.Export
 data class MessageWithMap(
     val map: Map<String, String> = emptyMap(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -160,6 +163,7 @@ data class MessageWithMap(
     }
 }
 
+@pbandk.Export
 data class FooMap(
     val map: Map<String, pbandk.testpb.Foo?> = emptyMap(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -239,6 +243,7 @@ data class FooMap(
     }
 }
 
+@pbandk.Export
 data class FooMapEntries(
     val map: List<pbandk.testpb.FooMapEntries.MapEntry> = emptyList(),
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -318,6 +323,7 @@ data class FooMapEntries(
     }
 }
 
+@pbandk.Export
 data class Wrappers(
     val stringValue: String? = null,
     val uint64Values: List<Long> = emptyList(),
@@ -363,6 +369,8 @@ data class Wrappers(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFoo")
 fun Foo?.orDefault() = this ?: Foo.defaultInstance
 
 private fun Foo.protoMergeImpl(plus: pbandk.Message?): Foo = (plus as? Foo)?.let {
@@ -383,6 +391,8 @@ private fun Foo.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Foo {
     return Foo(`val`, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForBar")
 fun Bar?.orDefault() = this ?: Bar.defaultInstance
 
 private fun Bar.protoMergeImpl(plus: pbandk.Message?): Bar = (plus as? Bar)?.let {
@@ -407,6 +417,8 @@ private fun Bar.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Bar {
     return Bar(pbandk.ListWithSize.Builder.fixed(foos), singleFoo, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMessageWithMap")
 fun MessageWithMap?.orDefault() = this ?: MessageWithMap.defaultInstance
 
 private fun MessageWithMap.protoMergeImpl(plus: pbandk.Message?): MessageWithMap = (plus as? MessageWithMap)?.let {
@@ -428,6 +440,8 @@ private fun MessageWithMap.Companion.decodeWithImpl(u: pbandk.MessageDecoder): M
     return MessageWithMap(pbandk.MessageMap.Builder.fixed(map), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMessageWithMapMapEntry")
 fun MessageWithMap.MapEntry?.orDefault() = this ?: MessageWithMap.MapEntry.defaultInstance
 
 private fun MessageWithMap.MapEntry.protoMergeImpl(plus: pbandk.Message?): MessageWithMap.MapEntry = (plus as? MessageWithMap.MapEntry)?.let {
@@ -450,6 +464,8 @@ private fun MessageWithMap.MapEntry.Companion.decodeWithImpl(u: pbandk.MessageDe
     return MessageWithMap.MapEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFooMap")
 fun FooMap?.orDefault() = this ?: FooMap.defaultInstance
 
 private fun FooMap.protoMergeImpl(plus: pbandk.Message?): FooMap = (plus as? FooMap)?.let {
@@ -471,6 +487,8 @@ private fun FooMap.Companion.decodeWithImpl(u: pbandk.MessageDecoder): FooMap {
     return FooMap(pbandk.MessageMap.Builder.fixed(map), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFooMapMapEntry")
 fun FooMap.MapEntry?.orDefault() = this ?: FooMap.MapEntry.defaultInstance
 
 private fun FooMap.MapEntry.protoMergeImpl(plus: pbandk.Message?): FooMap.MapEntry = (plus as? FooMap.MapEntry)?.let {
@@ -494,6 +512,8 @@ private fun FooMap.MapEntry.Companion.decodeWithImpl(u: pbandk.MessageDecoder): 
     return FooMap.MapEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFooMapEntries")
 fun FooMapEntries?.orDefault() = this ?: FooMapEntries.defaultInstance
 
 private fun FooMapEntries.protoMergeImpl(plus: pbandk.Message?): FooMapEntries = (plus as? FooMapEntries)?.let {
@@ -515,6 +535,8 @@ private fun FooMapEntries.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Fo
     return FooMapEntries(pbandk.ListWithSize.Builder.fixed(map), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFooMapEntriesMapEntry")
 fun FooMapEntries.MapEntry?.orDefault() = this ?: FooMapEntries.MapEntry.defaultInstance
 
 private fun FooMapEntries.MapEntry.protoMergeImpl(plus: pbandk.Message?): FooMapEntries.MapEntry = (plus as? FooMapEntries.MapEntry)?.let {
@@ -538,6 +560,8 @@ private fun FooMapEntries.MapEntry.Companion.decodeWithImpl(u: pbandk.MessageDec
     return FooMapEntries.MapEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForWrappers")
 fun Wrappers?.orDefault() = this ?: Wrappers.defaultInstance
 
 private fun Wrappers.protoMergeImpl(plus: pbandk.Message?): Wrappers = (plus as? Wrappers)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_compiler_limits.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_compiler_limits.kt
@@ -2,6 +2,7 @@
 
 package pbandk.testpb
 
+@pbandk.Export
 sealed class HugeEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is HugeEnum && other.value == value
     override fun hashCode() = value.hashCode()
@@ -1017,6 +1018,7 @@ sealed class HugeEnum(override val value: Int, override val name: String? = null
     }
 }
 
+@pbandk.Export
 data class MessageWithLotsOfFields(
     val field1000: String = "",
     val field1001: String = "",
@@ -12063,6 +12065,7 @@ data class MessageWithLotsOfFields(
     }
 }
 
+@pbandk.Export
 data class MessageWithHugeOneof(
     val hugeOneof: HugeOneof<*>? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -40139,6 +40142,8 @@ data class MessageWithHugeOneof(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMessageWithLotsOfFields")
 fun MessageWithLotsOfFields?.orDefault() = this ?: MessageWithLotsOfFields.defaultInstance
 
 private fun MessageWithLotsOfFields.protoMergeImpl(plus: pbandk.Message?): MessageWithLotsOfFields = (plus as? MessageWithLotsOfFields)?.let {
@@ -42406,6 +42411,8 @@ private fun MessageWithLotsOfFields.Companion.decodeWithImpl(u: pbandk.MessageDe
         field1996, field1997, field1998, field1999, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMessageWithHugeOneof")
 fun MessageWithHugeOneof?.orDefault() = this ?: MessageWithHugeOneof.defaultInstance
 
 private fun MessageWithHugeOneof.protoMergeImpl(plus: pbandk.Message?): MessageWithHugeOneof = (plus as? MessageWithHugeOneof)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_duplicate_oneof_name.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_duplicate_oneof_name.kt
@@ -2,6 +2,7 @@
 
 package pbandk.testpb
 
+@pbandk.Export
 data class Value(
     val value: Value<*>? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -72,6 +73,8 @@ data class Value(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForValue")
 fun Value?.orDefault() = this ?: Value.defaultInstance
 
 private fun Value.protoMergeImpl(plus: pbandk.Message?): Value = (plus as? Value)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_messages_proto3.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_messages_proto3.kt
@@ -2,6 +2,7 @@
 
 package pbandk.testpb
 
+@pbandk.Export
 sealed class ForeignEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is ForeignEnum && other.value == value
     override fun hashCode() = value.hashCode()
@@ -19,6 +20,7 @@ sealed class ForeignEnum(override val value: Int, override val name: String? = n
     }
 }
 
+@pbandk.Export
 data class TestAllTypesProto3(
     val optionalInt32: Int = 0,
     val optionalInt64: Long = 0L,
@@ -2651,6 +2653,7 @@ data class TestAllTypesProto3(
     }
 }
 
+@pbandk.Export
 data class ForeignMessage(
     val c: Int = 0,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -2685,6 +2688,8 @@ data class ForeignMessage(
     }
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3")
 fun TestAllTypesProto3?.orDefault() = this ?: TestAllTypesProto3.defaultInstance
 
 private fun TestAllTypesProto3.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3 = (plus as? TestAllTypesProto3)?.let {
@@ -3136,6 +3141,8 @@ private fun TestAllTypesProto3.Companion.decodeWithImpl(u: pbandk.MessageDecoder
         oneofField, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3NestedMessage")
 fun TestAllTypesProto3.NestedMessage?.orDefault() = this ?: TestAllTypesProto3.NestedMessage.defaultInstance
 
 private fun TestAllTypesProto3.NestedMessage.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.NestedMessage = (plus as? TestAllTypesProto3.NestedMessage)?.let {
@@ -3159,6 +3166,8 @@ private fun TestAllTypesProto3.NestedMessage.Companion.decodeWithImpl(u: pbandk.
     return TestAllTypesProto3.NestedMessage(a, corecursive, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt32Int32Entry")
 fun TestAllTypesProto3.MapInt32Int32Entry?.orDefault() = this ?: TestAllTypesProto3.MapInt32Int32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt32Int32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt32Int32Entry = (plus as? TestAllTypesProto3.MapInt32Int32Entry)?.let {
@@ -3181,6 +3190,8 @@ private fun TestAllTypesProto3.MapInt32Int32Entry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto3.MapInt32Int32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt64Int64Entry")
 fun TestAllTypesProto3.MapInt64Int64Entry?.orDefault() = this ?: TestAllTypesProto3.MapInt64Int64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt64Int64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt64Int64Entry = (plus as? TestAllTypesProto3.MapInt64Int64Entry)?.let {
@@ -3203,6 +3214,8 @@ private fun TestAllTypesProto3.MapInt64Int64Entry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto3.MapInt64Int64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapUint32Uint32Entry")
 fun TestAllTypesProto3.MapUint32Uint32Entry?.orDefault() = this ?: TestAllTypesProto3.MapUint32Uint32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapUint32Uint32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapUint32Uint32Entry = (plus as? TestAllTypesProto3.MapUint32Uint32Entry)?.let {
@@ -3225,6 +3238,8 @@ private fun TestAllTypesProto3.MapUint32Uint32Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapUint32Uint32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapUint64Uint64Entry")
 fun TestAllTypesProto3.MapUint64Uint64Entry?.orDefault() = this ?: TestAllTypesProto3.MapUint64Uint64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapUint64Uint64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapUint64Uint64Entry = (plus as? TestAllTypesProto3.MapUint64Uint64Entry)?.let {
@@ -3247,6 +3262,8 @@ private fun TestAllTypesProto3.MapUint64Uint64Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapUint64Uint64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSint32Sint32Entry")
 fun TestAllTypesProto3.MapSint32Sint32Entry?.orDefault() = this ?: TestAllTypesProto3.MapSint32Sint32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSint32Sint32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSint32Sint32Entry = (plus as? TestAllTypesProto3.MapSint32Sint32Entry)?.let {
@@ -3269,6 +3286,8 @@ private fun TestAllTypesProto3.MapSint32Sint32Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapSint32Sint32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSint64Sint64Entry")
 fun TestAllTypesProto3.MapSint64Sint64Entry?.orDefault() = this ?: TestAllTypesProto3.MapSint64Sint64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSint64Sint64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSint64Sint64Entry = (plus as? TestAllTypesProto3.MapSint64Sint64Entry)?.let {
@@ -3291,6 +3310,8 @@ private fun TestAllTypesProto3.MapSint64Sint64Entry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapSint64Sint64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapFixed32Fixed32Entry")
 fun TestAllTypesProto3.MapFixed32Fixed32Entry?.orDefault() = this ?: TestAllTypesProto3.MapFixed32Fixed32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapFixed32Fixed32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapFixed32Fixed32Entry = (plus as? TestAllTypesProto3.MapFixed32Fixed32Entry)?.let {
@@ -3313,6 +3334,8 @@ private fun TestAllTypesProto3.MapFixed32Fixed32Entry.Companion.decodeWithImpl(u
     return TestAllTypesProto3.MapFixed32Fixed32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapFixed64Fixed64Entry")
 fun TestAllTypesProto3.MapFixed64Fixed64Entry?.orDefault() = this ?: TestAllTypesProto3.MapFixed64Fixed64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapFixed64Fixed64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapFixed64Fixed64Entry = (plus as? TestAllTypesProto3.MapFixed64Fixed64Entry)?.let {
@@ -3335,6 +3358,8 @@ private fun TestAllTypesProto3.MapFixed64Fixed64Entry.Companion.decodeWithImpl(u
     return TestAllTypesProto3.MapFixed64Fixed64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSfixed32Sfixed32Entry")
 fun TestAllTypesProto3.MapSfixed32Sfixed32Entry?.orDefault() = this ?: TestAllTypesProto3.MapSfixed32Sfixed32Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSfixed32Sfixed32Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSfixed32Sfixed32Entry = (plus as? TestAllTypesProto3.MapSfixed32Sfixed32Entry)?.let {
@@ -3357,6 +3382,8 @@ private fun TestAllTypesProto3.MapSfixed32Sfixed32Entry.Companion.decodeWithImpl
     return TestAllTypesProto3.MapSfixed32Sfixed32Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapSfixed64Sfixed64Entry")
 fun TestAllTypesProto3.MapSfixed64Sfixed64Entry?.orDefault() = this ?: TestAllTypesProto3.MapSfixed64Sfixed64Entry.defaultInstance
 
 private fun TestAllTypesProto3.MapSfixed64Sfixed64Entry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapSfixed64Sfixed64Entry = (plus as? TestAllTypesProto3.MapSfixed64Sfixed64Entry)?.let {
@@ -3379,6 +3406,8 @@ private fun TestAllTypesProto3.MapSfixed64Sfixed64Entry.Companion.decodeWithImpl
     return TestAllTypesProto3.MapSfixed64Sfixed64Entry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt32FloatEntry")
 fun TestAllTypesProto3.MapInt32FloatEntry?.orDefault() = this ?: TestAllTypesProto3.MapInt32FloatEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt32FloatEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt32FloatEntry = (plus as? TestAllTypesProto3.MapInt32FloatEntry)?.let {
@@ -3401,6 +3430,8 @@ private fun TestAllTypesProto3.MapInt32FloatEntry.Companion.decodeWithImpl(u: pb
     return TestAllTypesProto3.MapInt32FloatEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapInt32DoubleEntry")
 fun TestAllTypesProto3.MapInt32DoubleEntry?.orDefault() = this ?: TestAllTypesProto3.MapInt32DoubleEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapInt32DoubleEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapInt32DoubleEntry = (plus as? TestAllTypesProto3.MapInt32DoubleEntry)?.let {
@@ -3423,6 +3454,8 @@ private fun TestAllTypesProto3.MapInt32DoubleEntry.Companion.decodeWithImpl(u: p
     return TestAllTypesProto3.MapInt32DoubleEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapBoolBoolEntry")
 fun TestAllTypesProto3.MapBoolBoolEntry?.orDefault() = this ?: TestAllTypesProto3.MapBoolBoolEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapBoolBoolEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapBoolBoolEntry = (plus as? TestAllTypesProto3.MapBoolBoolEntry)?.let {
@@ -3445,6 +3478,8 @@ private fun TestAllTypesProto3.MapBoolBoolEntry.Companion.decodeWithImpl(u: pban
     return TestAllTypesProto3.MapBoolBoolEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringStringEntry")
 fun TestAllTypesProto3.MapStringStringEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringStringEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringStringEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringStringEntry = (plus as? TestAllTypesProto3.MapStringStringEntry)?.let {
@@ -3467,6 +3502,8 @@ private fun TestAllTypesProto3.MapStringStringEntry.Companion.decodeWithImpl(u: 
     return TestAllTypesProto3.MapStringStringEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringBytesEntry")
 fun TestAllTypesProto3.MapStringBytesEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringBytesEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringBytesEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringBytesEntry = (plus as? TestAllTypesProto3.MapStringBytesEntry)?.let {
@@ -3489,6 +3526,8 @@ private fun TestAllTypesProto3.MapStringBytesEntry.Companion.decodeWithImpl(u: p
     return TestAllTypesProto3.MapStringBytesEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringNestedMessageEntry")
 fun TestAllTypesProto3.MapStringNestedMessageEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringNestedMessageEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringNestedMessageEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringNestedMessageEntry = (plus as? TestAllTypesProto3.MapStringNestedMessageEntry)?.let {
@@ -3512,6 +3551,8 @@ private fun TestAllTypesProto3.MapStringNestedMessageEntry.Companion.decodeWithI
     return TestAllTypesProto3.MapStringNestedMessageEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringForeignMessageEntry")
 fun TestAllTypesProto3.MapStringForeignMessageEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringForeignMessageEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringForeignMessageEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringForeignMessageEntry = (plus as? TestAllTypesProto3.MapStringForeignMessageEntry)?.let {
@@ -3535,6 +3576,8 @@ private fun TestAllTypesProto3.MapStringForeignMessageEntry.Companion.decodeWith
     return TestAllTypesProto3.MapStringForeignMessageEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringNestedEnumEntry")
 fun TestAllTypesProto3.MapStringNestedEnumEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringNestedEnumEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringNestedEnumEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringNestedEnumEntry = (plus as? TestAllTypesProto3.MapStringNestedEnumEntry)?.let {
@@ -3557,6 +3600,8 @@ private fun TestAllTypesProto3.MapStringNestedEnumEntry.Companion.decodeWithImpl
     return TestAllTypesProto3.MapStringNestedEnumEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTestAllTypesProto3MapStringForeignEnumEntry")
 fun TestAllTypesProto3.MapStringForeignEnumEntry?.orDefault() = this ?: TestAllTypesProto3.MapStringForeignEnumEntry.defaultInstance
 
 private fun TestAllTypesProto3.MapStringForeignEnumEntry.protoMergeImpl(plus: pbandk.Message?): TestAllTypesProto3.MapStringForeignEnumEntry = (plus as? TestAllTypesProto3.MapStringForeignEnumEntry)?.let {
@@ -3579,6 +3624,8 @@ private fun TestAllTypesProto3.MapStringForeignEnumEntry.Companion.decodeWithImp
     return TestAllTypesProto3.MapStringForeignEnumEntry(key, value, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForForeignMessage")
 fun ForeignMessage?.orDefault() = this ?: ForeignMessage.defaultInstance
 
 private fun ForeignMessage.protoMergeImpl(plus: pbandk.Message?): ForeignMessage = (plus as? ForeignMessage)?.let {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/validate.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/validate.kt
@@ -2,6 +2,7 @@
 
 package pbandk.testpb
 
+@pbandk.Export
 sealed class KnownRegex(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
     override fun equals(other: kotlin.Any?) = other is KnownRegex && other.value == value
     override fun hashCode() = value.hashCode()
@@ -19,6 +20,7 @@ sealed class KnownRegex(override val value: Int, override val name: String? = nu
     }
 }
 
+@pbandk.Export
 data class FieldRules(
     val message: pbandk.testpb.MessageRules? = null,
     val type: Type<*>? = null,
@@ -352,6 +354,7 @@ data class FieldRules(
     }
 }
 
+@pbandk.Export
 data class FloatRules(
     val const: Float? = null,
     val lt: Float? = null,
@@ -452,6 +455,7 @@ data class FloatRules(
     }
 }
 
+@pbandk.Export
 data class DoubleRules(
     val const: Double? = null,
     val lt: Double? = null,
@@ -552,6 +556,7 @@ data class DoubleRules(
     }
 }
 
+@pbandk.Export
 data class Int32Rules(
     val const: Int? = null,
     val lt: Int? = null,
@@ -652,6 +657,7 @@ data class Int32Rules(
     }
 }
 
+@pbandk.Export
 data class Int64Rules(
     val const: Long? = null,
     val lt: Long? = null,
@@ -752,6 +758,7 @@ data class Int64Rules(
     }
 }
 
+@pbandk.Export
 data class UInt32Rules(
     val const: Int? = null,
     val lt: Int? = null,
@@ -852,6 +859,7 @@ data class UInt32Rules(
     }
 }
 
+@pbandk.Export
 data class UInt64Rules(
     val const: Long? = null,
     val lt: Long? = null,
@@ -952,6 +960,7 @@ data class UInt64Rules(
     }
 }
 
+@pbandk.Export
 data class SInt32Rules(
     val const: Int? = null,
     val lt: Int? = null,
@@ -1052,6 +1061,7 @@ data class SInt32Rules(
     }
 }
 
+@pbandk.Export
 data class SInt64Rules(
     val const: Long? = null,
     val lt: Long? = null,
@@ -1152,6 +1162,7 @@ data class SInt64Rules(
     }
 }
 
+@pbandk.Export
 data class Fixed32Rules(
     val const: Int? = null,
     val lt: Int? = null,
@@ -1252,6 +1263,7 @@ data class Fixed32Rules(
     }
 }
 
+@pbandk.Export
 data class Fixed64Rules(
     val const: Long? = null,
     val lt: Long? = null,
@@ -1352,6 +1364,7 @@ data class Fixed64Rules(
     }
 }
 
+@pbandk.Export
 data class SFixed32Rules(
     val const: Int? = null,
     val lt: Int? = null,
@@ -1452,6 +1465,7 @@ data class SFixed32Rules(
     }
 }
 
+@pbandk.Export
 data class SFixed64Rules(
     val const: Long? = null,
     val lt: Long? = null,
@@ -1552,6 +1566,7 @@ data class SFixed64Rules(
     }
 }
 
+@pbandk.Export
 data class BoolRules(
     val const: Boolean? = null,
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
@@ -1586,6 +1601,7 @@ data class BoolRules(
     }
 }
 
+@pbandk.Export
 data class StringRules(
     val const: String? = null,
     val len: Long? = null,
@@ -1919,6 +1935,7 @@ data class StringRules(
     }
 }
 
+@pbandk.Export
 data class BytesRules(
     val const: pbandk.ByteArr? = null,
     val len: Long? = null,
@@ -2099,6 +2116,7 @@ data class BytesRules(
     }
 }
 
+@pbandk.Export
 data class EnumRules(
     val const: Int? = null,
     val definedOnly: Boolean? = null,
@@ -2166,6 +2184,7 @@ data class EnumRules(
     }
 }
 
+@pbandk.Export
 data class MessageRules(
     val skip: Boolean? = null,
     val required: Boolean? = null,
@@ -2211,6 +2230,7 @@ data class MessageRules(
     }
 }
 
+@pbandk.Export
 data class RepeatedRules(
     val minItems: Long? = null,
     val maxItems: Long? = null,
@@ -2278,6 +2298,7 @@ data class RepeatedRules(
     }
 }
 
+@pbandk.Export
 data class MapRules(
     val minPairs: Long? = null,
     val maxPairs: Long? = null,
@@ -2356,6 +2377,7 @@ data class MapRules(
     }
 }
 
+@pbandk.Export
 data class AnyRules(
     val required: Boolean? = null,
     val `in`: List<String> = emptyList(),
@@ -2412,6 +2434,7 @@ data class AnyRules(
     }
 }
 
+@pbandk.Export
 data class DurationRules(
     val required: Boolean? = null,
     val const: pbandk.wkt.Duration? = null,
@@ -2523,6 +2546,7 @@ data class DurationRules(
     }
 }
 
+@pbandk.Export
 data class TimestampRules(
     val required: Boolean? = null,
     val const: pbandk.wkt.Timestamp? = null,
@@ -2648,6 +2672,7 @@ data class TimestampRules(
 val pbandk.wkt.MessageOptions.disabled: Boolean? 
     get() = getExtension(pbandk.testpb.disabled)
 
+@pbandk.Export
 val disabled = pbandk.FieldDescriptor(
     messageDescriptor = pbandk.wkt.MessageOptions.Companion::descriptor,
     name = "disabled",
@@ -2660,6 +2685,7 @@ val disabled = pbandk.FieldDescriptor(
 val pbandk.wkt.OneofOptions.required: Boolean? 
     get() = getExtension(pbandk.testpb.required)
 
+@pbandk.Export
 val required = pbandk.FieldDescriptor(
     messageDescriptor = pbandk.wkt.OneofOptions.Companion::descriptor,
     name = "required",
@@ -2672,6 +2698,7 @@ val required = pbandk.FieldDescriptor(
 val pbandk.wkt.FieldOptions.rules: pbandk.testpb.FieldRules? 
     get() = getExtension(pbandk.testpb.rules)
 
+@pbandk.Export
 val rules = pbandk.FieldDescriptor(
     messageDescriptor = pbandk.wkt.FieldOptions.Companion::descriptor,
     name = "rules",
@@ -2681,6 +2708,8 @@ val rules = pbandk.FieldDescriptor(
     value = pbandk.wkt.FieldOptions::rules
 )
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFieldRules")
 fun FieldRules?.orDefault() = this ?: FieldRules.defaultInstance
 
 private fun FieldRules.protoMergeImpl(plus: pbandk.Message?): FieldRules = (plus as? FieldRules)?.let {
@@ -2770,6 +2799,8 @@ private fun FieldRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Field
     return FieldRules(message, type, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFloatRules")
 fun FloatRules?.orDefault() = this ?: FloatRules.defaultInstance
 
 private fun FloatRules.protoMergeImpl(plus: pbandk.Message?): FloatRules = (plus as? FloatRules)?.let {
@@ -2810,6 +2841,8 @@ private fun FloatRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Float
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDoubleRules")
 fun DoubleRules?.orDefault() = this ?: DoubleRules.defaultInstance
 
 private fun DoubleRules.protoMergeImpl(plus: pbandk.Message?): DoubleRules = (plus as? DoubleRules)?.let {
@@ -2850,6 +2883,8 @@ private fun DoubleRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Doub
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForInt32Rules")
 fun Int32Rules?.orDefault() = this ?: Int32Rules.defaultInstance
 
 private fun Int32Rules.protoMergeImpl(plus: pbandk.Message?): Int32Rules = (plus as? Int32Rules)?.let {
@@ -2890,6 +2925,8 @@ private fun Int32Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Int32
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForInt64Rules")
 fun Int64Rules?.orDefault() = this ?: Int64Rules.defaultInstance
 
 private fun Int64Rules.protoMergeImpl(plus: pbandk.Message?): Int64Rules = (plus as? Int64Rules)?.let {
@@ -2930,6 +2967,8 @@ private fun Int64Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Int64
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUInt32Rules")
 fun UInt32Rules?.orDefault() = this ?: UInt32Rules.defaultInstance
 
 private fun UInt32Rules.protoMergeImpl(plus: pbandk.Message?): UInt32Rules = (plus as? UInt32Rules)?.let {
@@ -2970,6 +3009,8 @@ private fun UInt32Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): UInt
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForUInt64Rules")
 fun UInt64Rules?.orDefault() = this ?: UInt64Rules.defaultInstance
 
 private fun UInt64Rules.protoMergeImpl(plus: pbandk.Message?): UInt64Rules = (plus as? UInt64Rules)?.let {
@@ -3010,6 +3051,8 @@ private fun UInt64Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): UInt
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSInt32Rules")
 fun SInt32Rules?.orDefault() = this ?: SInt32Rules.defaultInstance
 
 private fun SInt32Rules.protoMergeImpl(plus: pbandk.Message?): SInt32Rules = (plus as? SInt32Rules)?.let {
@@ -3050,6 +3093,8 @@ private fun SInt32Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SInt
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSInt64Rules")
 fun SInt64Rules?.orDefault() = this ?: SInt64Rules.defaultInstance
 
 private fun SInt64Rules.protoMergeImpl(plus: pbandk.Message?): SInt64Rules = (plus as? SInt64Rules)?.let {
@@ -3090,6 +3135,8 @@ private fun SInt64Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SInt
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFixed32Rules")
 fun Fixed32Rules?.orDefault() = this ?: Fixed32Rules.defaultInstance
 
 private fun Fixed32Rules.protoMergeImpl(plus: pbandk.Message?): Fixed32Rules = (plus as? Fixed32Rules)?.let {
@@ -3130,6 +3177,8 @@ private fun Fixed32Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Fix
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForFixed64Rules")
 fun Fixed64Rules?.orDefault() = this ?: Fixed64Rules.defaultInstance
 
 private fun Fixed64Rules.protoMergeImpl(plus: pbandk.Message?): Fixed64Rules = (plus as? Fixed64Rules)?.let {
@@ -3170,6 +3219,8 @@ private fun Fixed64Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Fix
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSFixed32Rules")
 fun SFixed32Rules?.orDefault() = this ?: SFixed32Rules.defaultInstance
 
 private fun SFixed32Rules.protoMergeImpl(plus: pbandk.Message?): SFixed32Rules = (plus as? SFixed32Rules)?.let {
@@ -3210,6 +3261,8 @@ private fun SFixed32Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SF
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForSFixed64Rules")
 fun SFixed64Rules?.orDefault() = this ?: SFixed64Rules.defaultInstance
 
 private fun SFixed64Rules.protoMergeImpl(plus: pbandk.Message?): SFixed64Rules = (plus as? SFixed64Rules)?.let {
@@ -3250,6 +3303,8 @@ private fun SFixed64Rules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): SF
         gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForBoolRules")
 fun BoolRules?.orDefault() = this ?: BoolRules.defaultInstance
 
 private fun BoolRules.protoMergeImpl(plus: pbandk.Message?): BoolRules = (plus as? BoolRules)?.let {
@@ -3271,6 +3326,8 @@ private fun BoolRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): BoolRu
     return BoolRules(const, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForStringRules")
 fun StringRules?.orDefault() = this ?: StringRules.defaultInstance
 
 private fun StringRules.protoMergeImpl(plus: pbandk.Message?): StringRules = (plus as? StringRules)?.let {
@@ -3349,6 +3406,8 @@ private fun StringRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Stri
         pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), strict, wellKnown, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForBytesRules")
 fun BytesRules?.orDefault() = this ?: BytesRules.defaultInstance
 
 private fun BytesRules.protoMergeImpl(plus: pbandk.Message?): BytesRules = (plus as? BytesRules)?.let {
@@ -3404,6 +3463,8 @@ private fun BytesRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Bytes
         pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), wellKnown, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForEnumRules")
 fun EnumRules?.orDefault() = this ?: EnumRules.defaultInstance
 
 private fun EnumRules.protoMergeImpl(plus: pbandk.Message?): EnumRules = (plus as? EnumRules)?.let {
@@ -3434,6 +3495,8 @@ private fun EnumRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): EnumRu
     return EnumRules(const, definedOnly, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMessageRules")
 fun MessageRules?.orDefault() = this ?: MessageRules.defaultInstance
 
 private fun MessageRules.protoMergeImpl(plus: pbandk.Message?): MessageRules = (plus as? MessageRules)?.let {
@@ -3458,6 +3521,8 @@ private fun MessageRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Mes
     return MessageRules(skip, required, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForRepeatedRules")
 fun RepeatedRules?.orDefault() = this ?: RepeatedRules.defaultInstance
 
 private fun RepeatedRules.protoMergeImpl(plus: pbandk.Message?): RepeatedRules = (plus as? RepeatedRules)?.let {
@@ -3488,6 +3553,8 @@ private fun RepeatedRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Re
     return RepeatedRules(minItems, maxItems, unique, items, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForMapRules")
 fun MapRules?.orDefault() = this ?: MapRules.defaultInstance
 
 private fun MapRules.protoMergeImpl(plus: pbandk.Message?): MapRules = (plus as? MapRules)?.let {
@@ -3522,6 +3589,8 @@ private fun MapRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): MapRule
         values, unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForAnyRules")
 fun AnyRules?.orDefault() = this ?: AnyRules.defaultInstance
 
 private fun AnyRules.protoMergeImpl(plus: pbandk.Message?): AnyRules = (plus as? AnyRules)?.let {
@@ -3549,6 +3618,8 @@ private fun AnyRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): AnyRule
     return AnyRules(required, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForDurationRules")
 fun DurationRules?.orDefault() = this ?: DurationRules.defaultInstance
 
 private fun DurationRules.protoMergeImpl(plus: pbandk.Message?): DurationRules = (plus as? DurationRules)?.let {
@@ -3592,6 +3663,8 @@ private fun DurationRules.Companion.decodeWithImpl(u: pbandk.MessageDecoder): Du
         gt, gte, pbandk.ListWithSize.Builder.fixed(`in`), pbandk.ListWithSize.Builder.fixed(notIn), unknownFields)
 }
 
+@pbandk.Export
+@pbandk.JsName("orDefaultForTimestampRules")
 fun TimestampRules?.orDefault() = this ?: TimestampRules.defaultInstance
 
 private fun TimestampRules.protoMergeImpl(plus: pbandk.Message?): TimestampRules = (plus as? TimestampRules)?.let {

--- a/runtime/src/jsMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/Export.kt
@@ -2,4 +2,4 @@ package pbandk
 
 actual typealias Export = JsExport
 
-actual typealias Name = JsName
+actual typealias JsName = kotlin.js.JsName

--- a/runtime/src/jsMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/Export.kt
@@ -1,3 +1,5 @@
 package pbandk
 
 actual typealias Export = JsExport
+
+actual typealias Name = JsName

--- a/runtime/src/jsMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/Export.kt
@@ -1,0 +1,3 @@
+package pbandk
+
+actual typealias Export = JsExport

--- a/runtime/src/jsMain/kotlin/pbandk/protobufjs/Util.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/protobufjs/Util.kt
@@ -6,8 +6,15 @@ import pbandk.internal.asUint8Array
 internal val Long.protobufjsLong: dynamic
     get() {
         val ret = js("{}")
-        ret.high = this.asDynamic().getHighBits()
-        ret.low = this.asDynamic().getLowBits()
+        // Legacy compiler exposes Long bits via functions, while IR compiler exposes Long bits
+        // via `_high` and `_low` fields
+        if (this.asDynamic().getHighBits !== undefined) {
+            ret.high = this.asDynamic().getHighBits()
+            ret.low = this.asDynamic().getLowBits()
+        } else {
+            ret.high = this.asDynamic()._high
+            ret.low = this.asDynamic()._low
+        }
         return ret
     }
 
@@ -15,7 +22,13 @@ internal fun Long.Companion.fromProtobufjsLong(l: dynamic): Long {
     return if (l.low == null || l.high == null) {
         (l as Int).toLong()
     } else {
-        js("Kotlin").Long.fromBits(l.low, l.high) as Long
+        // Legacy compiler exposes Long-related function in `Kotlin` namespace, while IR compiler
+        // exposes a direct Long constructor
+        if (js("typeof Kotlin") !== "undefined") {
+            js("Kotlin").Long.fromBits(l.low, l.high) as Long
+        } else {
+            js("new Long(l.low, l.high)") as Long
+        }
     }
 }
 

--- a/runtime/src/nativeMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/Export.kt
@@ -1,0 +1,4 @@
+package pbandk
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
+actual annotation class Export()

--- a/runtime/src/nativeMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/Export.kt
@@ -11,4 +11,4 @@ actual annotation class Export()
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER
 )
-actual annotation class Name(actual val name: String)
+actual annotation class JsName(actual val name: String)

--- a/runtime/src/nativeMain/kotlin/pbandk/Export.kt
+++ b/runtime/src/nativeMain/kotlin/pbandk/Export.kt
@@ -2,3 +2,13 @@ package pbandk
 
 @Target(AnnotationTarget.CLASS, AnnotationTarget.PROPERTY, AnnotationTarget.FUNCTION, AnnotationTarget.FILE)
 actual annotation class Export()
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.PROPERTY_SETTER
+)
+actual annotation class Name(actual val name: String)


### PR DESCRIPTION
Fixes #136

I have tested `js_export` on my company's projects and it works pretty well. Obviously the resulting `.d.ts` declaration has some "red" parts as `@JsExport` does not support Kotlin collections, but overall it is still usable.

Let me know what you think and thanks for this amazing library!