### PR TITLE
Update to binary-compatibility-validator 0.8.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
@@ -8,16 +7,9 @@ plugins {
     kotlin("multiplatform") version Versions.kotlin apply false
     id("com.android.library") version Versions.androidGradlePlugin apply false
     id("org.springframework.boot") version Versions.springBootGradlePlugin apply false
+    id("binary-compatibility-validator") version Versions.binaryCompatibilityValidatorGradlePlugin apply false
 
     id("com.google.osdetector") version Versions.osDetectorGradlePlugin
-    id("binary-compatibility-validator") version Versions.binaryCompatibilityValidatorGradlePlugin
-}
-
-configure<ApiValidationExtension> {
-    ignoredProjects.addAll(
-        project.subprojects.map { it.name }.minus(listOf("pbandk-runtime"))
-    )
-    nonPublicMarkers.add("pbandk.PbandkInternal")
 }
 
 val sonatypeApiUser = providers.gradlePropertyOrEnvironmentVariable("sonatypeApiUser")

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -2,7 +2,7 @@ object Versions {
     const val androidGradlePlugin = "4.1.2"
     const val androidMinSdk = 21
     const val androidTargetSdk = 30
-    const val binaryCompatibilityValidatorGradlePlugin = "0.2.4"
+    const val binaryCompatibilityValidatorGradlePlugin = "0.8.0"
     const val junit = "4.12"
     const val kotlin = "1.4.31"
     const val kotlinCoroutines = "1.4.3"

--- a/runtime/api/android/pbandk-runtime.api
+++ b/runtime/api/android/pbandk-runtime.api
@@ -165,7 +165,6 @@ public final class pbandk/FieldDescriptor$Type$Repeated : pbandk/FieldDescriptor
 }
 
 public final class pbandk/InvalidProtocolBufferException : java/lang/RuntimeException {
-	public static final field Companion Lpbandk/InvalidProtocolBufferException$Companion;
 }
 
 public abstract interface annotation class pbandk/JsName : java/lang/annotation/Annotation {
@@ -173,7 +172,6 @@ public abstract interface annotation class pbandk/JsName : java/lang/annotation/
 }
 
 public final class pbandk/ListWithSize : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
-	public static final field Companion Lpbandk/ListWithSize$Companion;
 	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
 	public fun add (ILjava/lang/Object;)V
 	public fun add (Ljava/lang/Object;)Z
@@ -308,7 +306,6 @@ public final class pbandk/MessageKt {
 }
 
 public final class pbandk/MessageMap : kotlin/collections/AbstractMap {
-	public static final field Companion Lpbandk/MessageMap$Companion;
 	public fun getEntries ()Ljava/util/Set;
 }
 
@@ -2770,5 +2767,12 @@ public final class pbandk/wkt/WrappersKt {
 	public static final fun orDefault (Lpbandk/wkt/StringValue;)Lpbandk/wkt/StringValue;
 	public static final fun orDefault (Lpbandk/wkt/UInt32Value;)Lpbandk/wkt/UInt32Value;
 	public static final fun orDefault (Lpbandk/wkt/UInt64Value;)Lpbandk/wkt/UInt64Value;
+}
+
+public final class pro/streem/pbandk/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public fun <init> ()V
 }
 

--- a/runtime/api/jvm/pbandk-runtime.api
+++ b/runtime/api/jvm/pbandk-runtime.api
@@ -1,0 +1,2771 @@
+public final class pbandk/AnyExtensionsKt {
+	public static final fun isA (Lpbandk/wkt/Any;Lpbandk/Message$Companion;)Z
+	public static final fun pack (Lpbandk/wkt/Any$Companion;Lpbandk/Message;Ljava/lang/String;)Lpbandk/wkt/Any;
+	public static synthetic fun pack$default (Lpbandk/wkt/Any$Companion;Lpbandk/Message;Ljava/lang/String;ILjava/lang/Object;)Lpbandk/wkt/Any;
+	public static final fun unpack (Lpbandk/wkt/Any;Lpbandk/Message$Companion;)Lpbandk/Message;
+}
+
+public final class pbandk/ByteArr {
+	public static final field Companion Lpbandk/ByteArr$Companion;
+	public fun <init> ([B)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArray ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/ByteArr$Companion {
+	public final fun getEmpty ()Lpbandk/ByteArr;
+}
+
+public abstract interface annotation class pbandk/ExperimentalProtoJson : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class pbandk/ExperimentalProtoReflection : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class pbandk/Export : java/lang/annotation/Annotation {
+}
+
+public abstract interface class pbandk/ExtendableMessage : pbandk/Message {
+	public abstract fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public abstract fun getExtensionFields ()Lpbandk/ExtensionFieldSet;
+}
+
+public final class pbandk/ExtendableMessage$DefaultImpls {
+	public static fun getExtension (Lpbandk/ExtendableMessage;Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public static fun getProtoSize (Lpbandk/ExtendableMessage;)I
+}
+
+public final class pbandk/ExtensionFieldSet {
+	public fun <init> ()V
+}
+
+public final class pbandk/FieldDescriptor {
+	public fun <init> (Lkotlin/reflect/KProperty0;Ljava/lang/String;ILpbandk/FieldDescriptor$Type;Lkotlin/reflect/KProperty1;ZLjava/lang/String;Lpbandk/wkt/FieldOptions;)V
+	public synthetic fun <init> (Lkotlin/reflect/KProperty0;Ljava/lang/String;ILpbandk/FieldDescriptor$Type;Lkotlin/reflect/KProperty1;ZLjava/lang/String;Lpbandk/wkt/FieldOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lpbandk/wkt/FieldOptions;
+}
+
+public abstract class pbandk/FieldDescriptor$Type {
+}
+
+public final class pbandk/FieldDescriptor$Type$Enum : pbandk/FieldDescriptor$Type {
+	public fun <init> (Lpbandk/Message$Enum$Companion;Z)V
+	public synthetic fun <init> (Lpbandk/Message$Enum$Companion;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Map : pbandk/FieldDescriptor$Type {
+	public fun <init> (Lpbandk/FieldDescriptor$Type;Lpbandk/FieldDescriptor$Type;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Message : pbandk/FieldDescriptor$Type {
+	public fun <init> (Lpbandk/Message$Companion;)V
+}
+
+public abstract class pbandk/FieldDescriptor$Type$Primitive : pbandk/FieldDescriptor$Type {
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Bool : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Bytes : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Double : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Fixed32 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Fixed64 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Float : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Int32 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$Int64 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$SFixed32 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$SFixed64 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$SInt32 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$SInt64 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$String : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$UInt32 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Primitive$UInt64 : pbandk/FieldDescriptor$Type$Primitive {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/FieldDescriptor$Type$Repeated : pbandk/FieldDescriptor$Type {
+	public fun <init> (Lpbandk/FieldDescriptor$Type;Z)V
+	public synthetic fun <init> (Lpbandk/FieldDescriptor$Type;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getPacked ()Z
+}
+
+public final class pbandk/InvalidProtocolBufferException : java/lang/RuntimeException {
+}
+
+public abstract interface annotation class pbandk/JsName : java/lang/annotation/Annotation {
+	public abstract fun name ()Ljava/lang/String;
+}
+
+public final class pbandk/ListWithSize : java/util/List, kotlin/jvm/internal/markers/KMappedMarker {
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public fun add (ILjava/lang/Object;)V
+	public fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public fun equals (Ljava/lang/Object;)Z
+	public fun get (I)Ljava/lang/Object;
+	public final fun getList ()Ljava/util/List;
+	public final fun getProtoSize ()Ljava/lang/Integer;
+	public fun getSize ()I
+	public fun hashCode ()I
+	public fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun replaceAll (Ljava/util/function/UnaryOperator;)V
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun sort (Ljava/util/Comparator;)V
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/ListWithSize$Builder : java/util/List, kotlin/jvm/internal/markers/KMutableList {
+	public static final field Companion Lpbandk/ListWithSize$Builder$Companion;
+	public fun <init> ()V
+	public fun add (ILjava/lang/Object;)V
+	public fun add (Ljava/lang/Object;)Z
+	public fun addAll (ILjava/util/Collection;)Z
+	public fun addAll (Ljava/util/Collection;)Z
+	public fun clear ()V
+	public fun contains (Ljava/lang/Object;)Z
+	public fun containsAll (Ljava/util/Collection;)Z
+	public final fun fixed ()Lpbandk/ListWithSize;
+	public fun get (I)Ljava/lang/Object;
+	public final fun getList ()Ljava/util/ArrayList;
+	public fun getSize ()I
+	public fun indexOf (Ljava/lang/Object;)I
+	public fun isEmpty ()Z
+	public fun iterator ()Ljava/util/Iterator;
+	public fun lastIndexOf (Ljava/lang/Object;)I
+	public fun listIterator ()Ljava/util/ListIterator;
+	public fun listIterator (I)Ljava/util/ListIterator;
+	public final fun remove (I)Ljava/lang/Object;
+	public fun remove (Ljava/lang/Object;)Z
+	public fun removeAll (Ljava/util/Collection;)Z
+	public fun removeAt (I)Ljava/lang/Object;
+	public fun retainAll (Ljava/util/Collection;)Z
+	public fun set (ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun size ()I
+	public fun subList (II)Ljava/util/List;
+	public fun toArray ()[Ljava/lang/Object;
+	public fun toArray ([Ljava/lang/Object;)[Ljava/lang/Object;
+}
+
+public final class pbandk/ListWithSize$Builder$Companion {
+	public final fun fixed (Lpbandk/ListWithSize$Builder;)Lpbandk/ListWithSize;
+}
+
+public abstract interface class pbandk/Message {
+	public abstract fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public abstract fun getProtoSize ()I
+	public abstract fun getUnknownFields ()Ljava/util/Map;
+	public abstract fun plus (Lpbandk/Message;)Lpbandk/Message;
+}
+
+public abstract interface class pbandk/Message$Companion {
+	public abstract fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public abstract fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/Message$DefaultImpls {
+	public static fun getProtoSize (Lpbandk/Message;)I
+}
+
+public abstract interface class pbandk/Message$Enum {
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getValue ()I
+}
+
+public abstract interface class pbandk/Message$Enum$Companion {
+	public abstract fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public abstract fun fromValue (I)Lpbandk/Message$Enum;
+}
+
+public abstract class pbandk/Message$OneOf {
+	public fun <init> (Ljava/lang/Object;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class pbandk/MessageDecoder {
+	public abstract fun readMessage (Lpbandk/Message$Companion;Lkotlin/jvm/functions/Function2;)Ljava/util/Map;
+}
+
+public final class pbandk/MessageDescriptor {
+	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lpbandk/Message$Companion;Ljava/util/Collection;)V
+	public final fun getFields ()Ljava/util/Collection;
+	public final fun getMessageCompanion ()Lpbandk/Message$Companion;
+}
+
+public abstract interface class pbandk/MessageEncoder {
+	public abstract fun writeMessage (Lpbandk/Message;)V
+}
+
+public final class pbandk/MessageExtensionsJvmKt {
+	public static final fun decodeFromByteBuffer (Lpbandk/Message$Companion;Ljava/nio/ByteBuffer;)Lpbandk/Message;
+	public static final fun decodeFromStream (Lpbandk/Message$Companion;Ljava/io/InputStream;I)Lpbandk/Message;
+	public static synthetic fun decodeFromStream$default (Lpbandk/Message$Companion;Ljava/io/InputStream;IILjava/lang/Object;)Lpbandk/Message;
+	public static final fun encodeToStream (Lpbandk/Message;Ljava/io/OutputStream;)I
+}
+
+public final class pbandk/MessageKt {
+	public static final fun decodeFromByteArray (Lpbandk/Message$Companion;[B)Lpbandk/Message;
+	public static final fun encodeToByteArray (Lpbandk/Message;)[B
+	public static final fun encodeWith (Lpbandk/Message;Lpbandk/MessageEncoder;)V
+	public static final fun getFieldValue (Lpbandk/Message;Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public static final fun plus (Lpbandk/Message;Lpbandk/Message;)Lpbandk/Message;
+}
+
+public final class pbandk/MessageMap : kotlin/collections/AbstractMap {
+	public fun getEntries ()Ljava/util/Set;
+}
+
+public final class pbandk/MessageMap$Builder {
+	public static final field Companion Lpbandk/MessageMap$Builder$Companion;
+	public fun <init> ()V
+	public final fun fixed ()Lpbandk/MessageMap;
+	public final fun getEntries ()Ljava/util/Set;
+}
+
+public final class pbandk/MessageMap$Builder$Companion {
+	public final fun fixed (Lpbandk/MessageMap$Builder;)Lpbandk/MessageMap;
+}
+
+public final class pbandk/MessageMap$Entry : java/util/Map$Entry, kotlin/jvm/internal/markers/KMappedMarker, pbandk/Message {
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Lpbandk/MessageMap$Entry$Companion;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;Lpbandk/MessageMap$Entry$Companion;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getKey ()Ljava/lang/Object;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun getValue ()Ljava/lang/Object;
+	public fun plus (Lpbandk/Message;)Ljava/lang/Void;
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun setValue (Ljava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class pbandk/MessageMap$Entry$Companion : pbandk/Message$Companion {
+	public fun <init> (Lpbandk/FieldDescriptor$Type;Lpbandk/FieldDescriptor$Type;)V
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/MessageMap$Entry;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract interface annotation class pbandk/PbandkInternal : java/lang/annotation/Annotation {
+}
+
+public abstract interface annotation class pbandk/PublicForGeneratedCode : java/lang/annotation/Annotation {
+}
+
+public abstract interface class pbandk/TypeRegistry {
+	public static final field Companion Lpbandk/TypeRegistry$Companion;
+	public abstract fun contains (Ljava/lang/String;)Z
+	public abstract fun get (Ljava/lang/String;)Lpbandk/MessageDescriptor;
+}
+
+public abstract interface class pbandk/TypeRegistry$Builder : pbandk/TypeRegistry {
+	public abstract fun add (Lpbandk/MessageDescriptor;)V
+}
+
+public final class pbandk/TypeRegistry$Companion {
+	public final fun getEMPTY ()Lpbandk/TypeRegistry;
+}
+
+public abstract interface annotation class pbandk/TypeRegistryDsl : java/lang/annotation/Annotation {
+}
+
+public final class pbandk/TypeRegistryKt {
+	public static final fun add (Lpbandk/TypeRegistry$Builder;Lpbandk/Message$Companion;)V
+	public static final fun contains (Lpbandk/TypeRegistry;Lpbandk/Message$Companion;)Z
+	public static final fun contains (Lpbandk/TypeRegistry;Lpbandk/MessageDescriptor;)Z
+	public static final fun containsTypeUrl (Lpbandk/TypeRegistry;Ljava/lang/String;)Z
+	public static final fun getTypeUrl (Lpbandk/TypeRegistry;Ljava/lang/String;)Lpbandk/MessageDescriptor;
+	public static final fun typeRegistry (Lkotlin/jvm/functions/Function1;)Lpbandk/TypeRegistry;
+}
+
+public final class pbandk/UnknownField {
+	public fun <init> (ILjava/util/List;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (ILjava/util/List;)Lpbandk/UnknownField;
+	public static synthetic fun copy$default (Lpbandk/UnknownField;ILjava/util/List;ILjava/lang/Object;)Lpbandk/UnknownField;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFieldNum ()I
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/UnknownField$Value {
+	public fun <init> (ILpbandk/ByteArr;)V
+	public fun <init> (I[B)V
+	public final fun component1 ()I
+	public final fun component2 ()Lpbandk/ByteArr;
+	public final fun copy (ILpbandk/ByteArr;)Lpbandk/UnknownField$Value;
+	public static synthetic fun copy$default (Lpbandk/UnknownField$Value;ILpbandk/ByteArr;ILjava/lang/Object;)Lpbandk/UnknownField$Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRawBytes ()Lpbandk/ByteArr;
+	public final fun getWireType ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/json/JsonConfig {
+	public static final field Companion Lpbandk/json/JsonConfig$Companion;
+	public fun <init> ()V
+	public fun <init> (ZZZZZLpbandk/TypeRegistry;)V
+	public synthetic fun <init> (ZZZZZLpbandk/TypeRegistry;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Lpbandk/TypeRegistry;
+	public final fun copy (ZZZZZLpbandk/TypeRegistry;)Lpbandk/json/JsonConfig;
+	public static synthetic fun copy$default (Lpbandk/json/JsonConfig;ZZZZZLpbandk/TypeRegistry;ILjava/lang/Object;)Lpbandk/json/JsonConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCompactOutput ()Z
+	public final fun getIgnoreUnknownFieldsInInput ()Z
+	public final fun getOutputDefaultStringsAsNull ()Z
+	public final fun getOutputDefaultValues ()Z
+	public final fun getOutputProtoFieldNames ()Z
+	public final fun getTypeRegistry ()Lpbandk/TypeRegistry;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/json/JsonConfig$Companion {
+	public final fun getDEFAULT ()Lpbandk/json/JsonConfig;
+}
+
+public final class pbandk/json/MessageExtensionsKt {
+	public static final fun decodeFromJsonString (Lpbandk/Message$Companion;Ljava/lang/String;Lpbandk/json/JsonConfig;)Lpbandk/Message;
+	public static synthetic fun decodeFromJsonString$default (Lpbandk/Message$Companion;Ljava/lang/String;Lpbandk/json/JsonConfig;ILjava/lang/Object;)Lpbandk/Message;
+	public static final fun encodeToJsonString (Lpbandk/Message;Lpbandk/json/JsonConfig;)Ljava/lang/String;
+	public static synthetic fun encodeToJsonString$default (Lpbandk/Message;Lpbandk/json/JsonConfig;ILjava/lang/Object;)Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Any : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Any$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lpbandk/ByteArr;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lpbandk/ByteArr;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lpbandk/ByteArr;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lpbandk/ByteArr;Ljava/util/Map;)Lpbandk/wkt/Any;
+	public static synthetic fun copy$default (Lpbandk/wkt/Any;Ljava/lang/String;Lpbandk/ByteArr;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Any;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public final fun getTypeUrl ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()Lpbandk/ByteArr;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Any;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Any$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Any;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Any;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/AnyKt {
+	public static final fun orDefault (Lpbandk/wkt/Any;)Lpbandk/wkt/Any;
+}
+
+public final class pbandk/wkt/Api : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Api$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lpbandk/wkt/SourceContext;Ljava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lpbandk/wkt/SourceContext;Ljava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lpbandk/wkt/SourceContext;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lpbandk/wkt/Syntax;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lpbandk/wkt/SourceContext;Ljava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;)Lpbandk/wkt/Api;
+	public static synthetic fun copy$default (Lpbandk/wkt/Api;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Lpbandk/wkt/SourceContext;Ljava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Api;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getMethods ()Ljava/util/List;
+	public final fun getMixins ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public final fun getSourceContext ()Lpbandk/wkt/SourceContext;
+	public final fun getSyntax ()Lpbandk/wkt/Syntax;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getVersion ()Ljava/lang/String;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Api;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Api$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Api;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Api;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/ApiKt {
+	public static final fun orDefault (Lpbandk/wkt/Api;)Lpbandk/wkt/Api;
+	public static final fun orDefault (Lpbandk/wkt/Method;)Lpbandk/wkt/Method;
+	public static final fun orDefault (Lpbandk/wkt/Mixin;)Lpbandk/wkt/Mixin;
+}
+
+public final class pbandk/wkt/BoolValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/BoolValue$Companion;
+	public fun <init> ()V
+	public fun <init> (ZLjava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (ZLjava/util/Map;)Lpbandk/wkt/BoolValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/BoolValue;ZLjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/BoolValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()Z
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/BoolValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/BoolValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/BoolValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/BoolValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/BytesValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/BytesValue$Companion;
+	public fun <init> ()V
+	public fun <init> (Lpbandk/ByteArr;Ljava/util/Map;)V
+	public synthetic fun <init> (Lpbandk/ByteArr;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lpbandk/ByteArr;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Lpbandk/ByteArr;Ljava/util/Map;)Lpbandk/wkt/BytesValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/BytesValue;Lpbandk/ByteArr;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/BytesValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()Lpbandk/ByteArr;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/BytesValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/BytesValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/BytesValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/BytesValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/DescriptorKt {
+	public static final fun orDefault (Lpbandk/wkt/DescriptorProto$ExtensionRange;)Lpbandk/wkt/DescriptorProto$ExtensionRange;
+	public static final fun orDefault (Lpbandk/wkt/DescriptorProto$ReservedRange;)Lpbandk/wkt/DescriptorProto$ReservedRange;
+	public static final fun orDefault (Lpbandk/wkt/DescriptorProto;)Lpbandk/wkt/DescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;)Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;
+	public static final fun orDefault (Lpbandk/wkt/EnumDescriptorProto;)Lpbandk/wkt/EnumDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/EnumOptions;)Lpbandk/wkt/EnumOptions;
+	public static final fun orDefault (Lpbandk/wkt/EnumValueDescriptorProto;)Lpbandk/wkt/EnumValueDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/EnumValueOptions;)Lpbandk/wkt/EnumValueOptions;
+	public static final fun orDefault (Lpbandk/wkt/ExtensionRangeOptions;)Lpbandk/wkt/ExtensionRangeOptions;
+	public static final fun orDefault (Lpbandk/wkt/FieldDescriptorProto;)Lpbandk/wkt/FieldDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/FieldOptions;)Lpbandk/wkt/FieldOptions;
+	public static final fun orDefault (Lpbandk/wkt/FileDescriptorProto;)Lpbandk/wkt/FileDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/FileDescriptorSet;)Lpbandk/wkt/FileDescriptorSet;
+	public static final fun orDefault (Lpbandk/wkt/FileOptions;)Lpbandk/wkt/FileOptions;
+	public static final fun orDefault (Lpbandk/wkt/GeneratedCodeInfo$Annotation;)Lpbandk/wkt/GeneratedCodeInfo$Annotation;
+	public static final fun orDefault (Lpbandk/wkt/GeneratedCodeInfo;)Lpbandk/wkt/GeneratedCodeInfo;
+	public static final fun orDefault (Lpbandk/wkt/MessageOptions;)Lpbandk/wkt/MessageOptions;
+	public static final fun orDefault (Lpbandk/wkt/MethodDescriptorProto;)Lpbandk/wkt/MethodDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/MethodOptions;)Lpbandk/wkt/MethodOptions;
+	public static final fun orDefault (Lpbandk/wkt/OneofDescriptorProto;)Lpbandk/wkt/OneofDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/OneofOptions;)Lpbandk/wkt/OneofOptions;
+	public static final fun orDefault (Lpbandk/wkt/ServiceDescriptorProto;)Lpbandk/wkt/ServiceDescriptorProto;
+	public static final fun orDefault (Lpbandk/wkt/ServiceOptions;)Lpbandk/wkt/ServiceOptions;
+	public static final fun orDefault (Lpbandk/wkt/SourceCodeInfo$Location;)Lpbandk/wkt/SourceCodeInfo$Location;
+	public static final fun orDefault (Lpbandk/wkt/SourceCodeInfo;)Lpbandk/wkt/SourceCodeInfo;
+	public static final fun orDefault (Lpbandk/wkt/UninterpretedOption$NamePart;)Lpbandk/wkt/UninterpretedOption$NamePart;
+	public static final fun orDefault (Lpbandk/wkt/UninterpretedOption;)Lpbandk/wkt/UninterpretedOption;
+}
+
+public final class pbandk/wkt/DescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/DescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/MessageOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/MessageOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lpbandk/wkt/MessageOptions;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/MessageOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/DescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/DescriptorProto;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/MessageOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/DescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnumType ()Ljava/util/List;
+	public final fun getExtension ()Ljava/util/List;
+	public final fun getExtensionRange ()Ljava/util/List;
+	public final fun getField ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNestedType ()Ljava/util/List;
+	public final fun getOneofDecl ()Ljava/util/List;
+	public final fun getOptions ()Lpbandk/wkt/MessageOptions;
+	public fun getProtoSize ()I
+	public final fun getReservedName ()Ljava/util/List;
+	public final fun getReservedRange ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/DescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/DescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/DescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/DescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/DescriptorProto$ExtensionRange : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/DescriptorProto$ExtensionRange$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Lpbandk/wkt/ExtensionRangeOptions;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Lpbandk/wkt/ExtensionRangeOptions;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Lpbandk/wkt/ExtensionRangeOptions;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Lpbandk/wkt/ExtensionRangeOptions;Ljava/util/Map;)Lpbandk/wkt/DescriptorProto$ExtensionRange;
+	public static synthetic fun copy$default (Lpbandk/wkt/DescriptorProto$ExtensionRange;Ljava/lang/Integer;Ljava/lang/Integer;Lpbandk/wkt/ExtensionRangeOptions;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/DescriptorProto$ExtensionRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getOptions ()Lpbandk/wkt/ExtensionRangeOptions;
+	public fun getProtoSize ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/DescriptorProto$ExtensionRange;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/DescriptorProto$ExtensionRange$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/DescriptorProto$ExtensionRange;
+	public final fun getDefaultInstance ()Lpbandk/wkt/DescriptorProto$ExtensionRange;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/DescriptorProto$ReservedRange : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/DescriptorProto$ReservedRange$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;)Lpbandk/wkt/DescriptorProto$ReservedRange;
+	public static synthetic fun copy$default (Lpbandk/wkt/DescriptorProto$ReservedRange;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/DescriptorProto$ReservedRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public fun getProtoSize ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/DescriptorProto$ReservedRange;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/DescriptorProto$ReservedRange$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/DescriptorProto$ReservedRange;
+	public final fun getDefaultInstance ()Lpbandk/wkt/DescriptorProto$ReservedRange;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/DoubleValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/DoubleValue$Companion;
+	public fun <init> ()V
+	public fun <init> (DLjava/util/Map;)V
+	public synthetic fun <init> (DLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()D
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (DLjava/util/Map;)Lpbandk/wkt/DoubleValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/DoubleValue;DLjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/DoubleValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()D
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/DoubleValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/DoubleValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/DoubleValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/DoubleValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Duration : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Duration$Companion;
+	public fun <init> ()V
+	public fun <init> (JILjava/util/Map;)V
+	public synthetic fun <init> (JILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (JILjava/util/Map;)Lpbandk/wkt/Duration;
+	public static synthetic fun copy$default (Lpbandk/wkt/Duration;JILjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Duration;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getNanos ()I
+	public fun getProtoSize ()I
+	public final fun getSeconds ()J
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Duration;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Duration$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Duration;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Duration;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/DurationKt {
+	public static final fun orDefault (Lpbandk/wkt/Duration;)Lpbandk/wkt/Duration;
+}
+
+public final class pbandk/wkt/Empty : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Empty$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lpbandk/wkt/Empty;
+	public static synthetic fun copy$default (Lpbandk/wkt/Empty;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Empty;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Empty;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Empty$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Empty;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Empty;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EmptyKt {
+	public static final fun orDefault (Lpbandk/wkt/Empty;)Lpbandk/wkt/Empty;
+}
+
+public final class pbandk/wkt/Enum : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Enum$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lpbandk/wkt/SourceContext;
+	public final fun component5 ()Lpbandk/wkt/Syntax;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;)Lpbandk/wkt/Enum;
+	public static synthetic fun copy$default (Lpbandk/wkt/Enum;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Enum;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnumvalue ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public final fun getSourceContext ()Lpbandk/wkt/SourceContext;
+	public final fun getSyntax ()Lpbandk/wkt/Syntax;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Enum;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Enum$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Enum;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Enum;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EnumDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/EnumDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/EnumOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/EnumOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lpbandk/wkt/EnumOptions;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/EnumOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/EnumDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/EnumDescriptorProto;Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/EnumOptions;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/EnumDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lpbandk/wkt/EnumOptions;
+	public fun getProtoSize ()I
+	public final fun getReservedName ()Ljava/util/List;
+	public final fun getReservedRange ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()Ljava/util/List;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/EnumDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/EnumDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/EnumDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/EnumDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EnumDescriptorProto$EnumReservedRange : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;)Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;
+	public static synthetic fun copy$default (Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public fun getProtoSize ()I
+	public final fun getStart ()Ljava/lang/Integer;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/EnumDescriptorProto$EnumReservedRange$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;
+	public final fun getDefaultInstance ()Lpbandk/wkt/EnumDescriptorProto$EnumReservedRange;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EnumOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/EnumOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/EnumOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/EnumOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/EnumOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAlias ()Ljava/lang/Boolean;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/EnumOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/EnumOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/EnumOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/EnumOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EnumValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/EnumValue$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;ILjava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;ILjava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;ILjava/util/List;Ljava/util/Map;)Lpbandk/wkt/EnumValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/EnumValue;Ljava/lang/String;ILjava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/EnumValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()I
+	public final fun getOptions ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/EnumValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/EnumValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/EnumValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/EnumValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EnumValueDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/EnumValueDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/EnumValueOptions;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/EnumValueOptions;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Lpbandk/wkt/EnumValueOptions;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/EnumValueOptions;Ljava/util/Map;)Lpbandk/wkt/EnumValueDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/EnumValueDescriptorProto;Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/EnumValueOptions;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/EnumValueDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOptions ()Lpbandk/wkt/EnumValueOptions;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/EnumValueDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/EnumValueDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/EnumValueDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/EnumValueDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/EnumValueOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/EnumValueOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/EnumValueOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/EnumValueOptions;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/EnumValueOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/EnumValueOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/EnumValueOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/EnumValueOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/EnumValueOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/ExtensionRangeOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/ExtensionRangeOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/ExtensionRangeOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/ExtensionRangeOptions;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/ExtensionRangeOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/ExtensionRangeOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/ExtensionRangeOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/ExtensionRangeOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/ExtensionRangeOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Field : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Field$Companion;
+	public fun <init> ()V
+	public fun <init> (Lpbandk/wkt/Field$Kind;Lpbandk/wkt/Field$Cardinality;ILjava/lang/String;Ljava/lang/String;IZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Lpbandk/wkt/Field$Kind;Lpbandk/wkt/Field$Cardinality;ILjava/lang/String;Ljava/lang/String;IZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lpbandk/wkt/Field$Kind;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component2 ()Lpbandk/wkt/Field$Cardinality;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Lpbandk/wkt/Field$Kind;Lpbandk/wkt/Field$Cardinality;ILjava/lang/String;Ljava/lang/String;IZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lpbandk/wkt/Field;
+	public static synthetic fun copy$default (Lpbandk/wkt/Field;Lpbandk/wkt/Field$Kind;Lpbandk/wkt/Field$Cardinality;ILjava/lang/String;Ljava/lang/String;IZLjava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Field;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCardinality ()Lpbandk/wkt/Field$Cardinality;
+	public final fun getDefaultValue ()Ljava/lang/String;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getJsonName ()Ljava/lang/String;
+	public final fun getKind ()Lpbandk/wkt/Field$Kind;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()I
+	public final fun getOneofIndex ()I
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getPacked ()Z
+	public fun getProtoSize ()I
+	public final fun getTypeUrl ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Field;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class pbandk/wkt/Field$Cardinality : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/Field$Cardinality$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Field$Cardinality$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/Field$Cardinality;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/Field$Cardinality;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/Field$Cardinality$OPTIONAL : pbandk/wkt/Field$Cardinality {
+	public static final field INSTANCE Lpbandk/wkt/Field$Cardinality$OPTIONAL;
+}
+
+public final class pbandk/wkt/Field$Cardinality$REPEATED : pbandk/wkt/Field$Cardinality {
+	public static final field INSTANCE Lpbandk/wkt/Field$Cardinality$REPEATED;
+}
+
+public final class pbandk/wkt/Field$Cardinality$REQUIRED : pbandk/wkt/Field$Cardinality {
+	public static final field INSTANCE Lpbandk/wkt/Field$Cardinality$REQUIRED;
+}
+
+public final class pbandk/wkt/Field$Cardinality$UNKNOWN : pbandk/wkt/Field$Cardinality {
+	public static final field INSTANCE Lpbandk/wkt/Field$Cardinality$UNKNOWN;
+}
+
+public final class pbandk/wkt/Field$Cardinality$UNRECOGNIZED : pbandk/wkt/Field$Cardinality {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/Field$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Field;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Field;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/Field$Kind : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/Field$Kind$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Field$Kind$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/Field$Kind;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/Field$Kind;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_BOOL : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_BOOL;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_BYTES : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_BYTES;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_DOUBLE : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_DOUBLE;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_ENUM : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_ENUM;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_FIXED32 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_FIXED32;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_FIXED64 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_FIXED64;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_FLOAT : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_FLOAT;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_GROUP : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_GROUP;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_INT32 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_INT32;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_INT64 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_INT64;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_MESSAGE : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_MESSAGE;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_SFIXED32 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_SFIXED32;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_SFIXED64 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_SFIXED64;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_SINT32 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_SINT32;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_SINT64 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_SINT64;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_STRING : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_STRING;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_UINT32 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_UINT32;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_UINT64 : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_UINT64;
+}
+
+public final class pbandk/wkt/Field$Kind$TYPE_UNKNOWN : pbandk/wkt/Field$Kind {
+	public static final field INSTANCE Lpbandk/wkt/Field$Kind$TYPE_UNKNOWN;
+}
+
+public final class pbandk/wkt/Field$Kind$UNRECOGNIZED : pbandk/wkt/Field$Kind {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/FieldDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/FieldDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/FieldDescriptorProto$Label;Lpbandk/wkt/FieldDescriptorProto$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lpbandk/wkt/FieldOptions;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/FieldDescriptorProto$Label;Lpbandk/wkt/FieldDescriptorProto$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lpbandk/wkt/FieldOptions;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lpbandk/wkt/FieldOptions;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Lpbandk/wkt/FieldDescriptorProto$Label;
+	public final fun component4 ()Lpbandk/wkt/FieldDescriptorProto$Type;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/FieldDescriptorProto$Label;Lpbandk/wkt/FieldDescriptorProto$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lpbandk/wkt/FieldOptions;Ljava/lang/Boolean;Ljava/util/Map;)Lpbandk/wkt/FieldDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/FieldDescriptorProto;Ljava/lang/String;Ljava/lang/Integer;Lpbandk/wkt/FieldDescriptorProto$Label;Lpbandk/wkt/FieldDescriptorProto$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lpbandk/wkt/FieldOptions;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/FieldDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaultValue ()Ljava/lang/String;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getExtendee ()Ljava/lang/String;
+	public final fun getJsonName ()Ljava/lang/String;
+	public final fun getLabel ()Lpbandk/wkt/FieldDescriptorProto$Label;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getNumber ()Ljava/lang/Integer;
+	public final fun getOneofIndex ()Ljava/lang/Integer;
+	public final fun getOptions ()Lpbandk/wkt/FieldOptions;
+	public final fun getProto3Optional ()Ljava/lang/Boolean;
+	public fun getProtoSize ()I
+	public final fun getType ()Lpbandk/wkt/FieldDescriptorProto$Type;
+	public final fun getTypeName ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FieldDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FieldDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FieldDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/FieldDescriptorProto$Label : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/FieldDescriptorProto$Label$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Label$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/FieldDescriptorProto$Label;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/FieldDescriptorProto$Label;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Label$OPTIONAL : pbandk/wkt/FieldDescriptorProto$Label {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Label$OPTIONAL;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Label$REPEATED : pbandk/wkt/FieldDescriptorProto$Label {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Label$REPEATED;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Label$REQUIRED : pbandk/wkt/FieldDescriptorProto$Label {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Label$REQUIRED;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Label$UNRECOGNIZED : pbandk/wkt/FieldDescriptorProto$Label {
+	public fun <init> (I)V
+}
+
+public abstract class pbandk/wkt/FieldDescriptorProto$Type : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/FieldDescriptorProto$Type$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$BOOL : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$BOOL;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$BYTES : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$BYTES;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/FieldDescriptorProto$Type;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/FieldDescriptorProto$Type;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$DOUBLE : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$DOUBLE;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$ENUM : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$ENUM;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$FIXED32 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$FIXED32;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$FIXED64 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$FIXED64;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$FLOAT : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$FLOAT;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$GROUP : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$GROUP;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$INT32 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$INT32;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$INT64 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$INT64;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$MESSAGE : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$MESSAGE;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$SFIXED32 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$SFIXED32;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$SFIXED64 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$SFIXED64;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$SINT32 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$SINT32;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$SINT64 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$SINT64;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$STRING : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$STRING;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$UINT32 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$UINT32;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$UINT64 : pbandk/wkt/FieldDescriptorProto$Type {
+	public static final field INSTANCE Lpbandk/wkt/FieldDescriptorProto$Type$UINT64;
+}
+
+public final class pbandk/wkt/FieldDescriptorProto$Type$UNRECOGNIZED : pbandk/wkt/FieldDescriptorProto$Type {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/FieldMask : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/FieldMask$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/FieldMask;
+	public static synthetic fun copy$default (Lpbandk/wkt/FieldMask;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/FieldMask;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getPaths ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FieldMask;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FieldMask$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FieldMask;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FieldMask;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/FieldOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/FieldOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Lpbandk/wkt/FieldOptions$CType;Ljava/lang/Boolean;Lpbandk/wkt/FieldOptions$JSType;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Lpbandk/wkt/FieldOptions$CType;Ljava/lang/Boolean;Lpbandk/wkt/FieldOptions$JSType;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lpbandk/wkt/FieldOptions$CType;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Lpbandk/wkt/FieldOptions$JSType;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Lpbandk/wkt/FieldOptions$CType;Ljava/lang/Boolean;Lpbandk/wkt/FieldOptions$JSType;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/FieldOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/FieldOptions;Lpbandk/wkt/FieldOptions$CType;Ljava/lang/Boolean;Lpbandk/wkt/FieldOptions$JSType;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/FieldOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCtype ()Lpbandk/wkt/FieldOptions$CType;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public final fun getJstype ()Lpbandk/wkt/FieldOptions$JSType;
+	public final fun getLazy ()Ljava/lang/Boolean;
+	public final fun getPacked ()Ljava/lang/Boolean;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getWeak ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FieldOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class pbandk/wkt/FieldOptions$CType : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/FieldOptions$CType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FieldOptions$CType$CORD : pbandk/wkt/FieldOptions$CType {
+	public static final field INSTANCE Lpbandk/wkt/FieldOptions$CType$CORD;
+}
+
+public final class pbandk/wkt/FieldOptions$CType$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/FieldOptions$CType;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/FieldOptions$CType;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/FieldOptions$CType$STRING : pbandk/wkt/FieldOptions$CType {
+	public static final field INSTANCE Lpbandk/wkt/FieldOptions$CType$STRING;
+}
+
+public final class pbandk/wkt/FieldOptions$CType$STRING_PIECE : pbandk/wkt/FieldOptions$CType {
+	public static final field INSTANCE Lpbandk/wkt/FieldOptions$CType$STRING_PIECE;
+}
+
+public final class pbandk/wkt/FieldOptions$CType$UNRECOGNIZED : pbandk/wkt/FieldOptions$CType {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/FieldOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FieldOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FieldOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/FieldOptions$JSType : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/FieldOptions$JSType$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FieldOptions$JSType$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/FieldOptions$JSType;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/FieldOptions$JSType;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/FieldOptions$JSType$JS_NORMAL : pbandk/wkt/FieldOptions$JSType {
+	public static final field INSTANCE Lpbandk/wkt/FieldOptions$JSType$JS_NORMAL;
+}
+
+public final class pbandk/wkt/FieldOptions$JSType$JS_NUMBER : pbandk/wkt/FieldOptions$JSType {
+	public static final field INSTANCE Lpbandk/wkt/FieldOptions$JSType$JS_NUMBER;
+}
+
+public final class pbandk/wkt/FieldOptions$JSType$JS_STRING : pbandk/wkt/FieldOptions$JSType {
+	public static final field INSTANCE Lpbandk/wkt/FieldOptions$JSType$JS_STRING;
+}
+
+public final class pbandk/wkt/FieldOptions$JSType$UNRECOGNIZED : pbandk/wkt/FieldOptions$JSType {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/Field_maskKt {
+	public static final fun orDefault (Lpbandk/wkt/FieldMask;)Lpbandk/wkt/FieldMask;
+}
+
+public final class pbandk/wkt/FileDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/FileDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/FileOptions;Lpbandk/wkt/SourceCodeInfo;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/FileOptions;Lpbandk/wkt/SourceCodeInfo;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lpbandk/wkt/FileOptions;
+	public final fun component11 ()Lpbandk/wkt/SourceCodeInfo;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/FileOptions;Lpbandk/wkt/SourceCodeInfo;Ljava/lang/String;Ljava/util/Map;)Lpbandk/wkt/FileDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/FileDescriptorProto;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/FileOptions;Lpbandk/wkt/SourceCodeInfo;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/FileDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDependency ()Ljava/util/List;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnumType ()Ljava/util/List;
+	public final fun getExtension ()Ljava/util/List;
+	public final fun getMessageType ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lpbandk/wkt/FileOptions;
+	public final fun getPackage ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public final fun getPublicDependency ()Ljava/util/List;
+	public final fun getService ()Ljava/util/List;
+	public final fun getSourceCodeInfo ()Lpbandk/wkt/SourceCodeInfo;
+	public final fun getSyntax ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getWeakDependency ()Ljava/util/List;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FileDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FileDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FileDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FileDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/FileDescriptorSet : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/FileDescriptorSet$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/FileDescriptorSet;
+	public static synthetic fun copy$default (Lpbandk/wkt/FileDescriptorSet;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/FileDescriptorSet;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getFile ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FileDescriptorSet;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FileDescriptorSet$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FileDescriptorSet;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FileDescriptorSet;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/FileOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/FileOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lpbandk/wkt/FileOptions$OptimizeMode;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lpbandk/wkt/FileOptions$OptimizeMode;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component23 ()Lpbandk/ExtensionFieldSet;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Lpbandk/wkt/FileOptions$OptimizeMode;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lpbandk/wkt/FileOptions$OptimizeMode;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/FileOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/FileOptions;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lpbandk/wkt/FileOptions$OptimizeMode;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/FileOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCcEnableArenas ()Ljava/lang/Boolean;
+	public final fun getCcGenericServices ()Ljava/lang/Boolean;
+	public final fun getCsharpNamespace ()Ljava/lang/String;
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public final fun getGoPackage ()Ljava/lang/String;
+	public final fun getJavaGenerateEqualsAndHash ()Ljava/lang/Boolean;
+	public final fun getJavaGenericServices ()Ljava/lang/Boolean;
+	public final fun getJavaMultipleFiles ()Ljava/lang/Boolean;
+	public final fun getJavaOuterClassname ()Ljava/lang/String;
+	public final fun getJavaPackage ()Ljava/lang/String;
+	public final fun getJavaStringCheckUtf8 ()Ljava/lang/Boolean;
+	public final fun getObjcClassPrefix ()Ljava/lang/String;
+	public final fun getOptimizeFor ()Lpbandk/wkt/FileOptions$OptimizeMode;
+	public final fun getPhpClassPrefix ()Ljava/lang/String;
+	public final fun getPhpGenericServices ()Ljava/lang/Boolean;
+	public final fun getPhpMetadataNamespace ()Ljava/lang/String;
+	public final fun getPhpNamespace ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public final fun getPyGenericServices ()Ljava/lang/Boolean;
+	public final fun getRubyPackage ()Ljava/lang/String;
+	public final fun getSwiftPrefix ()Ljava/lang/String;
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FileOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FileOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FileOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FileOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/FileOptions$OptimizeMode : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/FileOptions$OptimizeMode$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FileOptions$OptimizeMode$CODE_SIZE : pbandk/wkt/FileOptions$OptimizeMode {
+	public static final field INSTANCE Lpbandk/wkt/FileOptions$OptimizeMode$CODE_SIZE;
+}
+
+public final class pbandk/wkt/FileOptions$OptimizeMode$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/FileOptions$OptimizeMode;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/FileOptions$OptimizeMode;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/FileOptions$OptimizeMode$LITE_RUNTIME : pbandk/wkt/FileOptions$OptimizeMode {
+	public static final field INSTANCE Lpbandk/wkt/FileOptions$OptimizeMode$LITE_RUNTIME;
+}
+
+public final class pbandk/wkt/FileOptions$OptimizeMode$SPEED : pbandk/wkt/FileOptions$OptimizeMode {
+	public static final field INSTANCE Lpbandk/wkt/FileOptions$OptimizeMode$SPEED;
+}
+
+public final class pbandk/wkt/FileOptions$OptimizeMode$UNRECOGNIZED : pbandk/wkt/FileOptions$OptimizeMode {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/FloatValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/FloatValue$Companion;
+	public fun <init> ()V
+	public fun <init> (FLjava/util/Map;)V
+	public synthetic fun <init> (FLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()F
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (FLjava/util/Map;)Lpbandk/wkt/FloatValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/FloatValue;FLjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/FloatValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()F
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/FloatValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/FloatValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/FloatValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/FloatValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/GeneratedCodeInfo : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/GeneratedCodeInfo$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/GeneratedCodeInfo;
+	public static synthetic fun copy$default (Lpbandk/wkt/GeneratedCodeInfo;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/GeneratedCodeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnotation ()Ljava/util/List;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/GeneratedCodeInfo;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/GeneratedCodeInfo$Annotation : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/GeneratedCodeInfo$Annotation$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;)Lpbandk/wkt/GeneratedCodeInfo$Annotation;
+	public static synthetic fun copy$default (Lpbandk/wkt/GeneratedCodeInfo$Annotation;Ljava/util/List;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/GeneratedCodeInfo$Annotation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBegin ()Ljava/lang/Integer;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getEnd ()Ljava/lang/Integer;
+	public final fun getPath ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public final fun getSourceFile ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/GeneratedCodeInfo$Annotation;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/GeneratedCodeInfo$Annotation$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/GeneratedCodeInfo$Annotation;
+	public final fun getDefaultInstance ()Lpbandk/wkt/GeneratedCodeInfo$Annotation;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/GeneratedCodeInfo$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/GeneratedCodeInfo;
+	public final fun getDefaultInstance ()Lpbandk/wkt/GeneratedCodeInfo;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Int32Value : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Int32Value$Companion;
+	public fun <init> ()V
+	public fun <init> (ILjava/util/Map;)V
+	public synthetic fun <init> (ILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (ILjava/util/Map;)Lpbandk/wkt/Int32Value;
+	public static synthetic fun copy$default (Lpbandk/wkt/Int32Value;ILjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Int32Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Int32Value;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Int32Value$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Int32Value;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Int32Value;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Int64Value : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Int64Value$Companion;
+	public fun <init> ()V
+	public fun <init> (JLjava/util/Map;)V
+	public synthetic fun <init> (JLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (JLjava/util/Map;)Lpbandk/wkt/Int64Value;
+	public static synthetic fun copy$default (Lpbandk/wkt/Int64Value;JLjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Int64Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Int64Value;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Int64Value$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Int64Value;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Int64Value;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/ListValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/ListValue$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/ListValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/ListValue;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/ListValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValues ()Ljava/util/List;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/ListValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/ListValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/ListValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/ListValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/MessageOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/MessageOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/MessageOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/MessageOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/MessageOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public final fun getMapEntry ()Ljava/lang/Boolean;
+	public final fun getMessageSetWireFormat ()Ljava/lang/Boolean;
+	public final fun getNoStandardDescriptorAccessor ()Ljava/lang/Boolean;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/MessageOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/MessageOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/MessageOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/MessageOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Method : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Method$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lpbandk/wkt/Syntax;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;)Lpbandk/wkt/Method;
+	public static synthetic fun copy$default (Lpbandk/wkt/Method;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Lpbandk/wkt/Syntax;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Method;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public final fun getRequestStreaming ()Z
+	public final fun getRequestTypeUrl ()Ljava/lang/String;
+	public final fun getResponseStreaming ()Z
+	public final fun getResponseTypeUrl ()Ljava/lang/String;
+	public final fun getSyntax ()Lpbandk/wkt/Syntax;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Method;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Method$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Method;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Method;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/MethodDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/MethodDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lpbandk/wkt/MethodOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lpbandk/wkt/MethodOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lpbandk/wkt/MethodOptions;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lpbandk/wkt/MethodOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;)Lpbandk/wkt/MethodDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/MethodDescriptorProto;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lpbandk/wkt/MethodOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/MethodDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientStreaming ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getInputType ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lpbandk/wkt/MethodOptions;
+	public final fun getOutputType ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public final fun getServerStreaming ()Ljava/lang/Boolean;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/MethodDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/MethodDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/MethodDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/MethodDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/MethodOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/MethodOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Lpbandk/wkt/MethodOptions$IdempotencyLevel;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Lpbandk/wkt/MethodOptions$IdempotencyLevel;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Lpbandk/wkt/MethodOptions$IdempotencyLevel;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/lang/Boolean;Lpbandk/wkt/MethodOptions$IdempotencyLevel;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/MethodOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/MethodOptions;Ljava/lang/Boolean;Lpbandk/wkt/MethodOptions$IdempotencyLevel;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/MethodOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public final fun getIdempotencyLevel ()Lpbandk/wkt/MethodOptions$IdempotencyLevel;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/MethodOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/MethodOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/MethodOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/MethodOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/MethodOptions$IdempotencyLevel : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/MethodOptions$IdempotencyLevel$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/MethodOptions$IdempotencyLevel$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/MethodOptions$IdempotencyLevel;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/MethodOptions$IdempotencyLevel;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/MethodOptions$IdempotencyLevel$IDEMPOTENCY_UNKNOWN : pbandk/wkt/MethodOptions$IdempotencyLevel {
+	public static final field INSTANCE Lpbandk/wkt/MethodOptions$IdempotencyLevel$IDEMPOTENCY_UNKNOWN;
+}
+
+public final class pbandk/wkt/MethodOptions$IdempotencyLevel$IDEMPOTENT : pbandk/wkt/MethodOptions$IdempotencyLevel {
+	public static final field INSTANCE Lpbandk/wkt/MethodOptions$IdempotencyLevel$IDEMPOTENT;
+}
+
+public final class pbandk/wkt/MethodOptions$IdempotencyLevel$NO_SIDE_EFFECTS : pbandk/wkt/MethodOptions$IdempotencyLevel {
+	public static final field INSTANCE Lpbandk/wkt/MethodOptions$IdempotencyLevel$NO_SIDE_EFFECTS;
+}
+
+public final class pbandk/wkt/MethodOptions$IdempotencyLevel$UNRECOGNIZED : pbandk/wkt/MethodOptions$IdempotencyLevel {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/Mixin : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Mixin$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lpbandk/wkt/Mixin;
+	public static synthetic fun copy$default (Lpbandk/wkt/Mixin;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Mixin;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public final fun getRoot ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Mixin;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Mixin$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Mixin;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Mixin;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/NullValue : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/NullValue$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/NullValue$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/NullValue;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/NullValue;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/NullValue$NULL_VALUE : pbandk/wkt/NullValue {
+	public static final field INSTANCE Lpbandk/wkt/NullValue$NULL_VALUE;
+}
+
+public final class pbandk/wkt/NullValue$UNRECOGNIZED : pbandk/wkt/NullValue {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/OneofDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/OneofDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lpbandk/wkt/OneofOptions;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lpbandk/wkt/OneofOptions;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lpbandk/wkt/OneofOptions;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lpbandk/wkt/OneofOptions;Ljava/util/Map;)Lpbandk/wkt/OneofDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/OneofDescriptorProto;Ljava/lang/String;Lpbandk/wkt/OneofOptions;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/OneofDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lpbandk/wkt/OneofOptions;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/OneofDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/OneofDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/OneofDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/OneofDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/OneofOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/OneofOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/OneofOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/OneofOptions;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/OneofOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/OneofOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/OneofOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/OneofOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/OneofOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Option : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Option$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lpbandk/wkt/Any;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lpbandk/wkt/Any;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lpbandk/wkt/Any;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lpbandk/wkt/Any;Ljava/util/Map;)Lpbandk/wkt/Option;
+	public static synthetic fun copy$default (Lpbandk/wkt/Option;Ljava/lang/String;Lpbandk/wkt/Any;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Option;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getName ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()Lpbandk/wkt/Any;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Option;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Option$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Option;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Option;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/ServiceDescriptorProto : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/ServiceDescriptorProto$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/ServiceOptions;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/ServiceOptions;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lpbandk/wkt/ServiceOptions;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/ServiceOptions;Ljava/util/Map;)Lpbandk/wkt/ServiceDescriptorProto;
+	public static synthetic fun copy$default (Lpbandk/wkt/ServiceDescriptorProto;Ljava/lang/String;Ljava/util/List;Lpbandk/wkt/ServiceOptions;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/ServiceDescriptorProto;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getMethod ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lpbandk/wkt/ServiceOptions;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/ServiceDescriptorProto;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/ServiceDescriptorProto$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/ServiceDescriptorProto;
+	public final fun getDefaultInstance ()Lpbandk/wkt/ServiceDescriptorProto;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/ServiceOptions : pbandk/ExtendableMessage {
+	public static final field Companion Lpbandk/wkt/ServiceOptions$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lpbandk/ExtensionFieldSet;
+	public final fun copy (Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;)Lpbandk/wkt/ServiceOptions;
+	public static synthetic fun copy$default (Lpbandk/wkt/ServiceOptions;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;Lpbandk/ExtensionFieldSet;ILjava/lang/Object;)Lpbandk/wkt/ServiceOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeprecated ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getExtension (Lpbandk/FieldDescriptor;)Ljava/lang/Object;
+	public fun getProtoSize ()I
+	public final fun getUninterpretedOption ()Ljava/util/List;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/ServiceOptions;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/ServiceOptions$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/ServiceOptions;
+	public final fun getDefaultInstance ()Lpbandk/wkt/ServiceOptions;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/SourceCodeInfo : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/SourceCodeInfo$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/SourceCodeInfo;
+	public static synthetic fun copy$default (Lpbandk/wkt/SourceCodeInfo;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/SourceCodeInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getLocation ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/SourceCodeInfo;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/SourceCodeInfo$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/SourceCodeInfo;
+	public final fun getDefaultInstance ()Lpbandk/wkt/SourceCodeInfo;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/SourceCodeInfo$Location : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/SourceCodeInfo$Location$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lpbandk/wkt/SourceCodeInfo$Location;
+	public static synthetic fun copy$default (Lpbandk/wkt/SourceCodeInfo$Location;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/SourceCodeInfo$Location;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getLeadingComments ()Ljava/lang/String;
+	public final fun getLeadingDetachedComments ()Ljava/util/List;
+	public final fun getPath ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public final fun getSpan ()Ljava/util/List;
+	public final fun getTrailingComments ()Ljava/lang/String;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/SourceCodeInfo$Location;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/SourceCodeInfo$Location$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/SourceCodeInfo$Location;
+	public final fun getDefaultInstance ()Lpbandk/wkt/SourceCodeInfo$Location;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/SourceContext : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/SourceContext$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lpbandk/wkt/SourceContext;
+	public static synthetic fun copy$default (Lpbandk/wkt/SourceContext;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/SourceContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getFileName ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/SourceContext;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/SourceContext$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/SourceContext;
+	public final fun getDefaultInstance ()Lpbandk/wkt/SourceContext;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Source_contextKt {
+	public static final fun orDefault (Lpbandk/wkt/SourceContext;)Lpbandk/wkt/SourceContext;
+}
+
+public final class pbandk/wkt/StringValue : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/StringValue$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lpbandk/wkt/StringValue;
+	public static synthetic fun copy$default (Lpbandk/wkt/StringValue;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/StringValue;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/StringValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/StringValue$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/StringValue;
+	public final fun getDefaultInstance ()Lpbandk/wkt/StringValue;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Struct : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Struct$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;Ljava/util/Map;)Lpbandk/wkt/Struct;
+	public static synthetic fun copy$default (Lpbandk/wkt/Struct;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Struct;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getFields ()Ljava/util/Map;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Struct;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Struct$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Struct;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Struct;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Struct$FieldsEntry : java/util/Map$Entry, kotlin/jvm/internal/markers/KMappedMarker, pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Struct$FieldsEntry$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lpbandk/wkt/Value;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lpbandk/wkt/Value;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lpbandk/wkt/Value;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lpbandk/wkt/Value;Ljava/util/Map;)Lpbandk/wkt/Struct$FieldsEntry;
+	public static synthetic fun copy$default (Lpbandk/wkt/Struct$FieldsEntry;Ljava/lang/String;Lpbandk/wkt/Value;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Struct$FieldsEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public synthetic fun getKey ()Ljava/lang/Object;
+	public fun getKey ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public synthetic fun getValue ()Ljava/lang/Object;
+	public fun getValue ()Lpbandk/wkt/Value;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Struct$FieldsEntry;
+	public synthetic fun setValue (Ljava/lang/Object;)Ljava/lang/Object;
+	public fun setValue (Lpbandk/wkt/Value;)Lpbandk/wkt/Value;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Struct$FieldsEntry$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Struct$FieldsEntry;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Struct$FieldsEntry;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/StructKt {
+	public static final fun orDefault (Lpbandk/wkt/ListValue;)Lpbandk/wkt/ListValue;
+	public static final fun orDefault (Lpbandk/wkt/Struct$FieldsEntry;)Lpbandk/wkt/Struct$FieldsEntry;
+	public static final fun orDefault (Lpbandk/wkt/Struct;)Lpbandk/wkt/Struct;
+	public static final fun orDefault (Lpbandk/wkt/Value;)Lpbandk/wkt/Value;
+}
+
+public abstract class pbandk/wkt/Syntax : pbandk/Message$Enum {
+	public static final field Companion Lpbandk/wkt/Syntax$Companion;
+	public synthetic fun <init> (ILjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getName ()Ljava/lang/String;
+	public fun getValue ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Syntax$Companion : pbandk/Message$Enum$Companion {
+	public synthetic fun fromName (Ljava/lang/String;)Lpbandk/Message$Enum;
+	public fun fromName (Ljava/lang/String;)Lpbandk/wkt/Syntax;
+	public synthetic fun fromValue (I)Lpbandk/Message$Enum;
+	public fun fromValue (I)Lpbandk/wkt/Syntax;
+	public final fun getValues ()Ljava/util/List;
+}
+
+public final class pbandk/wkt/Syntax$PROTO2 : pbandk/wkt/Syntax {
+	public static final field INSTANCE Lpbandk/wkt/Syntax$PROTO2;
+}
+
+public final class pbandk/wkt/Syntax$PROTO3 : pbandk/wkt/Syntax {
+	public static final field INSTANCE Lpbandk/wkt/Syntax$PROTO3;
+}
+
+public final class pbandk/wkt/Syntax$UNRECOGNIZED : pbandk/wkt/Syntax {
+	public fun <init> (I)V
+}
+
+public final class pbandk/wkt/Timestamp : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Timestamp$Companion;
+	public fun <init> ()V
+	public fun <init> (JILjava/util/Map;)V
+	public synthetic fun <init> (JILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (JILjava/util/Map;)Lpbandk/wkt/Timestamp;
+	public static synthetic fun copy$default (Lpbandk/wkt/Timestamp;JILjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Timestamp;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getNanos ()I
+	public fun getProtoSize ()I
+	public final fun getSeconds ()J
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Timestamp;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Timestamp$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Timestamp;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Timestamp;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/TimestampKt {
+	public static final fun orDefault (Lpbandk/wkt/Timestamp;)Lpbandk/wkt/Timestamp;
+}
+
+public final class pbandk/wkt/Type : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Type$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Lpbandk/wkt/SourceContext;
+	public final fun component6 ()Lpbandk/wkt/Syntax;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;)Lpbandk/wkt/Type;
+	public static synthetic fun copy$default (Lpbandk/wkt/Type;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lpbandk/wkt/SourceContext;Lpbandk/wkt/Syntax;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Type;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getFields ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOneofs ()Ljava/util/List;
+	public final fun getOptions ()Ljava/util/List;
+	public fun getProtoSize ()I
+	public final fun getSourceContext ()Lpbandk/wkt/SourceContext;
+	public final fun getSyntax ()Lpbandk/wkt/Syntax;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Type;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Type$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Type;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Type;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/TypeKt {
+	public static final fun orDefault (Lpbandk/wkt/Enum;)Lpbandk/wkt/Enum;
+	public static final fun orDefault (Lpbandk/wkt/EnumValue;)Lpbandk/wkt/EnumValue;
+	public static final fun orDefault (Lpbandk/wkt/Field;)Lpbandk/wkt/Field;
+	public static final fun orDefault (Lpbandk/wkt/Option;)Lpbandk/wkt/Option;
+	public static final fun orDefault (Lpbandk/wkt/Type;)Lpbandk/wkt/Type;
+}
+
+public final class pbandk/wkt/UInt32Value : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/UInt32Value$Companion;
+	public fun <init> ()V
+	public fun <init> (ILjava/util/Map;)V
+	public synthetic fun <init> (ILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (ILjava/util/Map;)Lpbandk/wkt/UInt32Value;
+	public static synthetic fun copy$default (Lpbandk/wkt/UInt32Value;ILjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/UInt32Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()I
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/UInt32Value;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/UInt32Value$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/UInt32Value;
+	public final fun getDefaultInstance ()Lpbandk/wkt/UInt32Value;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/UInt64Value : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/UInt64Value$Companion;
+	public fun <init> ()V
+	public fun <init> (JLjava/util/Map;)V
+	public synthetic fun <init> (JLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (JLjava/util/Map;)Lpbandk/wkt/UInt64Value;
+	public static synthetic fun copy$default (Lpbandk/wkt/UInt64Value;JLjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/UInt64Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public final fun getValue ()J
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/UInt64Value;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/UInt64Value$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/UInt64Value;
+	public final fun getDefaultInstance ()Lpbandk/wkt/UInt64Value;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/UninterpretedOption : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/UninterpretedOption$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Lpbandk/ByteArr;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Lpbandk/ByteArr;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Long;
+	public final fun component4 ()Ljava/lang/Long;
+	public final fun component5 ()Ljava/lang/Double;
+	public final fun component6 ()Lpbandk/ByteArr;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Lpbandk/ByteArr;Ljava/lang/String;Ljava/util/Map;)Lpbandk/wkt/UninterpretedOption;
+	public static synthetic fun copy$default (Lpbandk/wkt/UninterpretedOption;Ljava/util/List;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Double;Lpbandk/ByteArr;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/UninterpretedOption;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAggregateValue ()Ljava/lang/String;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getDoubleValue ()Ljava/lang/Double;
+	public final fun getIdentifierValue ()Ljava/lang/String;
+	public final fun getName ()Ljava/util/List;
+	public final fun getNegativeIntValue ()Ljava/lang/Long;
+	public final fun getPositiveIntValue ()Ljava/lang/Long;
+	public fun getProtoSize ()I
+	public final fun getStringValue ()Lpbandk/ByteArr;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/UninterpretedOption;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/UninterpretedOption$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/UninterpretedOption;
+	public final fun getDefaultInstance ()Lpbandk/wkt/UninterpretedOption;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/UninterpretedOption$NamePart : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/UninterpretedOption$NamePart$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;ZLjava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;ZLjava/util/Map;)Lpbandk/wkt/UninterpretedOption$NamePart;
+	public static synthetic fun copy$default (Lpbandk/wkt/UninterpretedOption$NamePart;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/UninterpretedOption$NamePart;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getNamePart ()Ljava/lang/String;
+	public fun getProtoSize ()I
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public final fun isExtension ()Z
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/UninterpretedOption$NamePart;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/UninterpretedOption$NamePart$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/UninterpretedOption$NamePart;
+	public final fun getDefaultInstance ()Lpbandk/wkt/UninterpretedOption$NamePart;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public final class pbandk/wkt/Value : pbandk/Message {
+	public static final field Companion Lpbandk/wkt/Value$Companion;
+	public fun <init> ()V
+	public fun <init> (Lpbandk/wkt/Value$Kind;Ljava/util/Map;)V
+	public synthetic fun <init> (Lpbandk/wkt/Value$Kind;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lpbandk/wkt/Value$Kind;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Lpbandk/wkt/Value$Kind;Ljava/util/Map;)Lpbandk/wkt/Value;
+	public static synthetic fun copy$default (Lpbandk/wkt/Value;Lpbandk/wkt/Value$Kind;Ljava/util/Map;ILjava/lang/Object;)Lpbandk/wkt/Value;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoolValue ()Ljava/lang/Boolean;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+	public final fun getKind ()Lpbandk/wkt/Value$Kind;
+	public final fun getListValue ()Lpbandk/wkt/ListValue;
+	public final fun getNullValue ()Lpbandk/wkt/NullValue;
+	public final fun getNumberValue ()Ljava/lang/Double;
+	public fun getProtoSize ()I
+	public final fun getStringValue ()Ljava/lang/String;
+	public final fun getStructValue ()Lpbandk/wkt/Struct;
+	public fun getUnknownFields ()Ljava/util/Map;
+	public fun hashCode ()I
+	public synthetic fun plus (Lpbandk/Message;)Lpbandk/Message;
+	public fun plus (Lpbandk/Message;)Lpbandk/wkt/Value;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class pbandk/wkt/Value$Companion : pbandk/Message$Companion {
+	public synthetic fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/Message;
+	public fun decodeWith (Lpbandk/MessageDecoder;)Lpbandk/wkt/Value;
+	public final fun getDefaultInstance ()Lpbandk/wkt/Value;
+	public fun getDescriptor ()Lpbandk/MessageDescriptor;
+}
+
+public abstract class pbandk/wkt/Value$Kind : pbandk/Message$OneOf {
+	public synthetic fun <init> (Ljava/lang/Object;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/wkt/Value$Kind$BoolValue : pbandk/wkt/Value$Kind {
+	public fun <init> ()V
+	public fun <init> (Z)V
+	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/wkt/Value$Kind$ListValue : pbandk/wkt/Value$Kind {
+	public fun <init> (Lpbandk/wkt/ListValue;)V
+}
+
+public final class pbandk/wkt/Value$Kind$NullValue : pbandk/wkt/Value$Kind {
+	public fun <init> ()V
+	public fun <init> (Lpbandk/wkt/NullValue;)V
+	public synthetic fun <init> (Lpbandk/wkt/NullValue;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/wkt/Value$Kind$NumberValue : pbandk/wkt/Value$Kind {
+	public fun <init> ()V
+	public fun <init> (D)V
+	public synthetic fun <init> (DILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/wkt/Value$Kind$StringValue : pbandk/wkt/Value$Kind {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class pbandk/wkt/Value$Kind$StructValue : pbandk/wkt/Value$Kind {
+	public fun <init> (Lpbandk/wkt/Struct;)V
+}
+
+public final class pbandk/wkt/WrappersKt {
+	public static final fun orDefault (Lpbandk/wkt/BoolValue;)Lpbandk/wkt/BoolValue;
+	public static final fun orDefault (Lpbandk/wkt/BytesValue;)Lpbandk/wkt/BytesValue;
+	public static final fun orDefault (Lpbandk/wkt/DoubleValue;)Lpbandk/wkt/DoubleValue;
+	public static final fun orDefault (Lpbandk/wkt/FloatValue;)Lpbandk/wkt/FloatValue;
+	public static final fun orDefault (Lpbandk/wkt/Int32Value;)Lpbandk/wkt/Int32Value;
+	public static final fun orDefault (Lpbandk/wkt/Int64Value;)Lpbandk/wkt/Int64Value;
+	public static final fun orDefault (Lpbandk/wkt/StringValue;)Lpbandk/wkt/StringValue;
+	public static final fun orDefault (Lpbandk/wkt/UInt32Value;)Lpbandk/wkt/UInt32Value;
+	public static final fun orDefault (Lpbandk/wkt/UInt64Value;)Lpbandk/wkt/UInt64Value;
+}
+

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -5,12 +5,17 @@ plugins {
     id("com.android.library")
     `maven-publish`
     signing
+    id("binary-compatibility-validator")
 }
 
 description = "Kotlin runtime library for Protocol Buffers. It is built to work across multiple Kotlin platforms."
 
 repositories {
     google()
+}
+
+apiValidation {
+    nonPublicMarkers.add("pbandk.PbandkInternal")
 }
 
 kotlin {


### PR DESCRIPTION
This version allows applying the plugin to individual projects rather than having to be applied at the top level. This version also supports generating API dumps for multiple JVM-based targets (i.e. `jvm` and `android`) instead of only one.
