### PR TITLE
Update pbandk-protos library to be Java 8 compatible

### DIFF
--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -16,6 +16,12 @@ application {
     applicationName = "greeter"
 }
 
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinxCoroutinesVersion")
     implementation("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -1,5 +1,3 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     kotlin("jvm") version "1.5.32" apply false
     id("com.google.protobuf") version "0.8.18" apply false
@@ -13,11 +11,5 @@ subprojects {
             mavenLocal()
         }
         mavenCentral()
-    }
-
-    tasks.withType<KotlinCompile>().configureEach {
-        kotlinOptions {
-            jvmTarget = "1.8"
-        }
     }
 }

--- a/examples/custom-service-gen/generator/build.gradle.kts
+++ b/examples/custom-service-gen/generator/build.gradle.kts
@@ -4,6 +4,12 @@ plugins {
 
 val pbandkVersion: String by rootProject.extra
 
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 dependencies {
     compileOnly("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
     compileOnly("pro.streem.pbandk:protoc-gen-pbandk-lib:$pbandkVersion")

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -22,6 +22,12 @@ application {
     applicationName = "addressbook"
 }
 
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 dependencies {
     implementation("pro.streem.pbandk:pbandk-runtime:$pbandkVersion")
 }
@@ -57,7 +63,6 @@ tasks {
 
     withType<KotlinCompile>().configureEach {
         kotlinOptions {
-            jvmTarget = "1.8"
             freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
         }
     }

--- a/protos/build.gradle.kts
+++ b/protos/build.gradle.kts
@@ -25,6 +25,12 @@ java {
     withJavadocJar()
 }
 
+kotlin {
+    jvmToolchain {
+        (this as JavaToolchainSpec).languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 publishing {
     val protos by publications.creating(MavenPublication::class) {
         from(components["java"])


### PR DESCRIPTION
Without an explicit definition of the Java language version, gradle will default to building artifacts that depend on the same version of Java that gradle was running under. To guarantee that we don't break compatibility with existing pbandk users, we need to explicitly tell gradle to set the language version older than the currently-running Java version.

Also update the example project to use Java 8 when building to ensure that pbandk works correctly in a Java 8 project.

Fixes #211.
