### PR TITLE
Fix gradle metadata when building iOS/macOS builds separately

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -67,8 +67,8 @@ jobs:
       - name: Ensure bundled types are up-to-date
         if: matrix.os-type == 'linux'
         run: |
-          ./gradlew :runtime:generateWellKnownTypes \
-            :runtime:generateTestTypes \
+          ./gradlew :pbandk-runtime:generateWellKnownTypes \
+            :pbandk-runtime:generateTestTypes \
             :protoc-gen-pbandk:protoc-gen-pbandk-lib:generateProto \
             :conformance:conformance-lib:generateProto
           if [ -n "$(git status --porcelain)" ]; then

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -74,8 +74,8 @@ jobs:
       - name: Ensure bundled types are up-to-date
         if: matrix.os-type == 'linux'
         run: |
-          ./gradlew :runtime:generateWellKnownTypes \
-            :runtime:generateTestTypes \
+          ./gradlew :pbandk-runtime:generateWellKnownTypes \
+            :pbandk-runtime:generateTestTypes \
             :protoc-gen-pbandk:protoc-gen-pbandk-lib:generateProto \
             :conformance:conformance-lib:generateProto
           if [ -n "$(git status --porcelain)" ]; then

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ This will generate kotlin files for the specified `*.proto` files, without needi
 To build the runtime library for both JS and the JVM, run:
 
 ```
-./gradlew :runtime:assemble
+./gradlew :pbandk-runtime:assemble
 ```
 
 ### Bundled Types
@@ -514,16 +514,16 @@ well-known types (and other proto types used by pbandk) need to be re-generated 
 `protoc-gen-pbandk` binary:
 
 ```
-./gradlew :runtime:generateWellKnownTypes \
-    :runtime:generateTestTypes \
+./gradlew :pbandk-runtime:generateWellKnownTypes \
+    :pbandk-runtime:generateTestTypes \
     :protoc-gen-pbandk:protoc-gen-pbandk-lib:generateProto \
     :conformance:conformance-lib:generateProto
 ```
 
-Important: If making changes in both the `:protoc-gen-pbandk:protoc-gen-pbandk-lib` _and_ `:runtime` projects at the
-same time, then it's likely the `generateWellKnownTypes` task will fail to compile. To work
-around this, stash the changes in the `:runtime` project, run the `generateWellKnownTypes` task
-with only the `:protoc-gen-pbandk:protoc-gen-pbandk-lib` changes, and then unstash the `:runtime` changes and rerun the
+Important: If making changes in both the `:protoc-gen-pbandk:protoc-gen-pbandk-lib` _and_ `:pbandk-runtime` projects at
+the same time, then it's likely the `generateWellKnownTypes` task will fail to compile. To work around this, stash the
+changes in the `:pbandk-runtime` project, run the `generateWellKnownTypes` task with only
+the `:protoc-gen-pbandk:protoc-gen-pbandk-lib` changes, and then unstash the `:pbandk-runtime` changes and rerun the
 `generateWellKnownTypes` task.
 
 ### Conformance Tests

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":runtime"))
+                implementation(project(":pbandk-runtime"))
                 implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:${Versions.kotlinCoroutines}")
             }
         }

--- a/protoc-gen-pbandk/lib/build.gradle.kts
+++ b/protoc-gen-pbandk/lib/build.gradle.kts
@@ -22,7 +22,7 @@ kotlin {
 
         val commonMain by getting {
             dependencies {
-                implementation(project(":runtime"))
+                implementation(project(":pbandk-runtime"))
             }
         }
 

--- a/protos/build.gradle.kts
+++ b/protos/build.gradle.kts
@@ -27,7 +27,6 @@ java {
 
 publishing {
     val protos by publications.creating(MavenPublication::class) {
-        artifactId = "pbandk-$artifactId"
         from(components["java"])
         configurePbandkPom(project.description!!)
     }

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -63,7 +63,7 @@ kotlin {
         val androidMain by getting {
             kotlin.srcDir("src/commonJvmAndroid/kotlin")
             dependencies {
-                api(project(":protos"))
+                api(project(":pbandk-protos"))
             }
         }
 
@@ -79,7 +79,7 @@ kotlin {
         val jvmMain by getting {
             kotlin.srcDir("src/commonJvmAndroid/kotlin")
             dependencies {
-                api(project(":protos"))
+                api(project(":pbandk-protos"))
             }
         }
 
@@ -174,7 +174,6 @@ afterEvaluate {
             if (artifactId == "runtime-jvm") {
                 artifact(jvmJavadocJar)
             }
-            artifactId = "pbandk-$artifactId"
             configurePbandkPom(project.description!!)
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,9 @@ pluginManagement {
 rootProject.name = "pbandk"
 
 include(":runtime")
+project(":runtime").name = "pbandk-runtime"
 include(":protos")
+project(":protos").name = "pbandk-protos"
 include(":jvm-test-types")
 
 include(":protoc-gen-pbandk:lib")


### PR DESCRIPTION
`pbandk-runtime` targets that are built and published on a different machine than the main `pbandk-runtime` artifact were missing the `pbandk-` prefix in the `pbandk-runtime` gradle metadata file that gets published to Maven. This happens for example when `pbandk-runtime` is built on a Linux host but `pbandk-runtime-iosx64/iosarm64/macosx64` are built on a macOS host (such as in CI).

I believe this was happening because gradle does not create the iOS/macOS publications when running on a Linux host, so the modification of the `artifactId` to add the `pbandk-` prefix was getting skipped for these publications. But the gradle metadata file would still include references to these publications even though they weren't being created.

The solution ended up being pretty straightforward: instead of modifying the publication, we can just modify the gradle project name to include the `pbandk-` prefix. The project name is used as the default value for the publication's `artifactId`.

Fixes #175