### PR TITLE
Refactor handling of special JSON types

### DIFF
--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageAdapters.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonMessageAdapters.kt
@@ -1,0 +1,234 @@
+package pbandk.internal.json
+
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import pbandk.FieldDescriptor
+import pbandk.InvalidProtocolBufferException
+import pbandk.Message
+import pbandk.MessageMap
+import pbandk.internal.Util
+import pbandk.wkt.BoolValue
+import pbandk.wkt.BytesValue
+import pbandk.wkt.DoubleValue
+import pbandk.wkt.Duration
+import pbandk.wkt.FloatValue
+import pbandk.wkt.Int32Value
+import pbandk.wkt.Int64Value
+import pbandk.wkt.ListValue
+import pbandk.wkt.StringValue
+import pbandk.wkt.Struct
+import pbandk.wkt.Timestamp
+import pbandk.wkt.UInt32Value
+import pbandk.wkt.UInt64Value
+import pbandk.wkt.Value
+
+internal interface JsonMessageAdapter<T : Message> {
+    fun encode(message: T, jsonValueEncoder: JsonValueEncoder): JsonElement
+    fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder): T
+}
+
+internal object JsonMessageAdapters {
+    private val adapters = mapOf(
+        // Wrapper types use the same JSON representation as the wrapped value
+        // https://developers.google.com/protocol-buffers/docs/proto3#json
+
+        DoubleValue.descriptor to object : JsonMessageAdapter<DoubleValue> {
+            private val fieldType = DoubleValue.descriptor.fields.first().type
+
+            override fun encode(message: DoubleValue, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                DoubleValue(jsonValueDecoder.readDouble(json))
+        },
+
+        FloatValue.descriptor to object : JsonMessageAdapter<FloatValue> {
+            private val fieldType = FloatValue.descriptor.fields.first().type
+
+            override fun encode(message: FloatValue, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                FloatValue(jsonValueDecoder.readFloat(json))
+        },
+
+        Int64Value.descriptor to object : JsonMessageAdapter<Int64Value> {
+            private val fieldType = Int64Value.descriptor.fields.first().type
+
+            override fun encode(message: Int64Value, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                Int64Value(jsonValueDecoder.readInteger64(json))
+        },
+
+        UInt64Value.descriptor to object : JsonMessageAdapter<UInt64Value> {
+            private val fieldType = UInt64Value.descriptor.fields.first().type
+
+            override fun encode(message: UInt64Value, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                UInt64Value(jsonValueDecoder.readUnsignedInteger64(json))
+        },
+
+        Int32Value.descriptor to object : JsonMessageAdapter<Int32Value> {
+            private val fieldType = Int32Value.descriptor.fields.first().type
+
+            override fun encode(message: Int32Value, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                Int32Value(jsonValueDecoder.readInteger32(json))
+        },
+
+        UInt32Value.descriptor to object : JsonMessageAdapter<UInt32Value> {
+            private val fieldType = UInt32Value.descriptor.fields.first().type
+
+            override fun encode(message: UInt32Value, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                UInt32Value(jsonValueDecoder.readUnsignedInteger32(json))
+        },
+
+        BoolValue.descriptor to object : JsonMessageAdapter<BoolValue> {
+            private val fieldType = BoolValue.descriptor.fields.first().type
+
+            override fun encode(message: BoolValue, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                BoolValue(jsonValueDecoder.readBool(json))
+        },
+
+        StringValue.descriptor to object : JsonMessageAdapter<StringValue> {
+            private val fieldType = StringValue.descriptor.fields.first().type
+
+            override fun encode(message: StringValue, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                StringValue(jsonValueDecoder.readString(json))
+        },
+
+        BytesValue.descriptor to object : JsonMessageAdapter<BytesValue> {
+            private val fieldType = BytesValue.descriptor.fields.first().type
+
+            override fun encode(message: BytesValue, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.value, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                BytesValue(jsonValueDecoder.readBytes(json))
+        },
+
+        // Other well-known types with special JSON encoding
+
+        Duration.descriptor to object : JsonMessageAdapter<Duration> {
+            override fun encode(message: Duration, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeString(Util.durationToString(message))
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                Util.stringToDuration(jsonValueDecoder.readString(json))
+        },
+
+        ListValue.descriptor to object : JsonMessageAdapter<ListValue> {
+            private val fieldType = FieldDescriptor.Type.Message(Value.Companion)
+            override fun encode(message: ListValue, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeRepeated(message.values, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) = try {
+                @Suppress("UNCHECKED_CAST")
+                val values = jsonValueDecoder.readValue(
+                    json,
+                    ListValue.descriptor.fields.first().type
+                ) as Sequence<Value>
+                ListValue(values.toList())
+            } catch (e: InvalidProtocolBufferException) {
+                throw e
+            } catch (e: Exception) {
+                throw InvalidProtocolBufferException("dynamically typed list value did not contain a valid object", e)
+            }
+        },
+
+        Struct.descriptor to object : JsonMessageAdapter<Struct> {
+            private val fieldType = Struct.descriptor.fields.first().type
+
+            override fun encode(message: Struct, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeValue(message.fields, fieldType)
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) = try {
+                val fields = jsonValueDecoder.readMap(
+                    json,
+                    Struct.descriptor.fields.first().type as FieldDescriptor.Type.Map<*, *>
+                )
+                @Suppress("UNCHECKED_CAST")
+                Struct(MessageMap(fields.toSet() as Set<MessageMap.Entry<String, Value?>>))
+            } catch (e: InvalidProtocolBufferException) {
+                throw e
+            } catch (e: Exception) {
+                throw InvalidProtocolBufferException("struct field did not contain a valid object", e)
+            }
+        },
+
+        Timestamp.descriptor to object : JsonMessageAdapter<Timestamp> {
+            override fun encode(message: Timestamp, jsonValueEncoder: JsonValueEncoder) =
+                jsonValueEncoder.writeString(Util.timestampToString(message))
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) =
+                Util.stringToTimestamp(jsonValueDecoder.readString(json))
+        },
+
+        Value.descriptor to object : JsonMessageAdapter<Value> {
+            override fun encode(message: Value, jsonValueEncoder: JsonValueEncoder) = when (message.kind) {
+                is Value.Kind.StringValue -> jsonValueEncoder.writeString(message.kind.value)
+                is Value.Kind.BoolValue -> jsonValueEncoder.writeBool(message.kind.value)
+                is Value.Kind.NumberValue -> jsonValueEncoder.writeDouble(message.kind.value)
+                is Value.Kind.StructValue -> jsonValueEncoder.writeValue(
+                    message.kind.value.fields,
+                    Struct.descriptor.fields.first().type
+                )
+                is Value.Kind.ListValue -> jsonValueEncoder.writeValue(
+                    message.kind.value.values,
+                    ListValue.descriptor.fields.first().type
+                )
+                is Value.Kind.NullValue, null -> JsonNull
+            }
+
+            override fun decode(json: JsonElement, jsonValueDecoder: JsonValueDecoder) = when (json) {
+                is JsonNull -> Value(kind = Value.Kind.NullValue())
+                is JsonPrimitive -> runCatching { Value(kind = Value.Kind.StringValue(jsonValueDecoder.readString(json))) }
+                    .recoverCatching { Value(kind = Value.Kind.NumberValue(jsonValueDecoder.readDouble(json))) }
+                    .recoverCatching { Value(kind = Value.Kind.BoolValue(jsonValueDecoder.readBool(json))) }
+                    .getOrElse {
+                        throw InvalidProtocolBufferException(
+                            "dynamically typed value did not contain a valid primitive object"
+                        )
+                    }
+                is JsonArray -> Value(
+                    kind = Value.Kind.ListValue(
+                        jsonValueDecoder.readValue(json, FieldDescriptor.Type.Message(ListValue.Companion)) as ListValue
+                    )
+                )
+                is JsonObject -> Value(
+                    kind = Value.Kind.StructValue(
+                        jsonValueDecoder.readValue(json, FieldDescriptor.Type.Message(Struct.Companion)) as Struct
+                    )
+                )
+            }
+        },
+    )
+
+    fun <T : Message> getAdapter(message: T): JsonMessageAdapter<T>? {
+        @Suppress("UNCHECKED_CAST")
+        return adapters[message.descriptor] as? JsonMessageAdapter<T>
+    }
+
+    fun <T : Message> getAdapter(messageCompanion: Message.Companion<T>): JsonMessageAdapter<T>? {
+        @Suppress("UNCHECKED_CAST")
+        return adapters[messageCompanion.descriptor] as? JsonMessageAdapter<T>
+    }
+}

--- a/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueEncoder.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/internal/json/JsonValueEncoder.kt
@@ -1,16 +1,29 @@
 package pbandk.internal.json
 
-import kotlinx.serialization.json.*
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import pbandk.ByteArr
 import pbandk.FieldDescriptor
 import pbandk.Message
 import pbandk.internal.Util
 import pbandk.json.JsonConfig
-import pbandk.wkt.*
-import kotlin.Any
+import pbandk.wkt.BoolValue
+import pbandk.wkt.BytesValue
+import pbandk.wkt.DoubleValue
+import pbandk.wkt.FloatValue
+import pbandk.wkt.Int32Value
+import pbandk.wkt.Int64Value
+import pbandk.wkt.NullValue
+import pbandk.wkt.StringValue
+import pbandk.wkt.UInt32Value
+import pbandk.wkt.UInt64Value
 
 @OptIn(ExperimentalUnsignedTypes::class)
-internal class JsonValueEncoder(private val jsonConfig: JsonConfig) {
+internal class JsonValueEncoder(val jsonConfig: JsonConfig) {
     fun writeValue(value: Any, type: FieldDescriptor.Type): JsonElement = when (type) {
         is FieldDescriptor.Type.Primitive.Double -> writeDouble(value as Double)
         is FieldDescriptor.Type.Primitive.Float -> writeFloat(value as Float)
@@ -114,14 +127,5 @@ internal class JsonValueEncoder(private val jsonConfig: JsonConfig) {
             if (k == null || v == null) continue
             put(writeValue(k, keyType).jsonPrimitive.content, writeValue(v, valueType))
         }
-    }
-
-    fun writeDynamicValue(value: Value): JsonElement = when (value.kind) {
-        is Value.Kind.StringValue -> writeString(value.kind.value)
-        is Value.Kind.BoolValue -> writeBool(value.kind.value)
-        is Value.Kind.NumberValue -> writeDouble(value.kind.value)
-        is Value.Kind.StructValue -> writeValue(value.kind.value.fields, Struct.descriptor.fields.first().type)
-        is Value.Kind.ListValue -> writeValue(value.kind.value.values, ListValue.descriptor.fields.first().type)
-        is Value.Kind.NullValue, null -> JsonNull
     }
 }


### PR DESCRIPTION
Centralize all handling of protobuf messages that use a custom JSON representation into a new `JsonMessageAdapter` interface. This will make it easier to add types to the future without having to do lots of plumbing for each new type.

Note that this only includes protobuf messages that have a custom JSON representation but use the normal generated message in Kotlin. Protobuf messages that also use a custom type in Kotlin (namely, the `*Value` protobuf types that are converted to nullable primitive types in Kotlin) are not currently handled via `JsonMessageAdapter`.