### PR TITLE
Add proto name and fullName properties to MessageDescriptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.12.2] - Unreleased
+## [0.13.0] - Unreleased
 
-[0.12.2]: https://github.com/streem/pbandk/compare/v0.12.1...HEAD
+[0.13.0]: https://github.com/streem/pbandk/compare/v0.12.1...HEAD
 
 ### Added
+
+* **[BREAKING CHANGE]** Added `MessageDescriptor.fullName` and `MessageDescriptor.name` properties. All protobuf types have to be regenerated using this versio of `protoc-gen-pbandk`. These properties are currently `internal` but can be exposed publicly if there is a need/use case. (PR [#184])
 
 ### Changed
 
@@ -18,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * Suppress warnings about deprecated fields used in generated code. (PR [#182], continues [#1])
 
 [#182]: https://github.com/streem/pbandk/pull/182
+[#184]: https://github.com/streem/pbandk/pull/184
 
 
 ## [0.12.1] - 2021-11-11

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Pbandk is a Kotlin code generator and runtime for [Protocol Buffers](https://developers.google.com/protocol-buffers/).
 It is built to work across multiple Kotlin platforms.
 
-**NOTE**: This is the documentation for the version of pbandk currently in development. **Documentation for the latest stable version** is available at https://github.com/streem/pbandk/blob/v0.12.2/README.md.
+**NOTE**: This is the documentation for the version of pbandk currently in development. **Documentation for the latest stable version** is available at https://github.com/streem/pbandk/blob/v0.12.1/README.md.
 
 **Features**
 
@@ -160,7 +160,8 @@ data class Person(
                 )
             }
             pbandk.MessageDescriptor(
-                messageClass = Person::class,
+                fullName = "tutorial.Person",
+                messageClass = tutorial.Person::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -219,9 +220,10 @@ data class Person(
                         )
                     )
                 }
-                pbandk.MessageDescriptor(            
-                    messageClass = Person.PhoneNumber::class,
-                    messageCompanion = this,                    
+                pbandk.MessageDescriptor(
+                    fullName = "tutorial.Person.PhoneNumber",
+                    messageClass = tutorial.Person.PhoneNumber::class,
+                    messageCompanion = this,
                     fields = fieldsList
                 )
             }
@@ -254,7 +256,8 @@ data class AddressBook(
                 )
             }
             pbandk.MessageDescriptor(
-                messageClass = AddressBook::class,
+                fullName = "tutorial.AddressBook",
+                messageClass = tutorial.AddressBook::class,
                 messageCompanion = this,
                 fields = fieldsList
             )
@@ -339,7 +342,7 @@ repositories {
 dependencies {
     // Can be used from the `common` sourceset in a Kotlin Multiplatform project,
     // or from platform-specific JVM, Android, JS, or Native sourcesets/projects.
-    implementation("pro.streem.pbandk:pbandk-runtime:0.12.2-SNAPSHOT")
+    implementation("pro.streem.pbandk:pbandk-runtime:0.13.0-SNAPSHOT")
 }
 ```
 
@@ -369,7 +372,7 @@ runtime:
 
 ```
 dependencies {
-    compileOnly("pro.streem.pbandk:protoc-gen-pbandk-lib:0.12.2-SNAPSHOT")
+    compileOnly("pro.streem.pbandk:protoc-gen-pbandk-lib:0.13.0-SNAPSHOT")
 }
 ```
 

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/conformance.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/conformance.kt
@@ -70,6 +70,7 @@ data class FailureSet(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "conformance.FailureSet",
                 messageClass = pbandk.conformance.pb.FailureSet::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -210,6 +211,7 @@ data class ConformanceRequest(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "conformance.ConformanceRequest",
                 messageClass = pbandk.conformance.pb.ConformanceRequest::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -351,6 +353,7 @@ data class ConformanceResponse(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "conformance.ConformanceResponse",
                 messageClass = pbandk.conformance.pb.ConformanceResponse::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -386,6 +389,7 @@ data class JspbEncodingConfig(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "conformance.JspbEncodingConfig",
                 messageClass = pbandk.conformance.pb.JspbEncodingConfig::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
@@ -1358,6 +1358,7 @@ data class TestAllTypesProto2(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto2.TestAllTypesProto2",
                 messageClass = pbandk.conformance.pb.TestAllTypesProto2::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1366,18 +1367,18 @@ data class TestAllTypesProto2(
     }
 
     sealed class NestedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.conformance.pb.TestAllTypesProto2.NestedEnum && other.value == value
+        override fun equals(other: kotlin.Any?) = other is TestAllTypesProto2.NestedEnum && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "TestAllTypesProto2.NestedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object FOO : NestedEnum(0, "FOO")
         object BAR : NestedEnum(1, "BAR")
         object BAZ : NestedEnum(2, "BAZ")
         object NEG : NestedEnum(-1, "NEG")
-        class UNRECOGNIZED(value: Int) : pbandk.conformance.pb.TestAllTypesProto2.NestedEnum(value)
+        class UNRECOGNIZED(value: Int) : NestedEnum(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum> {
-            val values: List<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum> by lazy { listOf(FOO, BAR, BAZ, NEG) }
+        companion object : pbandk.Message.Enum.Companion<TestAllTypesProto2.NestedEnum> {
+            val values: List<TestAllTypesProto2.NestedEnum> by lazy { listOf(FOO, BAR, BAZ, NEG) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No NestedEnum with name: $name")
         }
@@ -1420,6 +1421,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.NestedMessage",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1465,6 +1467,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt32Int32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapInt32Int32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1510,6 +1513,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt64Int64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapInt64Int64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1555,6 +1559,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapUint32Uint32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapUint32Uint32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1600,6 +1605,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapUint64Uint64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapUint64Uint64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1645,6 +1651,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapSint32Sint32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapSint32Sint32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1690,6 +1697,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapSint64Sint64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapSint64Sint64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1735,6 +1743,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapFixed32Fixed32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapFixed32Fixed32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1780,6 +1789,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapFixed64Fixed64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapFixed64Fixed64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1825,6 +1835,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapSfixed32Sfixed32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapSfixed32Sfixed32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1870,6 +1881,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapSfixed64Sfixed64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapSfixed64Sfixed64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1915,6 +1927,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt32FloatEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapInt32FloatEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1960,6 +1973,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapInt32DoubleEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapInt32DoubleEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2005,6 +2019,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapBoolBoolEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapBoolBoolEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2050,6 +2065,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringStringEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapStringStringEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2095,6 +2111,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringBytesEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapStringBytesEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2140,6 +2157,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringNestedMessageEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapStringNestedMessageEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2185,6 +2203,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringForeignMessageEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapStringForeignMessageEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2230,6 +2249,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringNestedEnumEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapStringNestedEnumEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2275,6 +2295,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MapStringForeignEnumEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MapStringForeignEnumEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2320,6 +2341,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.Data",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.Data::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2346,6 +2368,7 @@ data class TestAllTypesProto2(
                 fieldsList.apply {
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrect",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MessageSetCorrect::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2380,6 +2403,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension1",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MessageSetCorrectExtension1::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2414,6 +2438,7 @@ data class TestAllTypesProto2(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.TestAllTypesProto2.MessageSetCorrectExtension2",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto2.MessageSetCorrectExtension2::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2450,6 +2475,7 @@ data class ForeignMessageProto2(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto2.ForeignMessageProto2",
                 messageClass = pbandk.conformance.pb.ForeignMessageProto2::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2529,6 +2555,7 @@ data class UnknownToTestAllTypes(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto2.UnknownToTestAllTypes",
                 messageClass = pbandk.conformance.pb.UnknownToTestAllTypes::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2562,6 +2589,7 @@ data class UnknownToTestAllTypes(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto2.UnknownToTestAllTypes.OptionalGroup",
                     messageClass = pbandk.conformance.pb.UnknownToTestAllTypes.OptionalGroup::class,
                     messageCompanion = this,
                     fields = fieldsList

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
@@ -1707,6 +1707,7 @@ data class TestAllTypesProto3(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto3.TestAllTypesProto3",
                 messageClass = pbandk.conformance.pb.TestAllTypesProto3::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1715,27 +1716,27 @@ data class TestAllTypesProto3(
     }
 
     sealed class NestedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.conformance.pb.TestAllTypesProto3.NestedEnum && other.value == value
+        override fun equals(other: kotlin.Any?) = other is TestAllTypesProto3.NestedEnum && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "TestAllTypesProto3.NestedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object FOO : NestedEnum(0, "FOO")
         object BAR : NestedEnum(1, "BAR")
         object BAZ : NestedEnum(2, "BAZ")
         object NEG : NestedEnum(-1, "NEG")
-        class UNRECOGNIZED(value: Int) : pbandk.conformance.pb.TestAllTypesProto3.NestedEnum(value)
+        class UNRECOGNIZED(value: Int) : NestedEnum(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum> {
-            val values: List<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum> by lazy { listOf(FOO, BAR, BAZ, NEG) }
+        companion object : pbandk.Message.Enum.Companion<TestAllTypesProto3.NestedEnum> {
+            val values: List<TestAllTypesProto3.NestedEnum> by lazy { listOf(FOO, BAR, BAZ, NEG) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No NestedEnum with name: $name")
         }
     }
 
     sealed class AliasedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum && other.value == value
+        override fun equals(other: kotlin.Any?) = other is TestAllTypesProto3.AliasedEnum && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "TestAllTypesProto3.AliasedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object ALIAS_FOO : AliasedEnum(0, "ALIAS_FOO")
         object ALIAS_BAR : AliasedEnum(1, "ALIAS_BAR")
@@ -1743,10 +1744,10 @@ data class TestAllTypesProto3(
         object QUX : AliasedEnum(2, "QUX")
         object QUX_ : AliasedEnum(2, "qux")
         object B_AZ : AliasedEnum(2, "bAz")
-        class UNRECOGNIZED(value: Int) : pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum(value)
+        class UNRECOGNIZED(value: Int) : AliasedEnum(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum> {
-            val values: List<pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum> by lazy { listOf(ALIAS_FOO, ALIAS_BAR, ALIAS_BAZ, QUX, QUX_, B_AZ) }
+        companion object : pbandk.Message.Enum.Companion<TestAllTypesProto3.AliasedEnum> {
+            val values: List<TestAllTypesProto3.AliasedEnum> by lazy { listOf(ALIAS_FOO, ALIAS_BAR, ALIAS_BAZ, QUX, QUX_, B_AZ) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No AliasedEnum with name: $name")
         }
@@ -1789,6 +1790,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1834,6 +1836,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32Int32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapInt32Int32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1879,6 +1882,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt64Int64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapInt64Int64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1924,6 +1928,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapUint32Uint32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapUint32Uint32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1969,6 +1974,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapUint64Uint64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapUint64Uint64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2014,6 +2020,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSint32Sint32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapSint32Sint32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2059,6 +2066,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSint64Sint64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapSint64Sint64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2104,6 +2112,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapFixed32Fixed32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapFixed32Fixed32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2149,6 +2158,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapFixed64Fixed64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapFixed64Fixed64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2194,6 +2204,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSfixed32Sfixed32Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapSfixed32Sfixed32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2239,6 +2250,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSfixed64Sfixed64Entry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapSfixed64Sfixed64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2284,6 +2296,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32FloatEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapInt32FloatEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2329,6 +2342,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32DoubleEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapInt32DoubleEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2374,6 +2388,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapBoolBoolEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapBoolBoolEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2419,6 +2434,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringStringEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapStringStringEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2464,6 +2480,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringBytesEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapStringBytesEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2509,6 +2526,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringNestedMessageEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapStringNestedMessageEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2554,6 +2572,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringForeignMessageEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapStringForeignMessageEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2599,6 +2618,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringNestedEnumEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapStringNestedEnumEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2644,6 +2664,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringForeignEnumEntry",
                     messageClass = pbandk.conformance.pb.TestAllTypesProto3.MapStringForeignEnumEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2680,6 +2701,7 @@ data class ForeignMessage(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto3.ForeignMessage",
                 messageClass = pbandk.conformance.pb.ForeignMessage::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.google.protobuf") version "0.8.17" apply false
 }
 
-val pbandkVersion by extra("0.12.2-SNAPSHOT")
+val pbandkVersion by extra("0.13.0-SNAPSHOT")
 
 subprojects {
     repositories {

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("com.google.protobuf") version "0.8.17" apply false
 }
 
-val pbandkVersion by extra("0.12.2-SNAPSHOT")
+val pbandkVersion by extra("0.13.0-SNAPSHOT")
 
 subprojects {
     repositories {

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 val protobufVersion by extra("3.11.1")
-val pbandkVersion by extra("0.12.2-SNAPSHOT")
+val pbandkVersion by extra("0.13.0-SNAPSHOT")
 
 repositories {
     if (System.getenv("CI") == "true") {

--- a/examples/gradle-and-jvm/src/main/pbandk/pbandk/examples/addressbook/pb/addressbook.kt
+++ b/examples/gradle-and-jvm/src/main/pbandk/pbandk/examples/addressbook/pb/addressbook.kt
@@ -73,6 +73,7 @@ data class Person(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "tutorial.Person",
                 messageClass = pbandk.examples.addressbook.pb.Person::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -81,17 +82,17 @@ data class Person(
     }
 
     sealed class PhoneType(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.examples.addressbook.pb.Person.PhoneType && other.value == value
+        override fun equals(other: kotlin.Any?) = other is Person.PhoneType && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.examples.addressbook.pb.Person.PhoneType.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "Person.PhoneType.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object MOBILE : PhoneType(0, "MOBILE")
         object HOME : PhoneType(1, "HOME")
         object WORK : PhoneType(2, "WORK")
-        class UNRECOGNIZED(value: Int) : pbandk.examples.addressbook.pb.Person.PhoneType(value)
+        class UNRECOGNIZED(value: Int) : PhoneType(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.examples.addressbook.pb.Person.PhoneType> {
-            val values: List<pbandk.examples.addressbook.pb.Person.PhoneType> by lazy { listOf(MOBILE, HOME, WORK) }
+        companion object : pbandk.Message.Enum.Companion<Person.PhoneType> {
+            val values: List<Person.PhoneType> by lazy { listOf(MOBILE, HOME, WORK) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No PhoneType with name: $name")
         }
@@ -134,6 +135,7 @@ data class Person(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "tutorial.Person.PhoneNumber",
                     messageClass = pbandk.examples.addressbook.pb.Person.PhoneNumber::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -170,6 +172,7 @@ data class AddressBook(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "tutorial.AddressBook",
                 messageClass = pbandk.examples.addressbook.pb.AddressBook::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group=pro.streem.pbandk
-version=0.12.2-SNAPSHOT
+version=0.13.0-SNAPSHOT
 
 kotlin.code.style=official
 kotlin.mpp.stability.nowarn=true

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -196,6 +196,7 @@ open class CodeGenerator(
             }
 
             line("pbandk.MessageDescriptor(").indented {
+                line("fullName = \"${type.fullName}\",")
                 line("messageClass = ${type.kotlinTypeNameWithPackage}::class,")
                 line("messageCompanion = this,")
                 line("fields = fieldsList")

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/File.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/File.kt
@@ -32,21 +32,27 @@ data class File(
 
     sealed class Type {
         abstract val name: String
+        abstract val fullName: String
         abstract val kotlinTypeName: String
+        abstract val kotlinFullTypeName: String
 
         data class Message(
             override val name: String,
+            override val fullName: String,
             val fields: List<Field>,
             val nestedTypes: List<Type>,
             val mapEntry: Boolean,
             override val kotlinTypeName: String,
+            override val kotlinFullTypeName: String,
             val extensionRange: List<pbandk.wkt.DescriptorProto.ExtensionRange> = emptyList()
         ) : Type()
 
         data class Enum(
             override val name: String,
+            override val fullName: String,
             val values: List<Value>,
-            override val kotlinTypeName: String
+            override val kotlinTypeName: String,
+            override val kotlinFullTypeName: String
         ) : Type() {
             data class Value(val number: Int, val name: String, val kotlinValueTypeName: String)
         }

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/pb/plugin.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/pb/plugin.kt
@@ -62,6 +62,7 @@ data class Version(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.compiler.Version",
                 messageClass = pbandk.gen.pb.Version::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -130,6 +131,7 @@ data class CodeGeneratorRequest(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.compiler.CodeGeneratorRequest",
                 messageClass = pbandk.gen.pb.CodeGeneratorRequest::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -187,6 +189,7 @@ data class CodeGeneratorResponse(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.compiler.CodeGeneratorResponse",
                 messageClass = pbandk.gen.pb.CodeGeneratorResponse::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -195,16 +198,16 @@ data class CodeGeneratorResponse(
     }
 
     sealed class Feature(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.gen.pb.CodeGeneratorResponse.Feature && other.value == value
+        override fun equals(other: kotlin.Any?) = other is CodeGeneratorResponse.Feature && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.gen.pb.CodeGeneratorResponse.Feature.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "CodeGeneratorResponse.Feature.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object NONE : Feature(0, "FEATURE_NONE")
         object PROTO3_OPTIONAL : Feature(1, "FEATURE_PROTO3_OPTIONAL")
-        class UNRECOGNIZED(value: Int) : pbandk.gen.pb.CodeGeneratorResponse.Feature(value)
+        class UNRECOGNIZED(value: Int) : Feature(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.gen.pb.CodeGeneratorResponse.Feature> {
-            val values: List<pbandk.gen.pb.CodeGeneratorResponse.Feature> by lazy { listOf(NONE, PROTO3_OPTIONAL) }
+        companion object : pbandk.Message.Enum.Companion<CodeGeneratorResponse.Feature> {
+            val values: List<CodeGeneratorResponse.Feature> by lazy { listOf(NONE, PROTO3_OPTIONAL) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No Feature with name: $name")
         }
@@ -269,6 +272,7 @@ data class CodeGeneratorResponse(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.compiler.CodeGeneratorResponse.File",
                     messageClass = pbandk.gen.pb.CodeGeneratorResponse.File::class,
                     messageCompanion = this,
                     fields = fieldsList

--- a/runtime/api/pbandk-runtime.api
+++ b/runtime/api/pbandk-runtime.api
@@ -276,7 +276,7 @@ public abstract interface class pbandk/MessageDecoder {
 }
 
 public final class pbandk/MessageDescriptor {
-	public fun <init> (Lkotlin/reflect/KClass;Lpbandk/Message$Companion;Ljava/util/Collection;)V
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lpbandk/Message$Companion;Ljava/util/Collection;)V
 	public final fun getFields ()Ljava/util/Collection;
 	public final fun getMessageCompanion ()Lpbandk/Message$Companion;
 }

--- a/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
@@ -5,9 +5,28 @@ import kotlin.reflect.KClass
 
 @JsExport
 class MessageDescriptor<T : Message> @PublicForGeneratedCode constructor(
+    /**
+     * The message type's fully-qualified name, within the proto language's namespace. This differs from
+     * the Kotlin name. For example, given this `.proto`:
+     *
+     * ```proto
+     *   package foo.bar;
+     *   option java_package = "com.example.protos"
+     *   message Baz {}
+     * ```
+     *
+     * `Baz`'s [fullName] is "foo.bar.Baz".
+     */
+    internal val fullName: String,
+
     internal val messageClass: KClass<T>,
+
     @ExperimentalProtoReflection
     val messageCompanion: Message.Companion<T>,
+
     @ExperimentalProtoReflection
     val fields: Collection<FieldDescriptor<T, *>>
-)
+) {
+    /** The message type's unqualified name. */
+    internal val name = fullName.substringAfterLast('.')
+}

--- a/runtime/src/commonMain/kotlin/pbandk/MessageMap.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageMap.kt
@@ -51,6 +51,7 @@ class MessageMap<K, V> internal constructor(override val entries: Set<Entry<K, V
 
             @Suppress("UNCHECKED_CAST")
             override val descriptor: MessageDescriptor<Entry<K, V>> = MessageDescriptor(
+                fullName = "MapFieldEntry",
                 messageClass = Entry::class as KClass<Entry<K, V>>,
                 messageCompanion = this,
                 fields = listOf(

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/any.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/any.kt
@@ -40,6 +40,7 @@ data class Any(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Any",
                 messageClass = pbandk.wkt.Any::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/api.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/api.kt
@@ -95,6 +95,7 @@ data class Api(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Api",
                 messageClass = pbandk.wkt.Api::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -196,6 +197,7 @@ data class Method(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Method",
                 messageClass = pbandk.wkt.Method::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -242,6 +244,7 @@ data class Mixin(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Mixin",
                 messageClass = pbandk.wkt.Mixin::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/descriptor.kt
@@ -29,6 +29,7 @@ data class FileDescriptorSet(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FileDescriptorSet",
                 messageClass = pbandk.wkt.FileDescriptorSet::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -185,6 +186,7 @@ data class FileDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FileDescriptorProto",
                 messageClass = pbandk.wkt.FileDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -319,6 +321,7 @@ data class DescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.DescriptorProto",
                 messageClass = pbandk.wkt.DescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -374,6 +377,7 @@ data class DescriptorProto(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.DescriptorProto.ExtensionRange",
                     messageClass = pbandk.wkt.DescriptorProto.ExtensionRange::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -419,6 +423,7 @@ data class DescriptorProto(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.DescriptorProto.ReservedRange",
                     messageClass = pbandk.wkt.DescriptorProto.ReservedRange::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -458,6 +463,7 @@ data class ExtensionRangeOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.ExtensionRangeOptions",
                 messageClass = pbandk.wkt.ExtensionRangeOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -603,6 +609,7 @@ data class FieldDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FieldDescriptorProto",
                 messageClass = pbandk.wkt.FieldDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -611,9 +618,9 @@ data class FieldDescriptorProto(
     }
 
     sealed class Type(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.FieldDescriptorProto.Type && other.value == value
+        override fun equals(other: kotlin.Any?) = other is FieldDescriptorProto.Type && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.FieldDescriptorProto.Type.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "FieldDescriptorProto.Type.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object DOUBLE : Type(1, "TYPE_DOUBLE")
         object FLOAT : Type(2, "TYPE_FLOAT")
@@ -633,27 +640,27 @@ data class FieldDescriptorProto(
         object SFIXED64 : Type(16, "TYPE_SFIXED64")
         object SINT32 : Type(17, "TYPE_SINT32")
         object SINT64 : Type(18, "TYPE_SINT64")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.FieldDescriptorProto.Type(value)
+        class UNRECOGNIZED(value: Int) : Type(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.FieldDescriptorProto.Type> {
-            val values: List<pbandk.wkt.FieldDescriptorProto.Type> by lazy { listOf(DOUBLE, FLOAT, INT64, UINT64, INT32, FIXED64, FIXED32, BOOL, STRING, GROUP, MESSAGE, BYTES, UINT32, ENUM, SFIXED32, SFIXED64, SINT32, SINT64) }
+        companion object : pbandk.Message.Enum.Companion<FieldDescriptorProto.Type> {
+            val values: List<FieldDescriptorProto.Type> by lazy { listOf(DOUBLE, FLOAT, INT64, UINT64, INT32, FIXED64, FIXED32, BOOL, STRING, GROUP, MESSAGE, BYTES, UINT32, ENUM, SFIXED32, SFIXED64, SINT32, SINT64) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No Type with name: $name")
         }
     }
 
     sealed class Label(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.FieldDescriptorProto.Label && other.value == value
+        override fun equals(other: kotlin.Any?) = other is FieldDescriptorProto.Label && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.FieldDescriptorProto.Label.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "FieldDescriptorProto.Label.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object OPTIONAL : Label(1, "LABEL_OPTIONAL")
         object REQUIRED : Label(2, "LABEL_REQUIRED")
         object REPEATED : Label(3, "LABEL_REPEATED")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.FieldDescriptorProto.Label(value)
+        class UNRECOGNIZED(value: Int) : Label(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.FieldDescriptorProto.Label> {
-            val values: List<pbandk.wkt.FieldDescriptorProto.Label> by lazy { listOf(OPTIONAL, REQUIRED, REPEATED) }
+        companion object : pbandk.Message.Enum.Companion<FieldDescriptorProto.Label> {
+            val values: List<FieldDescriptorProto.Label> by lazy { listOf(OPTIONAL, REQUIRED, REPEATED) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No Label with name: $name")
         }
@@ -698,6 +705,7 @@ data class OneofDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.OneofDescriptorProto",
                 messageClass = pbandk.wkt.OneofDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -777,6 +785,7 @@ data class EnumDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.EnumDescriptorProto",
                 messageClass = pbandk.wkt.EnumDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -821,6 +830,7 @@ data class EnumDescriptorProto(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.EnumDescriptorProto.EnumReservedRange",
                     messageClass = pbandk.wkt.EnumDescriptorProto.EnumReservedRange::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -879,6 +889,7 @@ data class EnumValueDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.EnumValueDescriptorProto",
                 messageClass = pbandk.wkt.EnumValueDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -936,6 +947,7 @@ data class ServiceDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.ServiceDescriptorProto",
                 messageClass = pbandk.wkt.ServiceDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1026,6 +1038,7 @@ data class MethodDescriptorProto(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.MethodDescriptorProto",
                 messageClass = pbandk.wkt.MethodDescriptorProto::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1289,6 +1302,7 @@ data class FileOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FileOptions",
                 messageClass = pbandk.wkt.FileOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1297,17 +1311,17 @@ data class FileOptions(
     }
 
     sealed class OptimizeMode(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.FileOptions.OptimizeMode && other.value == value
+        override fun equals(other: kotlin.Any?) = other is FileOptions.OptimizeMode && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.FileOptions.OptimizeMode.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "FileOptions.OptimizeMode.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object SPEED : OptimizeMode(1, "SPEED")
         object CODE_SIZE : OptimizeMode(2, "CODE_SIZE")
         object LITE_RUNTIME : OptimizeMode(3, "LITE_RUNTIME")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.FileOptions.OptimizeMode(value)
+        class UNRECOGNIZED(value: Int) : OptimizeMode(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.FileOptions.OptimizeMode> {
-            val values: List<pbandk.wkt.FileOptions.OptimizeMode> by lazy { listOf(SPEED, CODE_SIZE, LITE_RUNTIME) }
+        companion object : pbandk.Message.Enum.Companion<FileOptions.OptimizeMode> {
+            val values: List<FileOptions.OptimizeMode> by lazy { listOf(SPEED, CODE_SIZE, LITE_RUNTIME) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No OptimizeMode with name: $name")
         }
@@ -1388,6 +1402,7 @@ data class MessageOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.MessageOptions",
                 messageClass = pbandk.wkt.MessageOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1492,6 +1507,7 @@ data class FieldOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FieldOptions",
                 messageClass = pbandk.wkt.FieldOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1500,34 +1516,34 @@ data class FieldOptions(
     }
 
     sealed class CType(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.FieldOptions.CType && other.value == value
+        override fun equals(other: kotlin.Any?) = other is FieldOptions.CType && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.FieldOptions.CType.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "FieldOptions.CType.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object STRING : CType(0, "STRING")
         object CORD : CType(1, "CORD")
         object STRING_PIECE : CType(2, "STRING_PIECE")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.FieldOptions.CType(value)
+        class UNRECOGNIZED(value: Int) : CType(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.FieldOptions.CType> {
-            val values: List<pbandk.wkt.FieldOptions.CType> by lazy { listOf(STRING, CORD, STRING_PIECE) }
+        companion object : pbandk.Message.Enum.Companion<FieldOptions.CType> {
+            val values: List<FieldOptions.CType> by lazy { listOf(STRING, CORD, STRING_PIECE) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No CType with name: $name")
         }
     }
 
     sealed class JSType(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.FieldOptions.JSType && other.value == value
+        override fun equals(other: kotlin.Any?) = other is FieldOptions.JSType && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.FieldOptions.JSType.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "FieldOptions.JSType.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object JS_NORMAL : JSType(0, "JS_NORMAL")
         object JS_STRING : JSType(1, "JS_STRING")
         object JS_NUMBER : JSType(2, "JS_NUMBER")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.FieldOptions.JSType(value)
+        class UNRECOGNIZED(value: Int) : JSType(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.FieldOptions.JSType> {
-            val values: List<pbandk.wkt.FieldOptions.JSType> by lazy { listOf(JS_NORMAL, JS_STRING, JS_NUMBER) }
+        companion object : pbandk.Message.Enum.Companion<FieldOptions.JSType> {
+            val values: List<FieldOptions.JSType> by lazy { listOf(JS_NORMAL, JS_STRING, JS_NUMBER) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No JSType with name: $name")
         }
@@ -1564,6 +1580,7 @@ data class OneofOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.OneofOptions",
                 messageClass = pbandk.wkt.OneofOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1624,6 +1641,7 @@ data class EnumOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.EnumOptions",
                 messageClass = pbandk.wkt.EnumOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1673,6 +1691,7 @@ data class EnumValueOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.EnumValueOptions",
                 messageClass = pbandk.wkt.EnumValueOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1722,6 +1741,7 @@ data class ServiceOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.ServiceOptions",
                 messageClass = pbandk.wkt.ServiceOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1782,6 +1802,7 @@ data class MethodOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.MethodOptions",
                 messageClass = pbandk.wkt.MethodOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1790,17 +1811,17 @@ data class MethodOptions(
     }
 
     sealed class IdempotencyLevel(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.MethodOptions.IdempotencyLevel && other.value == value
+        override fun equals(other: kotlin.Any?) = other is MethodOptions.IdempotencyLevel && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.MethodOptions.IdempotencyLevel.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "MethodOptions.IdempotencyLevel.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object IDEMPOTENCY_UNKNOWN : IdempotencyLevel(0, "IDEMPOTENCY_UNKNOWN")
         object NO_SIDE_EFFECTS : IdempotencyLevel(1, "NO_SIDE_EFFECTS")
         object IDEMPOTENT : IdempotencyLevel(2, "IDEMPOTENT")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.MethodOptions.IdempotencyLevel(value)
+        class UNRECOGNIZED(value: Int) : IdempotencyLevel(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.MethodOptions.IdempotencyLevel> {
-            val values: List<pbandk.wkt.MethodOptions.IdempotencyLevel> by lazy { listOf(IDEMPOTENCY_UNKNOWN, NO_SIDE_EFFECTS, IDEMPOTENT) }
+        companion object : pbandk.Message.Enum.Companion<MethodOptions.IdempotencyLevel> {
+            val values: List<MethodOptions.IdempotencyLevel> by lazy { listOf(IDEMPOTENCY_UNKNOWN, NO_SIDE_EFFECTS, IDEMPOTENT) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No IdempotencyLevel with name: $name")
         }
@@ -1900,6 +1921,7 @@ data class UninterpretedOption(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.UninterpretedOption",
                 messageClass = pbandk.wkt.UninterpretedOption::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1944,6 +1966,7 @@ data class UninterpretedOption(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.UninterpretedOption.NamePart",
                     messageClass = pbandk.wkt.UninterpretedOption.NamePart::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1980,6 +2003,7 @@ data class SourceCodeInfo(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.SourceCodeInfo",
                 messageClass = pbandk.wkt.SourceCodeInfo::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2057,6 +2081,7 @@ data class SourceCodeInfo(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.SourceCodeInfo.Location",
                     messageClass = pbandk.wkt.SourceCodeInfo.Location::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2093,6 +2118,7 @@ data class GeneratedCodeInfo(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.GeneratedCodeInfo",
                 messageClass = pbandk.wkt.GeneratedCodeInfo::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2159,6 +2185,7 @@ data class GeneratedCodeInfo(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.GeneratedCodeInfo.Annotation",
                     messageClass = pbandk.wkt.GeneratedCodeInfo.Annotation::class,
                     messageCompanion = this,
                     fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/duration.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/duration.kt
@@ -40,6 +40,7 @@ data class Duration(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Duration",
                 messageClass = pbandk.wkt.Duration::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/empty.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/empty.kt
@@ -18,6 +18,7 @@ data class Empty(
             fieldsList.apply {
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Empty",
                 messageClass = pbandk.wkt.Empty::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/field_mask.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/field_mask.kt
@@ -29,6 +29,7 @@ data class FieldMask(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FieldMask",
                 messageClass = pbandk.wkt.FieldMask::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/source_context.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/source_context.kt
@@ -29,6 +29,7 @@ data class SourceContext(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.SourceContext",
                 messageClass = pbandk.wkt.SourceContext::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/struct.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/struct.kt
@@ -45,6 +45,7 @@ data class Struct(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Struct",
                 messageClass = pbandk.wkt.Struct::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -89,6 +90,7 @@ data class Struct(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "google.protobuf.Struct.FieldsEntry",
                     messageClass = pbandk.wkt.Struct.FieldsEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -203,6 +205,7 @@ data class Value(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Value",
                 messageClass = pbandk.wkt.Value::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -238,6 +241,7 @@ data class ListValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.ListValue",
                 messageClass = pbandk.wkt.ListValue::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/timestamp.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/timestamp.kt
@@ -40,6 +40,7 @@ data class Timestamp(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Timestamp",
                 messageClass = pbandk.wkt.Timestamp::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/type.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/type.kt
@@ -101,6 +101,7 @@ data class Type(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Type",
                 messageClass = pbandk.wkt.Type::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -235,6 +236,7 @@ data class Field(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Field",
                 messageClass = pbandk.wkt.Field::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -243,9 +245,9 @@ data class Field(
     }
 
     sealed class Kind(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.Field.Kind && other.value == value
+        override fun equals(other: kotlin.Any?) = other is Field.Kind && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.Field.Kind.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "Field.Kind.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object TYPE_UNKNOWN : Kind(0, "TYPE_UNKNOWN")
         object TYPE_DOUBLE : Kind(1, "TYPE_DOUBLE")
@@ -266,28 +268,28 @@ data class Field(
         object TYPE_SFIXED64 : Kind(16, "TYPE_SFIXED64")
         object TYPE_SINT32 : Kind(17, "TYPE_SINT32")
         object TYPE_SINT64 : Kind(18, "TYPE_SINT64")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.Field.Kind(value)
+        class UNRECOGNIZED(value: Int) : Kind(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.Field.Kind> {
-            val values: List<pbandk.wkt.Field.Kind> by lazy { listOf(TYPE_UNKNOWN, TYPE_DOUBLE, TYPE_FLOAT, TYPE_INT64, TYPE_UINT64, TYPE_INT32, TYPE_FIXED64, TYPE_FIXED32, TYPE_BOOL, TYPE_STRING, TYPE_GROUP, TYPE_MESSAGE, TYPE_BYTES, TYPE_UINT32, TYPE_ENUM, TYPE_SFIXED32, TYPE_SFIXED64, TYPE_SINT32, TYPE_SINT64) }
+        companion object : pbandk.Message.Enum.Companion<Field.Kind> {
+            val values: List<Field.Kind> by lazy { listOf(TYPE_UNKNOWN, TYPE_DOUBLE, TYPE_FLOAT, TYPE_INT64, TYPE_UINT64, TYPE_INT32, TYPE_FIXED64, TYPE_FIXED32, TYPE_BOOL, TYPE_STRING, TYPE_GROUP, TYPE_MESSAGE, TYPE_BYTES, TYPE_UINT32, TYPE_ENUM, TYPE_SFIXED32, TYPE_SFIXED64, TYPE_SINT32, TYPE_SINT64) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No Kind with name: $name")
         }
     }
 
     sealed class Cardinality(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.wkt.Field.Cardinality && other.value == value
+        override fun equals(other: kotlin.Any?) = other is Field.Cardinality && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.wkt.Field.Cardinality.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "Field.Cardinality.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object UNKNOWN : Cardinality(0, "CARDINALITY_UNKNOWN")
         object OPTIONAL : Cardinality(1, "CARDINALITY_OPTIONAL")
         object REQUIRED : Cardinality(2, "CARDINALITY_REQUIRED")
         object REPEATED : Cardinality(3, "CARDINALITY_REPEATED")
-        class UNRECOGNIZED(value: Int) : pbandk.wkt.Field.Cardinality(value)
+        class UNRECOGNIZED(value: Int) : Cardinality(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.wkt.Field.Cardinality> {
-            val values: List<pbandk.wkt.Field.Cardinality> by lazy { listOf(UNKNOWN, OPTIONAL, REQUIRED, REPEATED) }
+        companion object : pbandk.Message.Enum.Companion<Field.Cardinality> {
+            val values: List<Field.Cardinality> by lazy { listOf(UNKNOWN, OPTIONAL, REQUIRED, REPEATED) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No Cardinality with name: $name")
         }
@@ -365,6 +367,7 @@ data class Enum(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Enum",
                 messageClass = pbandk.wkt.Enum::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -422,6 +425,7 @@ data class EnumValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.EnumValue",
                 messageClass = pbandk.wkt.EnumValue::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -468,6 +472,7 @@ data class Option(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Option",
                 messageClass = pbandk.wkt.Option::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonMain/kotlin/pbandk/wkt/wrappers.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/wkt/wrappers.kt
@@ -29,6 +29,7 @@ data class DoubleValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.DoubleValue",
                 messageClass = pbandk.wkt.DoubleValue::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -64,6 +65,7 @@ data class FloatValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.FloatValue",
                 messageClass = pbandk.wkt.FloatValue::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -99,6 +101,7 @@ data class Int64Value(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Int64Value",
                 messageClass = pbandk.wkt.Int64Value::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -134,6 +137,7 @@ data class UInt64Value(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.UInt64Value",
                 messageClass = pbandk.wkt.UInt64Value::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -169,6 +173,7 @@ data class Int32Value(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.Int32Value",
                 messageClass = pbandk.wkt.Int32Value::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -204,6 +209,7 @@ data class UInt32Value(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.UInt32Value",
                 messageClass = pbandk.wkt.UInt32Value::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -239,6 +245,7 @@ data class BoolValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.BoolValue",
                 messageClass = pbandk.wkt.BoolValue::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -274,6 +281,7 @@ data class StringValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.StringValue",
                 messageClass = pbandk.wkt.StringValue::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -309,6 +317,7 @@ data class BytesValue(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "google.protobuf.BytesValue",
                 messageClass = pbandk.wkt.BytesValue::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonTest/kotlin/pbandk/MessageDescriptorTest.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/MessageDescriptorTest.kt
@@ -1,0 +1,30 @@
+package pbandk
+
+import pbandk.testpb.TestAllTypesProto3
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class MessageDescriptorTest {
+    @Test
+    fun testFullName() {
+        assertEquals("protobuf_test_messages.proto3.TestAllTypesProto3", TestAllTypesProto3.descriptor.fullName)
+    }
+
+    @Test
+    fun testFullName_Nested() {
+        assertEquals(
+            "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage",
+            TestAllTypesProto3.NestedMessage.descriptor.fullName
+        )
+    }
+
+    @Test
+    fun testName() {
+        assertEquals("TestAllTypesProto3", TestAllTypesProto3.descriptor.name)
+    }
+
+    @Test
+    fun testName_Nested() {
+        assertEquals("NestedMessage", TestAllTypesProto3.NestedMessage.descriptor.name)
+    }
+}

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/custom_options.kt
@@ -39,6 +39,7 @@ data class SingleRequiredCustomOption(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.SingleRequiredCustomOption",
                 messageClass = pbandk.testpb.SingleRequiredCustomOption::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -85,6 +86,7 @@ data class MultipleCustomOptions(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.MultipleCustomOptions",
                 messageClass = pbandk.testpb.MultipleCustomOptions::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -134,6 +136,7 @@ data class MultipleCustomOptionsPlusDeprecated(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.MultipleCustomOptionsPlusDeprecated",
                 messageClass = pbandk.testpb.MultipleCustomOptionsPlusDeprecated::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test.kt
@@ -29,6 +29,7 @@ data class Foo(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.Foo",
                 messageClass = pbandk.testpb.Foo::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -75,6 +76,7 @@ data class Bar(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.Bar",
                 messageClass = pbandk.testpb.Bar::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -110,6 +112,7 @@ data class MessageWithMap(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.MessageWithMap",
                 messageClass = pbandk.testpb.MessageWithMap::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -154,6 +157,7 @@ data class MessageWithMap(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "testpb.MessageWithMap.MapEntry",
                     messageClass = pbandk.testpb.MessageWithMap.MapEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -190,6 +194,7 @@ data class FooMap(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.FooMap",
                 messageClass = pbandk.testpb.FooMap::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -234,6 +239,7 @@ data class FooMap(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "testpb.FooMap.MapEntry",
                     messageClass = pbandk.testpb.FooMap.MapEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -270,6 +276,7 @@ data class FooMapEntries(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.FooMapEntries",
                 messageClass = pbandk.testpb.FooMapEntries::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -314,6 +321,7 @@ data class FooMapEntries(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "testpb.FooMapEntries.MapEntry",
                     messageClass = pbandk.testpb.FooMapEntries.MapEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -361,6 +369,7 @@ data class Wrappers(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.Wrappers",
                 messageClass = pbandk.testpb.Wrappers::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_compiler_limits.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_compiler_limits.kt
@@ -2037,6 +2037,7 @@ data class MessageWithLotsOfFields(
             addFields3(fieldsList)
             addFields4(fieldsList)
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.MessageWithLotsOfFields",
                 messageClass = pbandk.testpb.MessageWithLotsOfFields::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -18094,6 +18095,7 @@ data class MessageWithHugeOneof(
             addFields8(fieldsList)
             addFields9(fieldsList)
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.MessageWithHugeOneof",
                 messageClass = pbandk.testpb.MessageWithHugeOneof::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_duplicate_oneof_name.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_duplicate_oneof_name.kt
@@ -65,6 +65,7 @@ data class Value(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "testpb.Value",
                 messageClass = pbandk.testpb.Value::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/test_messages_proto3.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/test_messages_proto3.kt
@@ -1707,6 +1707,7 @@ data class TestAllTypesProto3(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto3.TestAllTypesProto3",
                 messageClass = pbandk.testpb.TestAllTypesProto3::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1715,27 +1716,27 @@ data class TestAllTypesProto3(
     }
 
     sealed class NestedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.testpb.TestAllTypesProto3.NestedEnum && other.value == value
+        override fun equals(other: kotlin.Any?) = other is TestAllTypesProto3.NestedEnum && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.testpb.TestAllTypesProto3.NestedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "TestAllTypesProto3.NestedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object FOO : NestedEnum(0, "FOO")
         object BAR : NestedEnum(1, "BAR")
         object BAZ : NestedEnum(2, "BAZ")
         object NEG : NestedEnum(-1, "NEG")
-        class UNRECOGNIZED(value: Int) : pbandk.testpb.TestAllTypesProto3.NestedEnum(value)
+        class UNRECOGNIZED(value: Int) : NestedEnum(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.testpb.TestAllTypesProto3.NestedEnum> {
-            val values: List<pbandk.testpb.TestAllTypesProto3.NestedEnum> by lazy { listOf(FOO, BAR, BAZ, NEG) }
+        companion object : pbandk.Message.Enum.Companion<TestAllTypesProto3.NestedEnum> {
+            val values: List<TestAllTypesProto3.NestedEnum> by lazy { listOf(FOO, BAR, BAZ, NEG) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No NestedEnum with name: $name")
         }
     }
 
     sealed class AliasedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {
-        override fun equals(other: kotlin.Any?) = other is pbandk.testpb.TestAllTypesProto3.AliasedEnum && other.value == value
+        override fun equals(other: kotlin.Any?) = other is TestAllTypesProto3.AliasedEnum && other.value == value
         override fun hashCode() = value.hashCode()
-        override fun toString() = "pbandk.testpb.TestAllTypesProto3.AliasedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
+        override fun toString() = "TestAllTypesProto3.AliasedEnum.${name ?: "UNRECOGNIZED"}(value=$value)"
 
         object ALIAS_FOO : AliasedEnum(0, "ALIAS_FOO")
         object ALIAS_BAR : AliasedEnum(1, "ALIAS_BAR")
@@ -1743,10 +1744,10 @@ data class TestAllTypesProto3(
         object QUX : AliasedEnum(2, "QUX")
         object QUX_ : AliasedEnum(2, "qux")
         object B_AZ : AliasedEnum(2, "bAz")
-        class UNRECOGNIZED(value: Int) : pbandk.testpb.TestAllTypesProto3.AliasedEnum(value)
+        class UNRECOGNIZED(value: Int) : AliasedEnum(value)
 
-        companion object : pbandk.Message.Enum.Companion<pbandk.testpb.TestAllTypesProto3.AliasedEnum> {
-            val values: List<pbandk.testpb.TestAllTypesProto3.AliasedEnum> by lazy { listOf(ALIAS_FOO, ALIAS_BAR, ALIAS_BAZ, QUX, QUX_, B_AZ) }
+        companion object : pbandk.Message.Enum.Companion<TestAllTypesProto3.AliasedEnum> {
+            val values: List<TestAllTypesProto3.AliasedEnum> by lazy { listOf(ALIAS_FOO, ALIAS_BAR, ALIAS_BAZ, QUX, QUX_, B_AZ) }
             override fun fromValue(value: Int) = values.firstOrNull { it.value == value } ?: UNRECOGNIZED(value)
             override fun fromName(name: String) = values.firstOrNull { it.name == name } ?: throw IllegalArgumentException("No AliasedEnum with name: $name")
         }
@@ -1789,6 +1790,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.NestedMessage",
                     messageClass = pbandk.testpb.TestAllTypesProto3.NestedMessage::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1834,6 +1836,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32Int32Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapInt32Int32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1879,6 +1882,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt64Int64Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapInt64Int64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1924,6 +1928,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapUint32Uint32Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapUint32Uint32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -1969,6 +1974,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapUint64Uint64Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapUint64Uint64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2014,6 +2020,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSint32Sint32Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapSint32Sint32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2059,6 +2066,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSint64Sint64Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapSint64Sint64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2104,6 +2112,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapFixed32Fixed32Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapFixed32Fixed32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2149,6 +2158,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapFixed64Fixed64Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapFixed64Fixed64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2194,6 +2204,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSfixed32Sfixed32Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapSfixed32Sfixed32Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2239,6 +2250,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapSfixed64Sfixed64Entry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapSfixed64Sfixed64Entry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2284,6 +2296,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32FloatEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapInt32FloatEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2329,6 +2342,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapInt32DoubleEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapInt32DoubleEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2374,6 +2388,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapBoolBoolEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapBoolBoolEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2419,6 +2434,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringStringEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapStringStringEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2464,6 +2480,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringBytesEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapStringBytesEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2509,6 +2526,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringNestedMessageEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapStringNestedMessageEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2554,6 +2572,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringForeignMessageEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapStringForeignMessageEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2599,6 +2618,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringNestedEnumEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapStringNestedEnumEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2644,6 +2664,7 @@ data class TestAllTypesProto3(
                     )
                 }
                 pbandk.MessageDescriptor(
+                    fullName = "protobuf_test_messages.proto3.TestAllTypesProto3.MapStringForeignEnumEntry",
                     messageClass = pbandk.testpb.TestAllTypesProto3.MapStringForeignEnumEntry::class,
                     messageCompanion = this,
                     fields = fieldsList
@@ -2680,6 +2701,7 @@ data class ForeignMessage(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "protobuf_test_messages.proto3.ForeignMessage",
                 messageClass = pbandk.testpb.ForeignMessage::class,
                 messageCompanion = this,
                 fields = fieldsList

--- a/runtime/src/commonTest/kotlin/pbandk/testpb/validate.kt
+++ b/runtime/src/commonTest/kotlin/pbandk/testpb/validate.kt
@@ -346,6 +346,7 @@ data class FieldRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.FieldRules",
                 messageClass = pbandk.testpb.FieldRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -447,6 +448,7 @@ data class FloatRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.FloatRules",
                 messageClass = pbandk.testpb.FloatRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -548,6 +550,7 @@ data class DoubleRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.DoubleRules",
                 messageClass = pbandk.testpb.DoubleRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -649,6 +652,7 @@ data class Int32Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.Int32Rules",
                 messageClass = pbandk.testpb.Int32Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -750,6 +754,7 @@ data class Int64Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.Int64Rules",
                 messageClass = pbandk.testpb.Int64Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -851,6 +856,7 @@ data class UInt32Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.UInt32Rules",
                 messageClass = pbandk.testpb.UInt32Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -952,6 +958,7 @@ data class UInt64Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.UInt64Rules",
                 messageClass = pbandk.testpb.UInt64Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1053,6 +1060,7 @@ data class SInt32Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.SInt32Rules",
                 messageClass = pbandk.testpb.SInt32Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1154,6 +1162,7 @@ data class SInt64Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.SInt64Rules",
                 messageClass = pbandk.testpb.SInt64Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1255,6 +1264,7 @@ data class Fixed32Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.Fixed32Rules",
                 messageClass = pbandk.testpb.Fixed32Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1356,6 +1366,7 @@ data class Fixed64Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.Fixed64Rules",
                 messageClass = pbandk.testpb.Fixed64Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1457,6 +1468,7 @@ data class SFixed32Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.SFixed32Rules",
                 messageClass = pbandk.testpb.SFixed32Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1558,6 +1570,7 @@ data class SFixed64Rules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.SFixed64Rules",
                 messageClass = pbandk.testpb.SFixed64Rules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1593,6 +1606,7 @@ data class BoolRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.BoolRules",
                 messageClass = pbandk.testpb.BoolRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -1927,6 +1941,7 @@ data class StringRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.StringRules",
                 messageClass = pbandk.testpb.StringRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2108,6 +2123,7 @@ data class BytesRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.BytesRules",
                 messageClass = pbandk.testpb.BytesRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2176,6 +2192,7 @@ data class EnumRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.EnumRules",
                 messageClass = pbandk.testpb.EnumRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2222,6 +2239,7 @@ data class MessageRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.MessageRules",
                 messageClass = pbandk.testpb.MessageRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2290,6 +2308,7 @@ data class RepeatedRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.RepeatedRules",
                 messageClass = pbandk.testpb.RepeatedRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2369,6 +2388,7 @@ data class MapRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.MapRules",
                 messageClass = pbandk.testpb.MapRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2426,6 +2446,7 @@ data class AnyRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.AnyRules",
                 messageClass = pbandk.testpb.AnyRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2538,6 +2559,7 @@ data class DurationRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.DurationRules",
                 messageClass = pbandk.testpb.DurationRules::class,
                 messageCompanion = this,
                 fields = fieldsList
@@ -2661,6 +2683,7 @@ data class TimestampRules(
                 )
             }
             pbandk.MessageDescriptor(
+                fullName = "pbandk.testpb.TimestampRules",
                 messageClass = pbandk.testpb.TimestampRules::class,
                 messageCompanion = this,
                 fields = fieldsList


### PR DESCRIPTION
This is in preparation for another PR that will add support for `Any` (see #63). Might be easier to review by looking at the individual commits in this PR rather than the combined diff.