### PR TITLE
Add support for more Kotlin/Native targets

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -54,14 +54,23 @@ jobs:
             ./gradlew build --stacktrace
           else
             ./gradlew compileKotlinIosArm64 \
+                    compileKotlinIosSimulatorArm64 \
                     compileKotlinIosX64 \
+                    compileKotlinTvosArm64 \
+                    compileKotlinTvosSimulatorArm64 \
+                    compileKotlinTvosX64 \
                     compileKotlinMacosArm64 \
                     compileKotlinMacosX64 \
                     compileTestKotlinIosArm64 \
+                    compileTestKotlinIosSimulatorArm64 \
                     compileTestKotlinIosX64 \
+                    compileTestKotlinTvosArm64 \
+                    compileTestKotlinTvosSimulatorArm64 \
+                    compileTestKotlinTvosX64 \
                     compileTestKotlinMacosArm64 \
                     compileTestKotlinMacosX64 \
                     iosX64Test \
+                    tvosX64Test \
                     macosX64Test \
                     --stacktrace
           fi
@@ -87,7 +96,11 @@ jobs:
             ./gradlew publishToMavenLocal
           else
             ./gradlew publishIosArm64PublicationToMavenLocal \
+                    publishIosSimulatorArm64PublicationToMavenLocal \
                     publishIosX64PublicationToMavenLocal \
+                    publishTvosArm64PublicationToMavenLocal \
+                    publishTvosSimulatorArm64PublicationToMavenLocal \
+                    publishTvosX64PublicationToMavenLocal \
                     publishMacosArm64PublicationToMavenLocal \
                     publishMacosX64PublicationToMavenLocal
           fi

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,14 +63,23 @@ jobs:
             ./gradlew build --stacktrace
           else
             ./gradlew compileKotlinIosArm64 \
+                    compileKotlinIosSimulatorArm64 \
                     compileKotlinIosX64 \
+                    compileKotlinTvosArm64 \
+                    compileKotlinTvosSimulatorArm64 \
+                    compileKotlinTvosX64 \
                     compileKotlinMacosArm64 \
                     compileKotlinMacosX64 \
                     compileTestKotlinIosArm64 \
+                    compileTestKotlinIosSimulatorArm64 \
                     compileTestKotlinIosX64 \
+                    compileTestKotlinTvosArm64 \
+                    compileTestKotlinTvosSimulatorArm64 \
+                    compileTestKotlinTvosX64 \
                     compileTestKotlinMacosArm64 \
                     compileTestKotlinMacosX64 \
                     iosX64Test \
+                    tvosX64Test \
                     macosX64Test \
                     --stacktrace
           fi
@@ -96,7 +105,11 @@ jobs:
             ./gradlew publishToMavenLocal
           else
             ./gradlew publishIosArm64PublicationToMavenLocal \
+                    publishIosSimulatorArm64PublicationToMavenLocal \
                     publishIosX64PublicationToMavenLocal \
+                    publishTvosArm64PublicationToMavenLocal \
+                    publishTvosSimulatorArm64PublicationToMavenLocal \
+                    publishTvosX64PublicationToMavenLocal \
                     publishMacosArm64PublicationToMavenLocal \
                     publishMacosX64PublicationToMavenLocal
           fi
@@ -358,7 +371,11 @@ jobs:
           else
             ./gradlew clean \
                     publishIosArm64PublicationToSonatype \
+                    publishIosSimulatorArm64PublicationToSonatype \
                     publishIosX64PublicationToSonatype \
+                    publishTvosArm64PublicationToSonatype \
+                    publishTvosSimulatorArm64PublicationToSonatype \
+                    publishTvosX64PublicationToSonatype \
                     publishMacosArm64PublicationToSonatype \
                     publishMacosX64PublicationToSonatype
           fi

--- a/conformance/lib/build.gradle.kts
+++ b/conformance/lib/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
@@ -18,8 +19,12 @@ kotlin {
         nodejs {}
     }
 
-    macosX64("macos")
     linuxX64("linux")
+    if (DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX && DefaultNativePlatform.getCurrentArchitecture().name == "aarch64") {
+        macosArm64("macos")
+    } else {
+        macosX64("macos")
+    }
     // Uncomment to enable Windows
     // mingwX64("windows")
 

--- a/conformance/native/build.gradle.kts
+++ b/conformance/native/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.nativeplatform.platform.internal.DefaultNativePlatform
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
@@ -6,7 +7,11 @@ plugins {
 
 kotlin {
     linuxX64("linux")
-    macosX64("macos")
+    if (DefaultNativePlatform.getCurrentOperatingSystem().isMacOsX && DefaultNativePlatform.getCurrentArchitecture().name == "aarch64") {
+        macosArm64("macos")
+    } else {
+        macosX64("macos")
+    }
 
     targets.withType<KotlinNativeTarget> {
         binaries {

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -34,10 +34,16 @@ kotlin {
 
     iosArm64()
     iosX64()
+    iosSimulatorArm64()
 
-    macosX64()
-    macosArm64()
+    tvosArm64()
+    tvosX64()
+    tvosSimulatorArm64()
+
+    linuxArm64()
     linuxX64()
+    macosArm64()
+    macosX64()
 
     sourceSets {
         all {


### PR DESCRIPTION
Add `iosSimulatorArm64`, tvOS, and `linuxArm64` targets.

Fixes #218