### PR TITLE
Some small followups to recent PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
-* **[BREAKING CHANGE]** Added `MessageDescriptor.fullName` and `MessageDescriptor.name` properties. All protobuf types have to be regenerated using this version of `protoc-gen-pbandk`. These properties are currently `internal` but can be exposed publicly if there is a need/use case. (PR [#184])
+* **[BREAKING CHANGE]** Added `MessageDescriptor.fullName` and `MessageDescriptor.name` properties. All protobuf types have to be regenerated using this version of `protoc-gen-pbandk`. (PR [#184])
 * Added special support for protobuf's `google.protobuf.Any` message type. (PR [#185], fixes [#63], partially fixes [#72])
     * Added `Any.Companion.pack()`, `Any.unpack()`, and `Any.isA()` convenience methods for working with `Any` instances. These methods mirror the same-named methods in other protobuf libraries.
     * The special JSON format used for `google.protobuf.Any` messsages is now correctly used during JSON encoding/decoding. Provide a value for `JsonConfig.typeRegistry` (which can be constructed using the new `typeRegistry {...}` builder) when encoding/decoding JSON messages that contain `google.protobuf.Any` fields.

--- a/runtime/api/android/pbandk-runtime.api
+++ b/runtime/api/android/pbandk-runtime.api
@@ -283,7 +283,9 @@ public abstract interface class pbandk/MessageDecoder {
 public final class pbandk/MessageDescriptor {
 	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lpbandk/Message$Companion;Ljava/util/Collection;)V
 	public final fun getFields ()Ljava/util/Collection;
+	public final fun getFullName ()Ljava/lang/String;
 	public final fun getMessageCompanion ()Lpbandk/Message$Companion;
+	public final fun getName ()Ljava/lang/String;
 }
 
 public abstract interface class pbandk/MessageEncoder {

--- a/runtime/api/jvm/pbandk-runtime.api
+++ b/runtime/api/jvm/pbandk-runtime.api
@@ -283,7 +283,9 @@ public abstract interface class pbandk/MessageDecoder {
 public final class pbandk/MessageDescriptor {
 	public fun <init> (Ljava/lang/String;Lkotlin/reflect/KClass;Lpbandk/Message$Companion;Ljava/util/Collection;)V
 	public final fun getFields ()Ljava/util/Collection;
+	public final fun getFullName ()Ljava/lang/String;
 	public final fun getMessageCompanion ()Lpbandk/Message$Companion;
+	public final fun getName ()Ljava/lang/String;
 }
 
 public abstract interface class pbandk/MessageEncoder {

--- a/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
@@ -17,7 +17,7 @@ public class MessageDescriptor<T : Message> @PublicForGeneratedCode constructor(
      *
      * `Baz`'s [fullName] is "foo.bar.Baz".
      */
-    internal val fullName: String,
+    public val fullName: String,
 
     internal val messageClass: KClass<T>,
 
@@ -28,5 +28,5 @@ public class MessageDescriptor<T : Message> @PublicForGeneratedCode constructor(
     public val fields: Collection<FieldDescriptor<T, *>>
 ) {
     /** The message type's unqualified name. */
-    internal val name = fullName.substringAfterLast('.')
+    public val name: String = fullName.substringAfterLast('.')
 }


### PR DESCRIPTION
- Codegen: Suppress more warnings for deprecated fields in generated code
- Make `MessageDescriptor`'s `fullName` and `name` fields public: turns out we already have a use case for this at Streem
