### PR TITLE
Move the WKT .proto files to a separate pbandk-protos artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,24 @@ if (signingKeyAsciiArmored.isPresent) {
     logger.info("PGP signing key not defined, skipping signing configuration")
 }
 
+val wellKnownTypes by configurations.creating {
+    isTransitive = false
+}
+
+dependencies {
+    wellKnownTypes("com.google.protobuf:protobuf-java:${Versions.protobufJava}")
+}
+
+val extractWellKnownTypeProtos by tasks.registering(Sync::class) {
+    dependsOn(wellKnownTypes)
+    from({
+        wellKnownTypes.filter { it.extension == "jar" }.map { zipTree(it) }
+    })
+    include("**/*.proto")
+    includeEmptyDirs = false
+    into(layout.buildDirectory.dir("bundled-protos"))
+}
+
 allprojects {
     repositories {
         mavenCentral()

--- a/protos/build.gradle.kts
+++ b/protos/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    kotlin("jvm")
+    `maven-publish`
+    signing
+}
+
+/**
+ * The main purpose of this sub-project is to allow using pbandk from the Protobuf Gradle Plugin. The Protobuf Gradle
+ * Plugin expects to find .proto files for the Well-Known Types somewhere in the pbandk dependency chain.
+ */
+
+description = "Kotlin library for Protocol Buffers. This artifact contains the .proto files for the Protocol Buffer Well-Known Types."
+
+val extractWellKnownTypeProtos = rootProject.tasks.named<Sync>("extractWellKnownTypeProtos")
+
+sourceSets {
+    main {
+        resources.srcDir(extractWellKnownTypeProtos)
+    }
+}
+
+@Suppress("UnstableApiUsage")
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+    val protos by publications.creating(MavenPublication::class) {
+        artifactId = "pbandk-$artifactId"
+        from(components["java"])
+        configurePbandkPom(project.description!!)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,6 +21,7 @@ pluginManagement {
 rootProject.name = "pbandk"
 
 include(":runtime")
+include(":protos")
 include(":jvm-test-types")
 
 include(":protoc-gen-kotlin:lib")


### PR DESCRIPTION
This allows `pbandk-runtime` to be used as a dependency in Android gradle projects that also use the Protobuf Gradle Plugin. This used to work correctly when the JVM and Android variants of `pbandk-runtime` had a dependency on `protobuf-java(lite)`. Now that pbandk doesn't depend on those libraries, pbandk has to provide the `.proto` files for the
Protocol Buffer Well Known Types.

The previous approach of adding the resources directory to the `commonMain` sourceset had two problems:

1. It only seems to affect the `pbandk-runtime-jvm` jar. It does not add the resources to the `pbandk-runtime-android` or
`pbandk-runtime-android-debug` aar files.

2. Even if the resources are added to the aar files, the Protobuf Gradle Plugin has trouble consuming the .proto files properly because the aar files are part of a Kotlin Multiplatform project.

To address both of these problems, the .proto files are now part of a separate `pbandk-protos` artifact which gets built as a plain jar file. By declaring `pbandk-protos` as a dependency of `pbandk-runtime-jvm` and `pbandk-runtime-android(-debug)`, the Protobuf Gradle Plugin finds the .proto files correctly even when the plugin is used in an Android project.