### PR TITLE
Update Kotlin/JS code to use UMD instead of CommonJS; and example updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,14 +21,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+* Switched Kotlin/JS runtime library to use UMD instead of CommonJS (PR [#170], fixes [#60])
+* Minor updates to the gradle config for examples (PR [#170])
+
 ### Fixed
 
 [#1]: https://github.com/streem/pbandk/issues/1
+[#60]: https://github.com/streem/pbandk/issues/60
 [#88]: https://github.com/streem/pbandk/issues/88
 [#136]: https://github.com/streem/pbandk/issues/136
 [#147]: https://github.com/streem/pbandk/pull/147
 [#163]: https://github.com/streem/pbandk/pull/163
 [#169]: https://github.com/streem/pbandk/pull/169
+[#170]: https://github.com/streem/pbandk/pull/170
 
 
 ## [0.11.0] - 2021-09-24

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -15,7 +15,6 @@ kotlin {
 
     js(IR) {
         binaries.executable()
-        useCommonJs()
         nodejs {}
     }
 

--- a/conformance/lib/src/jsMain/kotlin/pbandk/conformance/Platform.kt
+++ b/conformance/lib/src/jsMain/kotlin/pbandk/conformance/Platform.kt
@@ -26,6 +26,7 @@ internal external interface StdStream {
 }
 
 @JsModule("process")
+@JsNonModule
 internal external class Process {
     companion object {
         val stdin: StdStream
@@ -35,6 +36,7 @@ internal external class Process {
 }
 
 @JsModule("fs")
+@JsNonModule
 external class Fs {
     companion object {
         fun writeSync(

--- a/examples/browser-js/app/build.gradle.kts
+++ b/examples/browser-js/app/build.gradle.kts
@@ -8,13 +8,13 @@ val pbandkVersion: String by rootProject.extra
 val protobufjsVersion = "^6.10.2"
 
 dependencies {
-    implementation(kotlin("stdlib-js"))
     implementation("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
     implementation(npm("protobufjs", protobufjsVersion))
 }
 
 kotlin {
-    js(LEGACY) {
+    js(IR) {
+        binaries.executable()
         browser {}
     }
 
@@ -28,8 +28,7 @@ kotlin {
 tasks {
     val compileKotlinJs by getting(KotlinJsCompile::class) {
         kotlinOptions {
-            sourceMap = true
-            moduleKind = "commonjs"
+            moduleKind = "umd"
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
         }
     }
@@ -38,17 +37,4 @@ tasks {
     project(":lib-proto").tasks
         .matching { it.name == "generateProto" }
         .all { compileKotlinJs.dependsOn(this) }
-}
-
-// This is required for consuming a Kotlin/JS library compiled with Kotlin 1.4
-// from a Kotlin 1.3 project. See https://youtrack.jetbrains.com/issue/KT-40226
-// for details.
-private class KotlinJsCompilerDisambiguationRule : AttributeDisambiguationRule<String> {
-    override fun execute(details: MultipleCandidatesDetails<String>) {
-        details.closestMatch("legacy")
-    }
-}
-val jsCompilerAttr = Attribute.of("org.jetbrains.kotlin.js.compiler", String::class.java)
-project.dependencies.attributesSchema.attribute(jsCompilerAttr) {
-    disambiguationRules.add(KotlinJsCompilerDisambiguationRule::class.java)
 }

--- a/examples/browser-js/app/src/main/kotlin/pbandk/examples/browserjs/Web.kt
+++ b/examples/browser-js/app/src/main/kotlin/pbandk/examples/browserjs/Web.kt
@@ -5,9 +5,9 @@ import pbandk.decodeFromByteArray
 import pbandk.encodeToByteArray
 import pbandk.examples.browserjs.pb.AddressBook
 import pbandk.examples.browserjs.pb.Person
-import kotlin.browser.document
-import kotlin.browser.localStorage
-import kotlin.browser.window
+import kotlinx.browser.document
+import kotlinx.browser.localStorage
+import kotlinx.browser.window
 
 fun main(args: Array<String>) {
     // When ready, create the DOM

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     kotlin("js") version "1.4.32" apply false
-    id("com.google.protobuf") version "0.8.12" apply false
+    id("com.google.protobuf") version "0.8.17" apply false
 }
 
 val pbandkVersion by extra("0.12.0-SNAPSHOT")

--- a/examples/browser-js/settings.gradle
+++ b/examples/browser-js/settings.gradle
@@ -1,2 +1,0 @@
-include ':lib-proto'
-include ':app'

--- a/examples/browser-js/settings.gradle.kts
+++ b/examples/browser-js/settings.gradle.kts
@@ -1,0 +1,2 @@
+include(":lib-proto")
+include(":app")

--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 val pbandkVersion: String by rootProject.extra
-val kotlinxCoroutinesVersion by extra("1.3.6")
+val kotlinxCoroutinesVersion by extra("1.4.3")
 val protobufVersion by extra("3.11.1")
 
 application {

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -1,8 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.72" apply false
-    id("com.google.protobuf") version "0.8.12" apply false
+    kotlin("jvm") version "1.4.32" apply false
+    id("com.google.protobuf") version "0.8.17" apply false
 }
 
 val pbandkVersion by extra("0.12.0-SNAPSHOT")

--- a/examples/custom-service-gen/settings.gradle
+++ b/examples/custom-service-gen/settings.gradle
@@ -1,1 +1,0 @@
-include ':application', ':generator'

--- a/examples/custom-service-gen/settings.gradle.kts
+++ b/examples/custom-service-gen/settings.gradle.kts
@@ -1,0 +1,1 @@
+include(":application", ":generator")

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -2,9 +2,9 @@ import com.google.protobuf.gradle.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.3.72"
+    kotlin("jvm") version "1.4.32"
     application
-    id("com.google.protobuf") version "0.8.12"
+    id("com.google.protobuf") version "0.8.17"
 }
 
 val protobufVersion by extra("3.11.1")

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
     jvm()
 
     js(BOTH) {
-        useCommonJs()
         browser {}
         nodejs {}
     }

--- a/runtime/src/jsMain/kotlin/pbandk/protobufjs/protobufjs.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/protobufjs/protobufjs.kt
@@ -1,4 +1,5 @@
 @file:JsModule("protobufjs/light")
+@file:JsNonModule
 package pbandk.protobufjs
 
 import org.khronos.webgl.Uint8Array


### PR DESCRIPTION
Some minor cleanup to follow up on the recently-added Kotlin/JS IR support. Nothing super interesting, mostly rote updates.

- Update Kotlin/JS code to use UMD instead of CommonJS
- Update examples to use JS IR backend, Kotlin 1.4, and latest Protobuf Gradle Plugin