### PR TITLE
Codegen: Suppress warnings for deprecated fields in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [0.12.2] - Unreleased
 
-[0.12.2]: https://github.com/streem/pbandk/compare/v0.12.2...HEAD
+[0.12.2]: https://github.com/streem/pbandk/compare/v0.12.1...HEAD
 
 ### Added
 
 ### Changed
 
 ### Fixed
+
+* Suppress warnings about deprecated fields used in generated code. (PR [#182], continues [#1])
+
+[#182]: https://github.com/streem/pbandk/pull/182
 
 
 ## [0.12.1] - 2021-11-11

--- a/protoc-gen-pbandk/lib/build.gradle.kts
+++ b/protoc-gen-pbandk/lib/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
             dependencies {
                 implementation(kotlin("test"))
                 implementation(kotlin("test-junit"))
+                implementation(kotlin("reflect"))
                 implementation("junit:junit:4.12")
                 implementation("com.github.tschuchortdev:kotlin-compile-testing:1.2.9")
             }

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -223,6 +223,7 @@ open class CodeGenerator(
     ) {
         line("fieldsList.apply {").indented {
             chunk.forEach { (field, oneof) ->
+                if (field.options.deprecated == true) line("@Suppress(\"DEPRECATION\")")
                 line("add(").indented {
                     line("pbandk.FieldDescriptor(").indented {
                         generateFieldDescriptorConstructorValues(
@@ -349,6 +350,9 @@ open class CodeGenerator(
 
         line()
         line("private fun $fullTypeName.protoMergeImpl(plus: pbandk.Message?): $fullTypeName = (plus as? $fullTypeName)?.let {").indented {
+            if (type.fields.filterIsInstance<File.Field.Numbered>().any { it.options.deprecated == true }) {
+                line("@Suppress(\"DEPRECATION\")")
+            }
             line("it.copy(").indented {
                 type.fields.forEach { field ->
                     when (field) {

--- a/protoc-gen-pbandk/lib/src/jvmTest/kotlin/CodeGeneratorTest.kt
+++ b/protoc-gen-pbandk/lib/src/jvmTest/kotlin/CodeGeneratorTest.kt
@@ -1,3 +1,5 @@
+package pbandk.gen
+
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.SourceFile
@@ -6,9 +8,10 @@ import pbandk.gen.pb.CodeGeneratorRequest
 import pbandk.gen.runGenerator
 import pbandk.wkt.FileDescriptorSet
 import java.io.File
+import kotlin.reflect.full.declaredMemberProperties
+import kotlin.reflect.full.memberProperties
 import kotlin.test.Test
 import kotlin.test.assertEquals
-
 
 class CodeGeneratorTest {
     private val descriptorSetOutput = File("build/generateTestProtoDescriptor/fileDescriptor.protoset")
@@ -24,10 +27,24 @@ class CodeGeneratorTest {
         val result = compileProto("simple.proto")
 
         assertEquals(result.exitCode, ExitCode.OK)
-        val message1Clazz = result.classLoader.loadClass("foobar.Message1")
-        val message2Clazz = result.classLoader.loadClass("foobar.Message2")
-        message1Clazz.getDeclaredField("intVal")
-        message2Clazz.getDeclaredField("strVal")
+
+        // Ensure classes and fields were generated successfully
+        val message1Clazz = result.classLoader.loadClass("foobar.Message1").kotlin
+        val message2Clazz = result.classLoader.loadClass("foobar.Message2").kotlin
+        message1Clazz.declaredMemberProperties.single { it.name == "intVal" }
+        message2Clazz.declaredMemberProperties.single { it.name == "strVal" }
+    }
+
+    @Test
+    fun testDeprecatedAnnotation() {
+        val result = compileProto("options.proto")
+
+        assertEquals(result.exitCode, ExitCode.OK)
+
+        // Ensure that deprecated proto fields have a `@Deprecated` Kotlin annotation
+        val fooClazz = result.classLoader.loadClass("foobar.Foo").kotlin
+        val deprecatedField = fooClazz.declaredMemberProperties.single { it.name == "deprecatedField" }
+        deprecatedField.annotations.filterIsInstance<Deprecated>().single()
     }
 
     @Test
@@ -35,6 +52,8 @@ class CodeGeneratorTest {
         val result = compileProto("oneof_same_name.proto")
 
         assertEquals(result.exitCode, ExitCode.OK)
+
+        // Ensure the oneof with the same name as its containing message was generated correctly
         val valueClazz = result.classLoader.loadClass("foobar.Value")
         valueClazz.classLoader.loadClass("foobar.Value\$Value")
     }

--- a/protoc-gen-pbandk/lib/src/jvmTest/resources/protos/options.proto
+++ b/protoc-gen-pbandk/lib/src/jvmTest/resources/protos/options.proto
@@ -1,0 +1,6 @@
+syntax = "proto3";
+package foobar;
+
+message Foo {
+    int32 deprecated_field = 1 [deprecated = true];
+}

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
@@ -1153,6 +1153,7 @@ data class FileOptions(
                         value = pbandk.wkt.FileOptions::pyGenericServices
                     )
                 )
+                @Suppress("DEPRECATION")
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -2623,6 +2624,7 @@ private fun MethodDescriptorProto.Companion.decodeWithImpl(u: pbandk.MessageDeco
 fun FileOptions?.orDefault() = this ?: FileOptions.defaultInstance
 
 private fun FileOptions.protoMergeImpl(plus: pbandk.Message?): FileOptions = (plus as? FileOptions)?.let {
+    @Suppress("DEPRECATION")
     it.copy(
         javaPackage = plus.javaPackage ?: javaPackage,
         javaOuterClassname = plus.javaOuterClassname ?: javaOuterClassname,

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
@@ -109,6 +109,7 @@ data class MultipleCustomOptionsPlusDeprecated(
         override val descriptor: pbandk.MessageDescriptor<pbandk.testpb.MultipleCustomOptionsPlusDeprecated> by lazy {
             val fieldsList = ArrayList<pbandk.FieldDescriptor<pbandk.testpb.MultipleCustomOptionsPlusDeprecated, *>>(1)
             fieldsList.apply {
+                @Suppress("DEPRECATION")
                 add(
                     pbandk.FieldDescriptor(
                         messageDescriptor = this@Companion::descriptor,
@@ -190,6 +191,7 @@ private fun MultipleCustomOptions.Companion.decodeWithImpl(u: pbandk.MessageDeco
 fun MultipleCustomOptionsPlusDeprecated?.orDefault() = this ?: MultipleCustomOptionsPlusDeprecated.defaultInstance
 
 private fun MultipleCustomOptionsPlusDeprecated.protoMergeImpl(plus: pbandk.Message?): MultipleCustomOptionsPlusDeprecated = (plus as? MultipleCustomOptionsPlusDeprecated)?.let {
+    @Suppress("DEPRECATION")
     it.copy(
         unknownFields = unknownFields + plus.unknownFields
     )


### PR DESCRIPTION
Also add a unit test for the `@Deprecated` annotation being correctly output in the generated code.
