### PR TITLE
Added field level support for @Deprecated annotation

### DIFF
--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -33,6 +33,7 @@ open class CodeGenerator(
     private fun writeExtension(field: File.Field) {
         when (field) {
             is File.Field.Numbered -> {
+                if(field.options.deprecated == true) lineBegin("@Deprecated(message = \"\")").lineEnd()
                 line().line(
                     "val ${field.extendeeKotlinType}.${field.kotlinFieldName}: ${
                         field.kotlinValueType(true)

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -34,7 +34,7 @@ open class CodeGenerator(
         when (field) {
             is File.Field.Numbered -> {
                 line()
-                addAnnotation(field, "@Deprecated(message = \"Field marked deprecated in ${file.name}\")")
+                addDeprecatedAnnotation(field)
                 line(
                     "val ${field.extendeeKotlinType}.${field.kotlinFieldName}: ${
                         field.kotlinValueType(true)
@@ -43,7 +43,7 @@ open class CodeGenerator(
                     line("get() = getExtension(${file.kotlinPackageName}.${field.kotlinFieldName})")
                 }.line()
                 line("@pbandk.Export")
-                addAnnotation(field, "@Deprecated(message = \"Field marked deprecated in ${file.name}\")")
+                addDeprecatedAnnotation(field)
                 line("val ${field.kotlinFieldName} = pbandk.FieldDescriptor(").indented {
                     generateFieldDescriptorConstructorValues(
                         field,
@@ -106,7 +106,7 @@ open class CodeGenerator(
             type.fields.forEach { field ->
                 when (field) {
                     is File.Field.Numbered -> {
-                        addAnnotation(field, "@Deprecated(message = \"Field marked deprecated in ${file.name}\")")
+                        addDeprecatedAnnotation(field)
                         lineBegin(fieldBegin).writeConstructorField(field, true).lineEnd(",")
                     }
                     is File.Field.OneOf -> line("val ${field.kotlinFieldName}: ${field.kotlinTypeName}<*>? = null,")
@@ -156,7 +156,7 @@ open class CodeGenerator(
     protected fun writeOneOfType(oneOf: File.Field.OneOf) {
         line("sealed class ${oneOf.kotlinTypeName}<V>(value: V) : pbandk.Message.OneOf<V>(value) {").indented {
             oneOf.fields.forEach { field ->
-                addAnnotation(field, "@Deprecated(message = \"Field marked deprecated in ${file.name}\")")
+                addDeprecatedAnnotation(field)
                 lineBegin("class ${oneOf.kotlinFieldTypeNames[field.name]}(")
                 lineMid("${field.kotlinFieldName}: ${field.kotlinValueType(false)}")
                 if (field.type != File.Field.Type.MESSAGE) lineMid(" = ${field.defaultValue}")
@@ -165,7 +165,7 @@ open class CodeGenerator(
         }.line("}").line()
 
         oneOf.fields.forEach { field ->
-            addAnnotation(field, "@Deprecated(message = \"Field marked deprecated in ${file.name}\")")
+            addDeprecatedAnnotation(field)
             line("val ${field.kotlinFieldName}: ${field.kotlinValueType(false)}?").indented {
                 lineBegin("get() = ")
                 lineMid("(${oneOf.kotlinFieldName} as? ${oneOf.kotlinTypeName}.${oneOf.kotlinFieldTypeNames[field.name]})")
@@ -657,9 +657,9 @@ open class CodeGenerator(
         line("value = $fullTypeName::${field.kotlinFieldName}")
     }
 
-    private fun addAnnotation(field: File.Field, annotation: String) {
+    private fun addDeprecatedAnnotation(field: File.Field) {
         when (field) {
-            is File.Field.Numbered -> if(field.options.deprecated == true) line(annotation)
+            is File.Field.Numbered -> if(field.options.deprecated == true) line("@Deprecated(message = \"Field marked deprecated in ${file.name}\")")
         }
     }
 }

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -142,6 +142,8 @@ open class CodeGenerator(
     }
 
     protected fun writeConstructorField(field: File.Field.Numbered, nullableIfMessage: Boolean): CodeGenerator {
+        if(field.options.deprecated == true) lineMid("@Deprecated ")
+
         lineMid("val ${field.kotlinFieldName}: ${field.kotlinValueType(nullableIfMessage)}")
         if (field.type != File.Field.Type.MESSAGE || nullableIfMessage) lineMid(" = ${field.defaultValue}")
         return this

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
@@ -1039,7 +1039,7 @@ data class FileOptions(
     val javaPackage: String? = null,
     val javaOuterClassname: String? = null,
     val javaMultipleFiles: Boolean? = null,
-    @Deprecated(message = "")
+    @Deprecated(message = "Field marked deprecated in google/protobuf/descriptor.proto")
     val javaGenerateEqualsAndHash: Boolean? = null,
     val javaStringCheckUtf8: Boolean? = null,
     val optimizeFor: pbandk.wkt.FileOptions.OptimizeMode? = null,

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
@@ -1039,6 +1039,7 @@ data class FileOptions(
     val javaPackage: String? = null,
     val javaOuterClassname: String? = null,
     val javaMultipleFiles: Boolean? = null,
+    @Deprecated(message = "")
     val javaGenerateEqualsAndHash: Boolean? = null,
     val javaStringCheckUtf8: Boolean? = null,
     val optimizeFor: pbandk.wkt.FileOptions.OptimizeMode? = null,

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
@@ -95,7 +95,7 @@ data class MultipleCustomOptions(
 
 @pbandk.Export
 data class MultipleCustomOptionsPlusDeprecated(
-    @Deprecated(message = "")
+    @Deprecated(message = "Field marked deprecated in pbandk/testpb/custom_options.proto")
     val multipleDeprecated: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
@@ -95,6 +95,7 @@ data class MultipleCustomOptions(
 
 @pbandk.Export
 data class MultipleCustomOptionsPlusDeprecated(
+    @Deprecated(message = "")
     val multipleDeprecated: String = "",
     override val unknownFields: Map<Int, pbandk.UnknownField> = emptyMap()
 ) : pbandk.Message {


### PR DESCRIPTION
- Regenerated the well-know types for the CI tests to pass.
- The @Deprecated annotation now includes empty message argument.
