### PR TITLE
Update enum naming and validation

### DIFF
--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/Namer.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/Namer.kt
@@ -27,13 +27,13 @@ public interface Namer {
         private val disallowedFieldNamePrefixes = setOf(
             "decodeFrom", "encodeTo"
         )
-        private val disallowedValueTypeNames = disallowedTypeNames + setOf(
-            "UNRECOGNIZED"
-        )
         private val kotlinKeywords = setOf(
             "as", "break", "class", "continue", "do", "else", "false", "for", "fun", "if", "in",
             "interface", "is", "null", "object", "package", "return", "super", "this", "throw",
             "true", "try", "typealias", "typeof", "val", "var", "when", "while"
+        )
+        private val disallowedValueTypeNames = disallowedTypeNames + kotlinKeywords + setOf(
+            "UNRECOGNIZED"
         )
 
         override fun newTypeName(preferred: String, nameSet: Collection<String>): String {
@@ -52,11 +52,14 @@ public interface Namer {
 
         override fun newEnumValueTypeName(enumTypeName: String, preferred: String, nameSet: Collection<String>): String {
             val typePrefix = splitWordsToSnakeCase(enumTypeName) + '_'
-            var name = splitWordsToSnakeCase(preferred).substringAfter(typePrefix)
-            name = name.uppercase()
+            var name = splitWordsToSnakeCase(preferred).let { snakeCase ->
+                snakeCase.substringAfter(typePrefix).takeUnless {
+                    "^\\d|\\W".toRegex().matches(it)
+                } ?: snakeCase
+            }.apply { uppercase() }
 
             while (nameSet.contains(name) ||
-                    disallowedValueTypeNames.contains(name) ||
+                    disallowedValueTypeNames.any { it.equals(name, true) } ||
                     enumTypeName == name) {
                 name += '_'
             }

--- a/protoc-gen-pbandk/lib/src/jvmTest/kotlin/CodeGeneratorTest.kt
+++ b/protoc-gen-pbandk/lib/src/jvmTest/kotlin/CodeGeneratorTest.kt
@@ -30,8 +30,10 @@ class CodeGeneratorTest {
         // Ensure classes and fields were generated successfully
         val message1Clazz = result.classLoader.loadClass("foobar.Message1").kotlin
         val message2Clazz = result.classLoader.loadClass("foobar.Message2").kotlin
+        val message3Clazz = result.classLoader.loadClass("foobar.Variable").kotlin
         message1Clazz.declaredMemberProperties.single { it.name == "intVal" }
         message2Clazz.declaredMemberProperties.single { it.name == "strVal" }
+        message3Clazz.declaredMemberProperties.single { it.name == "name" }
     }
 
     @Test
@@ -123,6 +125,8 @@ class CodeGeneratorTest {
         // Ensure classes and fields were generated successfully
         result.classLoader.loadClass("newname.pkg.Message1").kotlin
         result.classLoader.loadClass("newname.pkg.Message2").kotlin
+        result.classLoader.loadClass("newname.pkg.Variable\$variable_1").kotlin
+        result.classLoader.loadClass("newname.pkg.Variable\$class_").kotlin
 
         assertFails { result.classLoader.loadClass("foobar.Message1").kotlin }
     }
@@ -138,6 +142,8 @@ class CodeGeneratorTest {
         // New package name should prefix the existing one.
         result.classLoader.loadClass("newname.pkg.foobar.Message1").kotlin
         result.classLoader.loadClass("newname.pkg.foobar.Message2").kotlin
+        result.classLoader.loadClass("newname.pkg.foobar.Variable\$variable_1").kotlin
+        result.classLoader.loadClass("newname.pkg.foobar.Variable\$class_").kotlin
 
         assertFails { result.classLoader.loadClass("foobar.Message1").kotlin }
     }
@@ -152,6 +158,8 @@ class CodeGeneratorTest {
         // New package name should overwrite the old one
         result.classLoader.loadClass("newname.pkg.Message1").kotlin
         result.classLoader.loadClass("newname.pkg.Message2").kotlin
+        result.classLoader.loadClass("newname.pkg.Variable\$variable_1").kotlin
+        result.classLoader.loadClass("newname.pkg.Variable\$class_").kotlin
 
         assertFails { result.classLoader.loadClass("foobar.Message1").kotlin }
     }
@@ -166,6 +174,8 @@ class CodeGeneratorTest {
         // New package name shouldn't change.
         result.classLoader.loadClass("foobar.Message1").kotlin
         result.classLoader.loadClass("foobar.Message2").kotlin
+        result.classLoader.loadClass("foobar.Variable\$variable_1").kotlin
+        result.classLoader.loadClass("foobar.Variable\$class_").kotlin
 
 
         assertFails { result.classLoader.loadClass("newname.pkg.Message1").kotlin }

--- a/protoc-gen-pbandk/lib/src/jvmTest/resources/protos/simple.proto
+++ b/protoc-gen-pbandk/lib/src/jvmTest/resources/protos/simple.proto
@@ -8,3 +8,9 @@ message Message1 {
 message Message2 {
     string str_val = 1;
 }
+
+enum Variable {
+    NONE = 0;
+    VARIABLE_1 = 1;
+    VARIABLE_CLASS = 2;
+}


### PR DESCRIPTION
Enum namings could end up being named as an invalid kotlin identifier, so updated the enum name generation to avoid invalid names.

Fixes https://github.com/streem/pbandk/issues/226