### PR TITLE
feature: Added mingwX64 and mingwX86 native targets 

### DIFF
--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -44,6 +44,8 @@ kotlin {
     linuxX64()
     macosArm64()
     macosX64()
+    mingwX64()
+    mingwX86()
 
     sourceSets {
         all {

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -28,6 +28,8 @@ kotlin {
     linuxX64()
     macosArm64()
     macosX64()
+    mingwX64()
+    mingwX86()
 
     sourceSets {
         all {


### PR DESCRIPTION
I've seen a couple of people (myself included) want to use mingw as Kotlin/Native target to build applications that execute under windows. See https://github.com/streem/pbandk/issues/251, https://github.com/streem/pbandk/issues/233 and https://github.com/streem/pbandk/issues/229

After reading @garyp's comment (https://github.com/streem/pbandk/issues/233#issuecomment-1278355568) it sounded like an easy task. 

I have added the `mingwX64()` and `mingwX86()` as kotlin targets to `build.gradle.kts` for modules 
* runtime
* test-types

@garyp: please advise if that is all that is required