### PR TITLE
Update to Kotlin 2.0.10 and associated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.iml
 .gradle
 .idea
+.kotlin
 build
 local.properties
 /failing_tests.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
+* Updated dependencies to Kotlin 2.0.10 and kotlinx-serialization 1.7.1. (PR [#270])
+
 ### Fixed
+
+[#270]: https://github.com/streem/pbandk/pull/270
 
 
 ## [0.15.0] - 2024-08-05

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,12 +1,12 @@
 object Versions {
-    const val androidGradlePlugin = "8.2.0"
+    const val androidGradlePlugin = "8.5.0"
     const val androidMinSdk = 21
-    const val androidTargetSdk = 30
-    const val binaryCompatibilityValidatorGradlePlugin = "0.14.0"
+    const val androidTargetSdk = 34
+    const val binaryCompatibilityValidatorGradlePlugin = "0.16.3"
     const val jvmTarget = "1.8"
-    const val kotlin = "1.9.24"
-    const val kotlinCoroutines = "1.8.0"
-    const val kotlinSerialization = "1.6.3"
+    const val kotlin = "2.0.10"
+    const val kotlinCoroutines = "1.9.0-RC"
+    const val kotlinSerialization = "1.7.1"
     const val robolectric = "11-robolectric-6757853"
     const val osDetectorGradlePlugin = "1.7.3"
     const val protoc = "3.19.1"

--- a/conformance/native/build.gradle.kts
+++ b/conformance/native/build.gradle.kts
@@ -16,10 +16,6 @@ kotlin {
     targets.withType<KotlinNativeTarget> {
         binaries {
             executable("conformance")
-            configureEach {
-                // See https://youtrack.jetbrains.com/issue/KT-44148
-                freeCompilerArgs += "-Xdisable-phases=EscapeAnalysis"
-            }
         }
     }
 

--- a/examples/browser-js/build.gradle.kts
+++ b/examples/browser-js/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("multiplatform") version "1.9.24" apply false
+    kotlin("multiplatform") version "2.0.10" apply false
     id("com.google.protobuf") version "0.9.4" apply false
 }
 

--- a/examples/browser-js/kotlin-js-store/yarn.lock
+++ b/examples/browser-js/kotlin-js-store/yarn.lock
@@ -12,6 +12,18 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@isaacs/cliui@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"
+  integrity sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==
+  dependencies:
+    string-width "^5.1.2"
+    string-width-cjs "npm:string-width@^4.2.0"
+    strip-ansi "^7.0.1"
+    strip-ansi-cjs "npm:strip-ansi@^6.0.1"
+    wrap-ansi "^8.1.0"
+    wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
 "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.5"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz#dcce6aff74bdf6dad1a95802b69b04a2fcb1fb36"
@@ -52,10 +64,35 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@jsonjoy.com/base64@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/base64/-/base64-1.1.2.tgz#cf8ea9dcb849b81c95f14fc0aaa151c6b54d2578"
+  integrity sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==
+
+"@jsonjoy.com/json-pack@^1.0.3":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/json-pack/-/json-pack-1.0.4.tgz#ab59c642a2e5368e8bcfd815d817143d4f3035d0"
+  integrity sha512-aOcSN4MeAtFROysrbqG137b7gaDDSmVrl5mpo6sT/w+kcXpWnzhMjmY/Fh/sDx26NBxyIE7MB1seqLeCAzy9Sg==
+  dependencies:
+    "@jsonjoy.com/base64" "^1.1.1"
+    "@jsonjoy.com/util" "^1.1.2"
+    hyperdyperid "^1.2.0"
+    thingies "^1.20.0"
+
+"@jsonjoy.com/util@^1.1.2":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@jsonjoy.com/util/-/util-1.2.0.tgz#0fe9a92de72308c566ebcebe8b5a3f01d3149df2"
+  integrity sha512-4B8B+3vFsY4eo33DMKyJPlQ3sBMpPFUZK2dr3O3rXrOGKKbYG44J0XSFkDo1VOQiri5HFEhIeVvItjR2xcazmg==
+
 "@leichtgewicht/ip-codec@^2.0.1":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz#4fc56c15c580b9adb7dc3c333a134e540b44bfb1"
   integrity sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==
+
+"@pkgjs/parseargs@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
+  integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
@@ -123,14 +160,14 @@
     "@types/connect" "*"
     "@types/node" "*"
 
-"@types/bonjour@^3.5.9":
+"@types/bonjour@^3.5.13":
   version "3.5.13"
   resolved "https://registry.yarnpkg.com/@types/bonjour/-/bonjour-3.5.13.tgz#adf90ce1a105e81dd1f9c61fdc5afda1bfb92956"
   integrity sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==
   dependencies:
     "@types/node" "*"
 
-"@types/connect-history-api-fallback@^1.3.5":
+"@types/connect-history-api-fallback@^1.5.4":
   version "1.5.4"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz#7de71645a103056b48ac3ce07b3520b819c1d5b3"
   integrity sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==
@@ -173,7 +210,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0":
+"@types/estree@*", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -188,7 +225,7 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@*", "@types/express@^4.17.13":
+"@types/express@*", "@types/express@^4.17.21":
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
   integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
@@ -244,10 +281,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
   integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
-"@types/retry@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
+"@types/retry@0.12.2":
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.2.tgz#ed279a64fa438bb69f2480eda44937912bb7480a"
+  integrity sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==
 
 "@types/send@*":
   version "0.17.4"
@@ -257,14 +294,14 @@
     "@types/mime" "^1"
     "@types/node" "*"
 
-"@types/serve-index@^1.9.1":
+"@types/serve-index@^1.9.4":
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/@types/serve-index/-/serve-index-1.9.4.tgz#e6ae13d5053cb06ed36392110b4f9a49ac4ec898"
   integrity sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==
   dependencies:
     "@types/express" "*"
 
-"@types/serve-static@*", "@types/serve-static@^1.13.10":
+"@types/serve-static@*", "@types/serve-static@^1.15.5":
   version "1.15.7"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.15.7.tgz#22174bbd74fb97fe303109738e9b5c2f3064f714"
   integrity sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==
@@ -273,21 +310,21 @@
     "@types/node" "*"
     "@types/send" "*"
 
-"@types/sockjs@^0.3.33":
+"@types/sockjs@^0.3.36":
   version "0.3.36"
   resolved "https://registry.yarnpkg.com/@types/sockjs/-/sockjs-0.3.36.tgz#ce322cf07bcc119d4cbf7f88954f3a3bd0f67535"
   integrity sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==
   dependencies:
     "@types/node" "*"
 
-"@types/ws@^8.5.1":
+"@types/ws@^8.5.10":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"
   integrity sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A==
   dependencies:
     "@types/node" "*"
 
-"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.11.5":
+"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
   integrity sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==
@@ -353,7 +390,7 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
   integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
 
-"@webassemblyjs/wasm-edit@^1.11.5":
+"@webassemblyjs/wasm-edit@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz#9f9f3ff52a14c980939be0ef9d5df9ebc678ae3b"
   integrity sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==
@@ -388,7 +425,7 @@
     "@webassemblyjs/wasm-gen" "1.12.1"
     "@webassemblyjs/wasm-parser" "1.12.1"
 
-"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.11.5":
+"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz#c47acb90e6f083391e3fa61d113650eea1e95937"
   integrity sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==
@@ -408,17 +445,17 @@
     "@webassemblyjs/ast" "1.12.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^2.1.0":
+"@webpack-cli/configtest@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
   integrity sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==
 
-"@webpack-cli/info@^2.0.1":
+"@webpack-cli/info@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
   integrity sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==
 
-"@webpack-cli/serve@^2.0.3":
+"@webpack-cli/serve@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
@@ -433,11 +470,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
-  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
-
 accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -446,7 +478,7 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.7.6:
+acorn-import-assertions@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
@@ -510,12 +542,22 @@ ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-regex@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.1.tgz#3183e38fae9a65d7cb5e53945cd5897d0260a06a"
+  integrity sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==
+
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^6.1.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
+  integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
 
 anymatch@~3.1.2:
   version "3.1.3"
@@ -573,7 +615,7 @@ body-parser@1.20.2, body-parser@^1.19.0:
     type-is "~1.6.18"
     unpipe "1.0.0"
 
-bonjour-service@^1.0.11:
+bonjour-service@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/bonjour-service/-/bonjour-service-1.2.1.tgz#eb41b3085183df3321da1264719fbada12478d02"
   integrity sha512-oSzCS2zV14bh2kji6vNe7vrpJYCHGvcZnlffFQ1MEoX/WOeQ/teD8SYWKR942OI3INjq8OMNJlbPK5LLLUxFDw==
@@ -608,20 +650,27 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.14.5:
-  version "4.23.1"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.1.tgz#ce4af0534b3d37db5c1a4ca98b9080f985041e96"
-  integrity sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==
+browserslist@^4.21.10:
+  version "4.23.2"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.2.tgz#244fe803641f1c19c28c48c4b6ec9736eb3d32ed"
+  integrity sha512-qkqSyistMYdxAcw+CzbZwlBy8AGmS/eEWs+sEV5TnLRGDOL+C5M2EnH6tlZyg0YoAxGJAFKh61En9BR941GnHA==
   dependencies:
-    caniuse-lite "^1.0.30001629"
-    electron-to-chromium "^1.4.796"
+    caniuse-lite "^1.0.30001640"
+    electron-to-chromium "^1.4.820"
     node-releases "^2.0.14"
-    update-browserslist-db "^1.0.16"
+    update-browserslist-db "^1.1.0"
 
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
+bundle-name@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bundle-name/-/bundle-name-4.1.0.tgz#f3b96b34160d6431a19d7688135af7cfb8797889"
+  integrity sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==
+  dependencies:
+    run-applescript "^7.0.0"
 
 bytes@3.0.0:
   version "3.0.0"
@@ -649,10 +698,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001629:
-  version "1.0.30001639"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001639.tgz#972b3a6adeacdd8f46af5fc7f771e9639f6c1521"
-  integrity sha512-eFHflNTBIlFwP2AIKaYuBQN/apnUoKNhBdza8ZnW/h2di4LCZ4xFqYlxUxo+LQ76KFI1PGcC1QDxMbxTZpSCAg==
+caniuse-lite@^1.0.30001640:
+  version "1.0.30001641"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001641.tgz#3572862cd18befae3f637f2a1101cc033c6782ac"
+  integrity sha512-Phv5thgl67bHYo1TtMY/MurjkHhV4EDaCosezRXgZ8jzA/Ub+wjxAvbGvjoFENStinwi5kCyOYV3mi5tOGykwA==
 
 chalk@^4.1.0:
   version "4.1.2"
@@ -677,7 +726,7 @@ chokidar@3.5.3:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chokidar@^3.5.1, chokidar@^3.5.3:
+chokidar@^3.5.1, chokidar@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
   integrity sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==
@@ -822,7 +871,7 @@ cors@~2.8.5:
     object-assign "^4"
     vary "^1"
 
-cross-spawn@^7.0.3:
+cross-spawn@^7.0.0, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -867,6 +916,19 @@ decamelize@^4.0.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-4.0.0.tgz#aa472d7bf660eb15f3494efd531cab7f2a709837"
   integrity sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==
 
+default-browser-id@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/default-browser-id/-/default-browser-id-5.0.0.tgz#a1d98bf960c15082d8a3fa69e83150ccccc3af26"
+  integrity sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==
+
+default-browser@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/default-browser/-/default-browser-5.2.1.tgz#7b7ba61204ff3e425b556869ae6d3e9d9f1712cf"
+  integrity sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==
+  dependencies:
+    bundle-name "^4.1.0"
+    default-browser-id "^5.0.0"
+
 default-gateway@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/default-gateway/-/default-gateway-6.0.3.tgz#819494c888053bdb743edbf343d6cdf7f2943a71"
@@ -883,10 +945,10 @@ define-data-property@^1.1.4:
     es-errors "^1.3.0"
     gopd "^1.0.1"
 
-define-lazy-prop@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
-  integrity sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==
+define-lazy-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz#dbb19adfb746d7fc6d734a06b72f4a00d021255f"
+  integrity sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==
 
 depd@2.0.0:
   version "2.0.0"
@@ -935,20 +997,30 @@ dom-serialize@^2.2.1:
     extend "^3.0.0"
     void-elements "^2.0.0"
 
+eastasianwidth@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
+  integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.796:
-  version "1.4.816"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.816.tgz#3624649d1e7fde5cdbadf59d31a524245d8ee85f"
-  integrity sha512-EKH5X5oqC6hLmiS7/vYtZHZFTNdhsYG5NVPRN6Yn0kQHNBlT59+xSM8HBy66P5fxWpKgZbPqb+diC64ng295Jw==
+electron-to-chromium@^1.4.820:
+  version "1.4.827"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.827.tgz#76068ed1c71dd3963e1befc8ae815004b2da6a02"
+  integrity sha512-VY+J0e4SFcNfQy19MEoMdaIcZLmDCprqvBtkii1WTCTQHpRvf5N8+3kTYCgL/PcntvwQvmMJWTuDPsq+IlhWKQ==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+emoji-regex@^9.2.2:
+  version "9.2.2"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
+  integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -976,7 +1048,7 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.17.1"
 
-enhanced-resolve@^5.13.0:
+enhanced-resolve@^5.16.0:
   version "5.17.0"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz#d037603789dd9555b89aaec7eb78845c49089bc5"
   integrity sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==
@@ -1211,6 +1283,14 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.6.tgz#7f815c0cda4249c74ff09e95ef97c23b5fd0399b"
   integrity sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==
 
+foreground-child@^3.1.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/foreground-child/-/foreground-child-3.2.1.tgz#767004ccf3a5b30df39bed90718bab43fe0a59f7"
+  integrity sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    signal-exit "^4.0.1"
+
 format-util@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/format-util/-/format-util-1.0.5.tgz#1ffb450c8a03e7bccffe40643180918cc297d271"
@@ -1234,11 +1314,6 @@ fs-extra@^8.1.0:
     graceful-fs "^4.2.0"
     jsonfile "^4.0.0"
     universalify "^0.1.0"
-
-fs-monkey@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-1.0.6.tgz#8ead082953e88d992cf3ff844faa907b26756da2"
-  integrity sha512-b1FMfwetIKymC0eioW7mTywihSQE4oLzQn1dB6rZB5fx/3NpNEdAWeCSMB+60/AeT0TCXsxzAlcYVEFCTAksWg==
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -1288,17 +1363,28 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
+
+glob@^10.3.7:
+  version "10.4.5"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
+  integrity sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==
+  dependencies:
+    foreground-child "^3.1.0"
+    jackspeak "^3.1.2"
+    minimatch "^9.0.4"
+    minipass "^7.1.2"
+    package-json-from-dist "^1.0.0"
+    path-scurry "^1.11.1"
 
 glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
@@ -1319,7 +1405,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1373,7 +1459,7 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
-html-entities@^2.3.2:
+html-entities@^2.4.0:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.5.2.tgz#201a3cf95d3a15be7099521620d19dfb4f65359f"
   integrity sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==
@@ -1434,6 +1520,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+hyperdyperid@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/hyperdyperid/-/hyperdyperid-1.2.0.tgz#59668d323ada92228d2a869d3e474d5a33b69e6b"
+  integrity sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==
+
 iconv-lite@0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -1484,7 +1575,7 @@ ipaddr.js@1.9.1:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz#bff38543eeb8984825079ff3a2a8e6cbd46781b3"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-ipaddr.js@^2.0.1:
+ipaddr.js@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-2.2.0.tgz#d33fa7bac284f4de7af949638c9d68157c6b92e8"
   integrity sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==
@@ -1503,10 +1594,10 @@ is-core-module@^2.13.0:
   dependencies:
     hasown "^2.0.2"
 
-is-docker@^2.0.0, is-docker@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.2.1.tgz#33eeabe23cfe86f14bde4408a02c0cfb853acdaa"
-  integrity sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==
+is-docker@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-3.0.0.tgz#90093aa3106277d8a77a5910dbae71747e15a200"
+  integrity sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -1524,6 +1615,18 @@ is-glob@^4.0.1, is-glob@~4.0.1:
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
+
+is-inside-container@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-inside-container/-/is-inside-container-1.0.0.tgz#e81fba699662eb31dbdaf26766a61d4814717ea4"
+  integrity sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==
+  dependencies:
+    is-docker "^3.0.0"
+
+is-network-error@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-network-error/-/is-network-error-1.1.0.tgz#d26a760e3770226d11c169052f266a4803d9c997"
+  integrity sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==
 
 is-number@^7.0.0:
   version "7.0.0"
@@ -1557,12 +1660,12 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-wsl@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
-  integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+is-wsl@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-3.1.0.tgz#e1c657e39c10090afcbedec61720f6b924c3cbd2"
+  integrity sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==
   dependencies:
-    is-docker "^2.0.0"
+    is-inside-container "^1.0.0"
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -1583,6 +1686,15 @@ isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
+
+jackspeak@^3.1.2:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/jackspeak/-/jackspeak-3.4.3.tgz#8833a9d89ab4acde6188942bd1c53b6390ed5a8a"
+  integrity sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==
+  dependencies:
+    "@isaacs/cliui" "^8.0.2"
+  optionalDependencies:
+    "@pkgjs/parseargs" "^0.11.0"
 
 jest-worker@^27.4.5:
   version "27.5.1"
@@ -1643,19 +1755,19 @@ karma-sourcemap-loader@0.4.0:
   dependencies:
     graceful-fs "^4.2.10"
 
-karma-webpack@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.0.tgz#2a2c7b80163fe7ffd1010f83f5507f95ef39f840"
-  integrity sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==
+karma-webpack@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.1.tgz#4eafd31bbe684a747a6e8f3e4ad373e53979ced4"
+  integrity sha512-oo38O+P3W2mSPCSUrQdySSPv1LvPpXP+f+bBimNomS5sW+1V4SuhCuW8TfJzV+rDv921w2fDSDw0xJbPe6U+kQ==
   dependencies:
     glob "^7.1.3"
-    minimatch "^3.0.4"
+    minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.2.tgz#a983f874cee6f35990c4b2dcc3d274653714de8e"
-  integrity sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==
+karma@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
+  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1676,7 +1788,7 @@ karma@6.4.2:
     qjobs "^1.2.0"
     range-parser "^1.2.1"
     rimraf "^3.0.2"
-    socket.io "^4.4.1"
+    socket.io "^4.7.2"
     source-map "^0.6.1"
     tmp "^0.2.1"
     ua-parser-js "^0.7.30"
@@ -1687,7 +1799,7 @@ kind-of@^6.0.2:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
-launch-editor@^2.6.0:
+launch-editor@^2.6.1:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/launch-editor/-/launch-editor-2.8.0.tgz#7255d90bdba414448e2138faa770a74f28451305"
   integrity sha512-vJranOAJrI/llyWGRQqiDM+adrw+k83fvmmx3+nV47g3+36xM15jE+zyZ6Ffel02+xSvuM0b2GDRosXZkbb6wA==
@@ -1743,17 +1855,25 @@ long@^5.0.0:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
+lru-cache@^10.2.0:
+  version "10.4.3"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
+  integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==
 
-memfs@^3.4.3:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-3.6.0.tgz#d7a2110f86f79dd950a8b6df6d57bc984aa185f6"
-  integrity sha512-EGowvkkgbMcIChjMTMkESFDbZeSh8xZ7kNSF0hAiAN4Jh6jgHCRS0Ga/+C8y6Au+oqpezRHCfPsmJ2+DwAgiwQ==
+memfs@^4.6.0:
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/memfs/-/memfs-4.9.3.tgz#41a3218065fe3911d9eba836250c8f4e43f816bc"
+  integrity sha512-bsYSSnirtYTWi1+OPMFb0M048evMKyUYe0EbtuGQgq6BVQM1g1W8/KIUJCCvjgI/El0j6Q4WsmMiBwLUBSw8LA==
   dependencies:
-    fs-monkey "^1.0.4"
+    "@jsonjoy.com/json-pack" "^1.0.3"
+    "@jsonjoy.com/util" "^1.1.2"
+    tree-dump "^1.0.1"
+    tslib "^2.0.0"
 
 merge-descriptors@1.0.1:
   version "1.0.1"
@@ -1824,10 +1944,29 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3, minimatch@^9.0.4:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
+
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
+  integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
 mkdirp@^0.5.5:
   version "0.5.6"
@@ -1836,10 +1975,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+mocha@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -1848,13 +1987,12 @@ mocha@10.2.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.2.0"
+    glob "8.1.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -1885,11 +2023,6 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -1938,7 +2071,7 @@ obuf@^1.0.0, obuf@^1.1.2:
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.2.tgz#09bea3343d41859ebd446292d11c9d4db619084e"
   integrity sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==
 
-on-finished@2.4.1:
+on-finished@2.4.1, on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
   integrity sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==
@@ -1971,14 +2104,15 @@ onetime@^5.1.2:
   dependencies:
     mimic-fn "^2.1.0"
 
-open@^8.0.9:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/open/-/open-8.4.2.tgz#5b5ffe2a8f793dcd2aad73e550cb87b59cb084f9"
-  integrity sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==
+open@^10.0.3:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/open/-/open-10.1.0.tgz#a7795e6e5d519abe4286d9937bb24b51122598e1"
+  integrity sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==
   dependencies:
-    define-lazy-prop "^2.0.0"
-    is-docker "^2.1.1"
-    is-wsl "^2.2.0"
+    default-browser "^5.2.1"
+    define-lazy-prop "^3.0.0"
+    is-inside-container "^1.0.0"
+    is-wsl "^3.1.0"
 
 p-limit@^2.2.0:
   version "2.3.0"
@@ -2008,18 +2142,24 @@ p-locate@^5.0.0:
   dependencies:
     p-limit "^3.0.2"
 
-p-retry@^4.5.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
-  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
+p-retry@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-6.2.0.tgz#8d6df01af298750009691ce2f9b3ad2d5968f3bd"
+  integrity sha512-JA6nkq6hKyWLLasXQXUrO4z8BUZGUt/LjlJxx8Gb2+2ntodU/SS63YZ8b0LUTbQ8ZB9iwOfhEPhg4ykKnn2KsA==
   dependencies:
-    "@types/retry" "0.12.0"
+    "@types/retry" "0.12.2"
+    is-network-error "^1.0.0"
     retry "^0.13.1"
 
 p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+package-json-from-dist@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz#e501cd3094b278495eb4258d4c9f6d5ac3019f00"
+  integrity sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -2045,6 +2185,14 @@ path-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
+
+path-scurry@^1.11.1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/path-scurry/-/path-scurry-1.11.1.tgz#7960a668888594a0720b12a911d1a742ab9f11d2"
+  integrity sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==
+  dependencies:
+    lru-cache "^10.2.0"
+    minipass "^5.0.0 || ^6.0.2 || ^7.0.0"
 
 path-to-regexp@0.1.7:
   version "0.1.7"
@@ -2232,6 +2380,18 @@ rimraf@^3.0.2:
   dependencies:
     glob "^7.1.3"
 
+rimraf@^5.0.5:
+  version "5.0.9"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-5.0.9.tgz#c3baa1b886eadc2ec7981a06a593c3d01134ffe9"
+  integrity sha512-3i7b8OcswU6CpU8Ej89quJD4O98id7TtVM5U4Mybh84zQXdrFmDLouWBEEaD/QfO3gDDfH+AGFCGsR7kngzQnA==
+  dependencies:
+    glob "^10.3.7"
+
+run-applescript@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.0.0.tgz#e5a553c2bffd620e169d276c1cd8f1b64778fbeb"
+  integrity sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==
+
 safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
@@ -2247,7 +2407,7 @@ safe-buffer@5.2.1, safe-buffer@>=5.1.0, safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1, schema-utils@^3.1.2:
+schema-utils@^3.1.1, schema-utils@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
@@ -2256,7 +2416,7 @@ schema-utils@^3.1.1, schema-utils@^3.1.2:
     ajv "^6.12.5"
     ajv-keywords "^3.5.2"
 
-schema-utils@^4.0.0:
+schema-utils@^4.0.0, schema-utils@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.2.0.tgz#70d7c93e153a273a805801882ebd3bff20d89c8b"
   integrity sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==
@@ -2271,7 +2431,7 @@ select-hose@^2.0.0:
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
   integrity sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==
 
-selfsigned@^2.1.1:
+selfsigned@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-2.4.1.tgz#560d90565442a3ed35b674034cec4e95dceb4ae0"
   integrity sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==
@@ -2396,6 +2556,11 @@ signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+signal-exit@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
+  integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
+
 socket.io-adapter@~2.5.2:
   version "2.5.5"
   resolved "https://registry.yarnpkg.com/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz#c7a1f9c703d7756844751b6ff9abfc1780664082"
@@ -2412,7 +2577,7 @@ socket.io-parser@~4.2.4:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
-socket.io@^4.4.1:
+socket.io@^4.7.2:
   version "4.7.5"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
   integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
@@ -2439,12 +2604,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
-source-map-loader@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
-  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
+source-map-loader@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-5.0.0.tgz#f593a916e1cc54471cfc8851b905c8a845fc7e38"
+  integrity sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==
   dependencies:
-    abab "^2.0.6"
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
@@ -2503,7 +2667,7 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-string-width@^4.1.0, string-width@^4.2.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2511,6 +2675,15 @@ string-width@^4.1.0, string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
+
+string-width@^5.0.1, string-width@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
+  integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
+  dependencies:
+    eastasianwidth "^0.2.0"
+    emoji-regex "^9.2.2"
+    strip-ansi "^7.0.1"
 
 string_decoder@^1.1.1:
   version "1.3.0"
@@ -2526,12 +2699,19 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.0.1:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-final-newline@^2.0.0:
   version "2.0.0"
@@ -2567,7 +2747,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-terser-webpack-plugin@^5.3.7:
+terser-webpack-plugin@^5.3.10:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
@@ -2587,6 +2767,11 @@ terser@^5.26.0:
     acorn "^8.8.2"
     commander "^2.20.0"
     source-map-support "~0.5.20"
+
+thingies@^1.20.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/thingies/-/thingies-1.21.0.tgz#e80fbe58fd6fdaaab8fad9b67bd0a5c943c445c1"
+  integrity sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==
 
 thunky@^1.0.2:
   version "1.1.0"
@@ -2610,6 +2795,16 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tree-dump@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tree-dump/-/tree-dump-1.0.2.tgz#c460d5921caeb197bde71d0e9a7b479848c5b8ac"
+  integrity sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==
+
+tslib@^2.0.0:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
+  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+
 type-is@~1.6.18:
   version "1.6.18"
   resolved "https://registry.yarnpkg.com/type-is/-/type-is-1.6.18.tgz#4e552cd05df09467dcbc4ef739de89f2cf37c131"
@@ -2618,10 +2813,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 ua-parser-js@^0.7.30:
   version "0.7.38"
@@ -2643,10 +2838,10 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-update-browserslist-db@^1.0.16:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz#f6d489ed90fb2f07d67784eb3f53d7891f736356"
-  integrity sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==
+update-browserslist-db@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz#7ca61c0d8650766090728046e416a8cde682859e"
+  integrity sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==
   dependencies:
     escalade "^3.1.2"
     picocolors "^1.0.1"
@@ -2683,7 +2878,7 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
-watchpack@^2.4.0:
+watchpack@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.1.tgz#29308f2cac150fa8e4c92f90e0ec954a9fed7fff"
   integrity sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==
@@ -2698,15 +2893,15 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   dependencies:
     minimalistic-assert "^1.0.0"
 
-webpack-cli@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.0.tgz#abc4b1f44b50250f2632d8b8b536cfe2f6257891"
-  integrity sha512-a7KRJnCxejFoDpYTOwzm5o21ZXMaNqtRlvS183XzGDUPRdVEzJNImcQokqYZ8BNTnk9DkKiuWxw75+DCCoZ26w==
+webpack-cli@5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
+  integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^2.1.0"
-    "@webpack-cli/info" "^2.0.1"
-    "@webpack-cli/serve" "^2.0.3"
+    "@webpack-cli/configtest" "^2.1.1"
+    "@webpack-cli/info" "^2.0.2"
+    "@webpack-cli/serve" "^2.0.5"
     colorette "^2.0.14"
     commander "^10.0.1"
     cross-spawn "^7.0.3"
@@ -2717,52 +2912,53 @@ webpack-cli@5.1.0:
     rechoir "^0.8.0"
     webpack-merge "^5.7.3"
 
-webpack-dev-middleware@^5.3.1:
-  version "5.3.4"
-  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-5.3.4.tgz#eb7b39281cbce10e104eb2b8bf2b63fce49a3517"
-  integrity sha512-BVdTqhhs+0IfoeAf7EoH5WE+exCmqGerHfDM0IL096Px60Tq2Mn9MAbnaGUe6HiMa41KMCYF19gyzZmBcq/o4Q==
+webpack-dev-middleware@^7.1.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-7.2.1.tgz#2af00538b6e4eda05f5afdd5d711dbebc05958f7"
+  integrity sha512-hRLz+jPQXo999Nx9fXVdKlg/aehsw1ajA9skAneGmT03xwmyuhvF93p6HUKKbWhXdcERtGTzUCtIQr+2IQegrA==
   dependencies:
     colorette "^2.0.10"
-    memfs "^3.4.3"
+    memfs "^4.6.0"
     mime-types "^2.1.31"
+    on-finished "^2.4.1"
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@4.15.0:
-  version "4.15.0"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.15.0.tgz#87ba9006eca53c551607ea0d663f4ae88be7af21"
-  integrity sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==
+webpack-dev-server@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-5.0.4.tgz#cb6ea47ff796b9251ec49a94f24a425e12e3c9b8"
+  integrity sha512-dljXhUgx3HqKP2d8J/fUMvhxGhzjeNVarDLcbO/EWMSgRizDkxHQDZQaLFL5VJY9tRBj2Gz+rvCEYYvhbqPHNA==
   dependencies:
-    "@types/bonjour" "^3.5.9"
-    "@types/connect-history-api-fallback" "^1.3.5"
-    "@types/express" "^4.17.13"
-    "@types/serve-index" "^1.9.1"
-    "@types/serve-static" "^1.13.10"
-    "@types/sockjs" "^0.3.33"
-    "@types/ws" "^8.5.1"
+    "@types/bonjour" "^3.5.13"
+    "@types/connect-history-api-fallback" "^1.5.4"
+    "@types/express" "^4.17.21"
+    "@types/serve-index" "^1.9.4"
+    "@types/serve-static" "^1.15.5"
+    "@types/sockjs" "^0.3.36"
+    "@types/ws" "^8.5.10"
     ansi-html-community "^0.0.8"
-    bonjour-service "^1.0.11"
-    chokidar "^3.5.3"
+    bonjour-service "^1.2.1"
+    chokidar "^3.6.0"
     colorette "^2.0.10"
     compression "^1.7.4"
     connect-history-api-fallback "^2.0.0"
     default-gateway "^6.0.3"
     express "^4.17.3"
     graceful-fs "^4.2.6"
-    html-entities "^2.3.2"
+    html-entities "^2.4.0"
     http-proxy-middleware "^2.0.3"
-    ipaddr.js "^2.0.1"
-    launch-editor "^2.6.0"
-    open "^8.0.9"
-    p-retry "^4.5.0"
-    rimraf "^3.0.2"
-    schema-utils "^4.0.0"
-    selfsigned "^2.1.1"
+    ipaddr.js "^2.1.0"
+    launch-editor "^2.6.1"
+    open "^10.0.3"
+    p-retry "^6.2.0"
+    rimraf "^5.0.5"
+    schema-utils "^4.2.0"
+    selfsigned "^2.4.1"
     serve-index "^1.9.1"
     sockjs "^0.3.24"
     spdy "^4.0.2"
-    webpack-dev-middleware "^5.3.1"
-    ws "^8.13.0"
+    webpack-dev-middleware "^7.1.0"
+    ws "^8.16.0"
 
 webpack-merge@^4.1.5:
   version "4.2.2"
@@ -2785,34 +2981,34 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.82.0:
-  version "5.82.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.0.tgz#3c0d074dec79401db026b4ba0fb23d6333f88e7d"
-  integrity sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==
+webpack@5.91.0:
+  version "5.91.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.91.0.tgz#ffa92c1c618d18c878f06892bbdc3373c71a01d9"
+  integrity sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
-    "@webassemblyjs/ast" "^1.11.5"
-    "@webassemblyjs/wasm-edit" "^1.11.5"
-    "@webassemblyjs/wasm-parser" "^1.11.5"
+    "@types/estree" "^1.0.5"
+    "@webassemblyjs/ast" "^1.12.1"
+    "@webassemblyjs/wasm-edit" "^1.12.1"
+    "@webassemblyjs/wasm-parser" "^1.12.1"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.7.6"
-    browserslist "^4.14.5"
+    acorn-import-assertions "^1.9.0"
+    browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.13.0"
+    enhanced-resolve "^5.16.0"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.9"
+    graceful-fs "^4.2.11"
     json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.1.2"
+    schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
-    watchpack "^2.4.0"
+    terser-webpack-plugin "^5.3.10"
+    watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
 websocket-driver@>=0.5.1, websocket-driver@^0.7.4:
@@ -2853,7 +3049,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -2862,12 +3058,26 @@ wrap-ansi@^7.0.0:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
 
+wrap-ansi@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-8.1.0.tgz#56dc22368ee570face1b49819975d9b9a5ead214"
+  integrity sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==
+  dependencies:
+    ansi-styles "^6.1.0"
+    string-width "^5.0.1"
+    strip-ansi "^7.0.1"
+
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.13.0, ws@~8.17.1:
+ws@^8.16.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
+
+ws@~8.17.1:
   version "8.17.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
   integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==

--- a/examples/custom-service-gen/application/build.gradle.kts
+++ b/examples/custom-service-gen/application/build.gradle.kts
@@ -45,7 +45,7 @@ protobuf {
                 id("pbandk") {
                     option("log=debug")
                     option("kotlin_package=pbandk.examples.greeter.pb")
-                    option("kotlin_service_gen=${project(":generator").buildDir}/libs/generator.jar|pbandk.examples.greeter.Generator")
+                    option("kotlin_service_gen=${project(":generator").layout.buildDirectory.get()}/libs/generator.jar|pbandk.examples.greeter.Generator")
                 }
             }
         }
@@ -55,13 +55,5 @@ protobuf {
 tasks {
     compileJava {
         enabled = false
-    }
-}
-
-// Workaround the Gradle bug resolving multi-platform dependencies.
-// Fix courtesy of https://github.com/square/okio/issues/647
-configurations.forEach {
-    if (it.name.toLowerCase().contains("kapt") || it.name.toLowerCase().contains("proto")) {
-        it.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
     }
 }

--- a/examples/custom-service-gen/build.gradle.kts
+++ b/examples/custom-service-gen/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.24" apply false
+    kotlin("jvm") version "2.0.10" apply false
     id("com.google.protobuf") version "0.9.4" apply false
 }
 

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -59,11 +59,3 @@ tasks {
         enabled = false
     }
 }
-
-// Workaround the Gradle bug resolving multi-platform dependencies.
-// Fix courtesy of https://github.com/square/okio/issues/647
-configurations.forEach {
-    if (it.name.toLowerCase().contains("kapt") || it.name.toLowerCase().contains("proto")) {
-        it.attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage::class.java, Usage.JAVA_RUNTIME))
-    }
-}

--- a/examples/gradle-and-jvm/build.gradle.kts
+++ b/examples/gradle-and-jvm/build.gradle.kts
@@ -2,7 +2,7 @@ import com.google.protobuf.gradle.*
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "1.9.24"
+    kotlin("jvm") version "2.0.10"
     application
     id("com.google.protobuf") version "0.9.4"
 }

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -138,7 +138,7 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0":
+"@types/estree@*", "@types/estree@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
@@ -155,7 +155,7 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.11.5":
+"@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
   integrity sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==
@@ -221,7 +221,7 @@
   resolved "https://registry.yarnpkg.com/@webassemblyjs/utf8/-/utf8-1.11.6.tgz#90f8bc34c561595fe156603be7253cdbcd0fab5a"
   integrity sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA==
 
-"@webassemblyjs/wasm-edit@^1.11.5":
+"@webassemblyjs/wasm-edit@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz#9f9f3ff52a14c980939be0ef9d5df9ebc678ae3b"
   integrity sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==
@@ -256,7 +256,7 @@
     "@webassemblyjs/wasm-gen" "1.12.1"
     "@webassemblyjs/wasm-parser" "1.12.1"
 
-"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.11.5":
+"@webassemblyjs/wasm-parser@1.12.1", "@webassemblyjs/wasm-parser@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz#c47acb90e6f083391e3fa61d113650eea1e95937"
   integrity sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==
@@ -276,17 +276,17 @@
     "@webassemblyjs/ast" "1.12.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^2.1.0":
+"@webpack-cli/configtest@^2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-2.1.1.tgz#3b2f852e91dac6e3b85fb2a314fb8bef46d94646"
   integrity sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==
 
-"@webpack-cli/info@^2.0.1":
+"@webpack-cli/info@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-2.0.2.tgz#cc3fbf22efeb88ff62310cf885c5b09f44ae0fdd"
   integrity sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==
 
-"@webpack-cli/serve@^2.0.3":
+"@webpack-cli/serve@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-2.0.5.tgz#325db42395cd49fe6c14057f9a900e427df8810e"
   integrity sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==
@@ -301,11 +301,6 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-abab@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
-  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
-
 accepts@~1.3.4:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -314,7 +309,7 @@ accepts@~1.3.4:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
-acorn-import-assertions@^1.7.6:
+acorn-import-assertions@^1.9.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz#507276249d684797c84e0734ef84860334cfb1ac"
   integrity sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==
@@ -429,15 +424,15 @@ browser-stdout@1.3.1:
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
   integrity sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==
 
-browserslist@^4.14.5:
-  version "4.23.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.0.tgz#8f3acc2bbe73af7213399430890f86c63a5674ab"
-  integrity sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==
+browserslist@^4.21.10:
+  version "4.23.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.1.tgz#ce4af0534b3d37db5c1a4ca98b9080f985041e96"
+  integrity sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==
   dependencies:
-    caniuse-lite "^1.0.30001587"
-    electron-to-chromium "^1.4.668"
+    caniuse-lite "^1.0.30001629"
+    electron-to-chromium "^1.4.796"
     node-releases "^2.0.14"
-    update-browserslist-db "^1.0.13"
+    update-browserslist-db "^1.0.16"
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -465,10 +460,10 @@ camelcase@^6.0.0:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
-caniuse-lite@^1.0.30001587:
-  version "1.0.30001606"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001606.tgz#b4d5f67ab0746a3b8b5b6d1f06e39c51beb39a9e"
-  integrity sha512-LPbwnW4vfpJId225pwjZJOgX1m9sGfbw/RKJvw/t0QhYOOaTXHvkjVGFGPpvwEzufrjvTlsULnVTxdy4/6cqkg==
+caniuse-lite@^1.0.30001629:
+  version "1.0.30001640"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001640.tgz#32c467d4bf1f1a0faa63fc793c2ba81169e7652f"
+  integrity sha512-lA4VMpW0PSUrFnkmVuEKBUovSWKhj7puyCg8StBChgu298N1AtuF1sKWEvfDuimSEDbhlb/KqPKC3fs1HbuQUA==
 
 chalk@^4.1.0:
   version "4.1.2"
@@ -673,10 +668,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
-electron-to-chromium@^1.4.668:
-  version "1.4.729"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.729.tgz#8477d21e2a50993781950885b2731d92ad532c00"
-  integrity sha512-bx7+5Saea/qu14kmPTDHQxkp2UnziG3iajUQu3BxFvCOnpAJdDbMV4rSl+EqFDkkpNNVUFlR1kDfpL59xfy1HA==
+electron-to-chromium@^1.4.796:
+  version "1.4.820"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.820.tgz#1195660c157535392a09442540a08ee63fea8c40"
+  integrity sha512-kK/4O/YunacfboFEk/BDf7VO1HoPmDudLTJAU9NmXIOSjsV7qVIX3OrI4REZo0VmdqhcpUcncQc6N8Q3aEXlHg==
 
 emoji-regex@^8.0.0:
   version "8.0.0"
@@ -709,10 +704,10 @@ engine.io@~6.5.2:
     engine.io-parser "~5.2.1"
     ws "~8.11.0"
 
-enhanced-resolve@^5.13.0:
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz#65ec88778083056cb32487faa9aef82ed0864787"
-  integrity sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==
+enhanced-resolve@^5.16.0:
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.17.0.tgz#d037603789dd9555b89aaec7eb78845c49089bc5"
+  integrity sha512-dwDPwZL0dmye8Txp2gzFmA6sxALaSvdRDjPH0viLcKrtlOL3tw62nWWweVD1SdILDTJrbrL6tdWVN58Wo6U3eA==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -744,7 +739,7 @@ es-module-lexer@^1.2.1:
   resolved "https://registry.yarnpkg.com/es-module-lexer/-/es-module-lexer-1.5.0.tgz#4878fee3789ad99e065f975fdd3c645529ff0236"
   integrity sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==
 
-escalade@^3.1.1:
+escalade@^3.1.1, escalade@^3.1.2:
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.2.tgz#54076e9ab29ea5bf3d8f1ed62acffbb88272df27"
   integrity sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==
@@ -922,17 +917,16 @@ glob-to-regexp@^0.4.1:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
   integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
 
-glob@7.2.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
-  integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
+glob@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
+  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
     inherits "2"
-    minimatch "^3.0.4"
+    minimatch "^5.0.1"
     once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 glob@^7.1.3, glob@^7.1.7:
   version "7.2.3"
@@ -953,7 +947,7 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.4, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.10, graceful-fs@^4.2.11, graceful-fs@^4.2.4, graceful-fs@^4.2.6:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -1174,19 +1168,19 @@ karma-sourcemap-loader@0.4.0:
   dependencies:
     graceful-fs "^4.2.10"
 
-karma-webpack@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.0.tgz#2a2c7b80163fe7ffd1010f83f5507f95ef39f840"
-  integrity sha512-+54i/cd3/piZuP3dr54+NcFeKOPnys5QeM1IY+0SPASwrtHsliXUiCL50iW+K9WWA7RvamC4macvvQ86l3KtaA==
+karma-webpack@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-5.0.1.tgz#4eafd31bbe684a747a6e8f3e4ad373e53979ced4"
+  integrity sha512-oo38O+P3W2mSPCSUrQdySSPv1LvPpXP+f+bBimNomS5sW+1V4SuhCuW8TfJzV+rDv921w2fDSDw0xJbPe6U+kQ==
   dependencies:
     glob "^7.1.3"
-    minimatch "^3.0.4"
+    minimatch "^9.0.3"
     webpack-merge "^4.1.5"
 
-karma@6.4.2:
-  version "6.4.2"
-  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.2.tgz#a983f874cee6f35990c4b2dcc3d274653714de8e"
-  integrity sha512-C6SU/53LB31BEgRg+omznBEMY4SjHU3ricV6zBcAe1EeILKkeScr+fZXtaI5WyDbkVowJxxAI6h73NcFPmXolQ==
+karma@6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/karma/-/karma-6.4.3.tgz#763e500f99597218bbb536de1a14acc4ceea7ce8"
+  integrity sha512-LuucC/RE92tJ8mlCwqEoRWXP38UMAqpnq98vktmS9SznSoUPPUJQbc91dHcxcunROvfQjdORVA/YFviH+Xci9Q==
   dependencies:
     "@colors/colors" "1.5.0"
     body-parser "^1.19.0"
@@ -1207,7 +1201,7 @@ karma@6.4.2:
     qjobs "^1.2.0"
     range-parser "^1.2.1"
     rimraf "^3.0.2"
-    socket.io "^4.4.1"
+    socket.io "^4.7.2"
     source-map "^0.6.1"
     tmp "^0.2.1"
     ua-parser-js "^0.7.30"
@@ -1307,6 +1301,20 @@ minimatch@^3.0.4, minimatch@^3.1.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^5.0.1:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
+  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+minimatch@^9.0.3:
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.5.tgz#d74f9dd6b57d83d8e98cfb82133b03978bc929e5"
+  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
+  dependencies:
+    brace-expansion "^2.0.1"
+
 minimist@^1.2.3, minimist@^1.2.6:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
@@ -1319,10 +1327,10 @@ mkdirp@^0.5.5:
   dependencies:
     minimist "^1.2.6"
 
-mocha@10.2.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.2.0.tgz#1fd4a7c32ba5ac372e03a17eef435bd00e5c68b8"
-  integrity sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==
+mocha@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.3.0.tgz#0e185c49e6dccf582035c05fa91084a4ff6e3fe9"
+  integrity sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==
   dependencies:
     ansi-colors "4.1.1"
     browser-stdout "1.3.1"
@@ -1331,13 +1339,12 @@ mocha@10.2.0:
     diff "5.0.0"
     escape-string-regexp "4.0.0"
     find-up "5.0.0"
-    glob "7.2.0"
+    glob "8.1.0"
     he "1.2.0"
     js-yaml "4.1.0"
     log-symbols "4.1.0"
     minimatch "5.0.1"
     ms "2.1.3"
-    nanoid "3.3.3"
     serialize-javascript "6.0.0"
     strip-json-comments "3.1.1"
     supports-color "8.1.1"
@@ -1360,11 +1367,6 @@ ms@2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
-
-nanoid@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.3.tgz#fd8e8b7aa761fe807dba2d1b98fb7241bb724a25"
-  integrity sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -1475,10 +1477,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-picocolors@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
-  integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+picocolors@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.1.tgz#a8ad579b571952f0e5d25892de5445bcfe25aaa1"
+  integrity sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
@@ -1616,7 +1618,7 @@ safe-buffer@^5.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
-schema-utils@^3.1.1, schema-utils@^3.1.2:
+schema-utils@^3.1.1, schema-utils@^3.2.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
   integrity sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==
@@ -1701,7 +1703,7 @@ socket.io-parser@~4.2.4:
     "@socket.io/component-emitter" "~3.1.0"
     debug "~4.3.1"
 
-socket.io@^4.4.1:
+socket.io@^4.7.2:
   version "4.7.5"
   resolved "https://registry.yarnpkg.com/socket.io/-/socket.io-4.7.5.tgz#56eb2d976aef9d1445f373a62d781a41c7add8f8"
   integrity sha512-DmeAkF6cwM9jSfmp6Dr/5/mfMwb5Z5qRrSXLpo3Fq5SqyU8CMF15jIN4ZhfSwu35ksM1qmHZDQ/DK5XTccSTvA==
@@ -1719,12 +1721,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
-source-map-loader@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-4.0.1.tgz#72f00d05f5d1f90f80974eda781cbd7107c125f2"
-  integrity sha512-oqXpzDIByKONVY8g1NUPOTQhe0UTU5bWUl32GSkqK2LjJj0HmwTMVKxcUip0RgAYhY1mqgOxjbQM48a0mmeNfA==
+source-map-loader@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/source-map-loader/-/source-map-loader-5.0.0.tgz#f593a916e1cc54471cfc8851b905c8a845fc7e38"
+  integrity sha512-k2Dur7CbSLcAH73sBcIkV5xjPV4SzqO1NJ7+XaQl8if3VODDUj3FNchNGpqgJSKbvUfJuhVdv8K2Eu8/TNl2eA==
   dependencies:
-    abab "^2.0.6"
     iconv-lite "^0.6.3"
     source-map-js "^1.0.2"
 
@@ -1805,7 +1806,7 @@ tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
   integrity sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==
 
-terser-webpack-plugin@^5.3.7:
+terser-webpack-plugin@^5.3.10:
   version "5.3.10"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz#904f4c9193c6fd2a03f693a2150c62a92f40d199"
   integrity sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==
@@ -1851,10 +1852,10 @@ type-is@~1.6.18:
     media-typer "0.3.0"
     mime-types "~2.1.24"
 
-typescript@5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@5.4.3:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.3.tgz#5c6fedd4c87bee01cd7a528a30145521f8e0feff"
+  integrity sha512-KrPd3PKaCLr78MalgiwJnA25Nm8HAmdwN3mYUYZgG/wizIo9EainNVQI9/yDavtVFRN2h3k8uf3GLHuhDMgEHg==
 
 ua-parser-js@^0.7.30:
   version "0.7.37"
@@ -1876,13 +1877,13 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
 
-update-browserslist-db@^1.0.13:
-  version "1.0.13"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz#3c5e4f5c083661bd38ef64b6328c26ed6c8248c4"
-  integrity sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==
+update-browserslist-db@^1.0.16:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz#7ca61c0d8650766090728046e416a8cde682859e"
+  integrity sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==
   dependencies:
-    escalade "^3.1.1"
-    picocolors "^1.0.0"
+    escalade "^3.1.2"
+    picocolors "^1.0.1"
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -1906,7 +1907,7 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==
 
-watchpack@^2.4.0:
+watchpack@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.1.tgz#29308f2cac150fa8e4c92f90e0ec954a9fed7fff"
   integrity sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==
@@ -1914,15 +1915,15 @@ watchpack@^2.4.0:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
 
-webpack-cli@5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.0.tgz#abc4b1f44b50250f2632d8b8b536cfe2f6257891"
-  integrity sha512-a7KRJnCxejFoDpYTOwzm5o21ZXMaNqtRlvS183XzGDUPRdVEzJNImcQokqYZ8BNTnk9DkKiuWxw75+DCCoZ26w==
+webpack-cli@5.1.4:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-5.1.4.tgz#c8e046ba7eaae4911d7e71e2b25b776fcc35759b"
+  integrity sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==
   dependencies:
     "@discoveryjs/json-ext" "^0.5.0"
-    "@webpack-cli/configtest" "^2.1.0"
-    "@webpack-cli/info" "^2.0.1"
-    "@webpack-cli/serve" "^2.0.3"
+    "@webpack-cli/configtest" "^2.1.1"
+    "@webpack-cli/info" "^2.0.2"
+    "@webpack-cli/serve" "^2.0.5"
     colorette "^2.0.14"
     commander "^10.0.1"
     cross-spawn "^7.0.3"
@@ -1954,34 +1955,34 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.82.0:
-  version "5.82.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.82.0.tgz#3c0d074dec79401db026b4ba0fb23d6333f88e7d"
-  integrity sha512-iGNA2fHhnDcV1bONdUu554eZx+XeldsaeQ8T67H6KKHl2nUSwX8Zm7cmzOA46ox/X1ARxf7Bjv8wQ/HsB5fxBg==
+webpack@5.91.0:
+  version "5.91.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.91.0.tgz#ffa92c1c618d18c878f06892bbdc3373c71a01d9"
+  integrity sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
-    "@types/estree" "^1.0.0"
-    "@webassemblyjs/ast" "^1.11.5"
-    "@webassemblyjs/wasm-edit" "^1.11.5"
-    "@webassemblyjs/wasm-parser" "^1.11.5"
+    "@types/estree" "^1.0.5"
+    "@webassemblyjs/ast" "^1.12.1"
+    "@webassemblyjs/wasm-edit" "^1.12.1"
+    "@webassemblyjs/wasm-parser" "^1.12.1"
     acorn "^8.7.1"
-    acorn-import-assertions "^1.7.6"
-    browserslist "^4.14.5"
+    acorn-import-assertions "^1.9.0"
+    browserslist "^4.21.10"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.13.0"
+    enhanced-resolve "^5.16.0"
     es-module-lexer "^1.2.1"
     eslint-scope "5.1.1"
     events "^3.2.0"
     glob-to-regexp "^0.4.1"
-    graceful-fs "^4.2.9"
+    graceful-fs "^4.2.11"
     json-parse-even-better-errors "^2.3.1"
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.1.2"
+    schema-utils "^3.2.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.7"
-    watchpack "^2.4.0"
+    terser-webpack-plugin "^5.3.10"
+    watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 
 which@^1.2.1:

--- a/protoc-gen-pbandk/lib/build.gradle.kts
+++ b/protoc-gen-pbandk/lib/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
         jvmTest {
             dependencies {
                 implementation(kotlin("reflect"))
-                implementation("com.github.tschuchortdev:kotlin-compile-testing:1.5.0")
+                implementation("com.github.tschuchortdev:kotlin-compile-testing:1.6.0")
             }
         }
     }

--- a/protoc-gen-pbandk/lib/src/jvmTest/kotlin/CodeGeneratorTest.kt
+++ b/protoc-gen-pbandk/lib/src/jvmTest/kotlin/CodeGeneratorTest.kt
@@ -3,6 +3,7 @@ package pbandk.gen
 import com.tschuchort.compiletesting.KotlinCompilation
 import com.tschuchort.compiletesting.KotlinCompilation.ExitCode
 import com.tschuchort.compiletesting.SourceFile
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import pbandk.decodeFromStream
 import pbandk.gen.pb.CodeGeneratorRequest
 import pbandk.wkt.FileDescriptorSet
@@ -12,6 +13,7 @@ import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 import kotlin.test.*
 
+@OptIn(ExperimentalCompilerApi::class)
 class CodeGeneratorTest {
     private val descriptorSetOutput = File("build/generateTestProtoDescriptor/fileDescriptor.protoset")
     private val fileDescriptorSet by lazy {

--- a/runtime/api/pbandk-runtime.klib.api
+++ b/runtime/api/pbandk-runtime.klib.api
@@ -1,0 +1,2935 @@
+// Klib ABI Dump
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64]
+// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64]
+// Rendering settings:
+// - Signature version: 2
+// - Show manifest properties: true
+// - Show declarations: true
+
+// Library unique name: <pro.streem.pbandk:pbandk-runtime>
+open annotation class pbandk/ExperimentalProtoJson : kotlin/Annotation { // pbandk/ExperimentalProtoJson|null[0]
+    constructor <init>() // pbandk/ExperimentalProtoJson.<init>|<init>(){}[0]
+}
+
+open annotation class pbandk/ExperimentalProtoReflection : kotlin/Annotation { // pbandk/ExperimentalProtoReflection|null[0]
+    constructor <init>() // pbandk/ExperimentalProtoReflection.<init>|<init>(){}[0]
+}
+
+open annotation class pbandk/PbandkInternal : kotlin/Annotation { // pbandk/PbandkInternal|null[0]
+    constructor <init>() // pbandk/PbandkInternal.<init>|<init>(){}[0]
+}
+
+open annotation class pbandk/PublicForGeneratedCode : kotlin/Annotation { // pbandk/PublicForGeneratedCode|null[0]
+    constructor <init>() // pbandk/PublicForGeneratedCode.<init>|<init>(){}[0]
+}
+
+open annotation class pbandk/TypeRegistryDsl : kotlin/Annotation { // pbandk/TypeRegistryDsl|null[0]
+    constructor <init>() // pbandk/TypeRegistryDsl.<init>|<init>(){}[0]
+}
+
+abstract interface pbandk/ExtendableMessage : pbandk/Message { // pbandk/ExtendableMessage|null[0]
+    abstract val extensionFields // pbandk/ExtendableMessage.extensionFields|{}extensionFields[0]
+        abstract fun <get-extensionFields>(): pbandk/ExtensionFieldSet // pbandk/ExtendableMessage.extensionFields.<get-extensionFields>|<get-extensionFields>(){}[0]
+
+    open fun <#A1: pbandk/Message, #B1: kotlin/Any?> getExtension(pbandk/FieldDescriptor<#A1, #B1>): #B1 // pbandk/ExtendableMessage.getExtension|getExtension(pbandk.FieldDescriptor<0:0,0:1>){0§<pbandk.Message>;1§<kotlin.Any?>}[0]
+}
+
+abstract interface pbandk/Message { // pbandk/Message|null[0]
+    abstract val descriptor // pbandk/Message.descriptor|{}descriptor[0]
+        abstract fun <get-descriptor>(): pbandk/MessageDescriptor<out pbandk/Message> // pbandk/Message.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    abstract val unknownFields // pbandk/Message.unknownFields|{}unknownFields[0]
+        abstract fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk/Message.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    open val protoSize // pbandk/Message.protoSize|{}protoSize[0]
+        open fun <get-protoSize>(): kotlin/Int // pbandk/Message.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+
+    abstract fun plus(pbandk/Message?): pbandk/Message // pbandk/Message.plus|plus(pbandk.Message?){}[0]
+
+    abstract interface <#A1: pbandk/Message> Companion { // pbandk/Message.Companion|null[0]
+        abstract val descriptor // pbandk/Message.Companion.descriptor|{}descriptor[0]
+            abstract fun <get-descriptor>(): pbandk/MessageDescriptor<#A1> // pbandk/Message.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        abstract fun decodeWith(pbandk/MessageDecoder): #A1 // pbandk/Message.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+
+    abstract interface Enum { // pbandk/Message.Enum|null[0]
+        abstract val name // pbandk/Message.Enum.name|{}name[0]
+            abstract fun <get-name>(): kotlin/String? // pbandk/Message.Enum.name.<get-name>|<get-name>(){}[0]
+        abstract val value // pbandk/Message.Enum.value|{}value[0]
+            abstract fun <get-value>(): kotlin/Int // pbandk/Message.Enum.value.<get-value>|<get-value>(){}[0]
+
+        abstract interface <#A2: pbandk/Message.Enum> Companion { // pbandk/Message.Enum.Companion|null[0]
+            abstract fun fromName(kotlin/String): #A2 // pbandk/Message.Enum.Companion.fromName|fromName(kotlin.String){}[0]
+            abstract fun fromValue(kotlin/Int): #A2 // pbandk/Message.Enum.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+    }
+
+    abstract class <#A1: kotlin/Any?> OneOf { // pbandk/Message.OneOf|null[0]
+        constructor <init>(#A1) // pbandk/Message.OneOf.<init>|<init>(1:0){}[0]
+
+        final val value // pbandk/Message.OneOf.value|{}value[0]
+            final fun <get-value>(): #A1 // pbandk/Message.OneOf.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk/Message.OneOf.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk/Message.OneOf.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk/Message.OneOf.toString|toString(){}[0]
+    }
+}
+
+abstract interface pbandk/MessageDecoder { // pbandk/MessageDecoder|null[0]
+    abstract fun <#A1: pbandk/Message> readMessage(pbandk/Message.Companion<#A1>, kotlin/Function2<kotlin/Int, kotlin/Any, kotlin/Unit>): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk/MessageDecoder.readMessage|readMessage(pbandk.Message.Companion<0:0>;kotlin.Function2<kotlin.Int,kotlin.Any,kotlin.Unit>){0§<pbandk.Message>}[0]
+}
+
+abstract interface pbandk/MessageEncoder { // pbandk/MessageEncoder|null[0]
+    abstract fun <#A1: pbandk/Message> writeMessage(#A1) // pbandk/MessageEncoder.writeMessage|writeMessage(0:0){0§<pbandk.Message>}[0]
+}
+
+abstract interface pbandk/TypeRegistry { // pbandk/TypeRegistry|null[0]
+    abstract fun contains(kotlin/String): kotlin/Boolean // pbandk/TypeRegistry.contains|contains(kotlin.String){}[0]
+    abstract fun get(kotlin/String): pbandk/MessageDescriptor<*>? // pbandk/TypeRegistry.get|get(kotlin.String){}[0]
+
+    abstract interface Builder : pbandk/TypeRegistry { // pbandk/TypeRegistry.Builder|null[0]
+        abstract fun add(pbandk/MessageDescriptor<*>) // pbandk/TypeRegistry.Builder.add|add(pbandk.MessageDescriptor<*>){}[0]
+    }
+
+    final object Companion { // pbandk/TypeRegistry.Companion|null[0]
+        final val EMPTY // pbandk/TypeRegistry.Companion.EMPTY|{}EMPTY[0]
+            final fun <get-EMPTY>(): pbandk/TypeRegistry // pbandk/TypeRegistry.Companion.EMPTY.<get-EMPTY>|<get-EMPTY>(){}[0]
+    }
+}
+
+final class <#A: kotlin/Any?, #B: kotlin/Any?> pbandk/MessageMap : kotlin.collections/AbstractMap<#A, #B> { // pbandk/MessageMap|null[0]
+    final val entries // pbandk/MessageMap.entries|{}entries[0]
+        final fun <get-entries>(): kotlin.collections/Set<pbandk/MessageMap.Entry<#A, #B>> // pbandk/MessageMap.entries.<get-entries>|<get-entries>(){}[0]
+
+    final class <#A1: kotlin/Any?, #B1: kotlin/Any?> Builder { // pbandk/MessageMap.Builder|null[0]
+        constructor <init>() // pbandk/MessageMap.Builder.<init>|<init>(){}[0]
+
+        final val entries // pbandk/MessageMap.Builder.entries|{}entries[0]
+            final fun <get-entries>(): kotlin.collections/MutableSet<pbandk/MessageMap.Entry<#A1, #B1>> // pbandk/MessageMap.Builder.entries.<get-entries>|<get-entries>(){}[0]
+
+        final fun fixed(): pbandk/MessageMap<#A1, #B1> // pbandk/MessageMap.Builder.fixed|fixed(){}[0]
+
+        final object Companion { // pbandk/MessageMap.Builder.Companion|null[0]
+            final fun <#A3: kotlin/Any?, #B3: kotlin/Any?> fixed(pbandk/MessageMap.Builder<#A3, #B3>?): pbandk/MessageMap<#A3, #B3> // pbandk/MessageMap.Builder.Companion.fixed|fixed(pbandk.MessageMap.Builder<0:0,0:1>?){0§<kotlin.Any?>;1§<kotlin.Any?>}[0]
+        }
+    }
+
+    final class <#A1: kotlin/Any?, #B1: kotlin/Any?> Entry : kotlin.collections/Map.Entry<#A1, #B1>, pbandk/Message { // pbandk/MessageMap.Entry|null[0]
+        constructor <init>(#A1, #B1, pbandk/MessageMap.Entry.Companion<#A1, #B1>, kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk/MessageMap.Entry.<init>|<init>(1:0;1:1;pbandk.MessageMap.Entry.Companion<1:0,1:1>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk/MessageMap.Entry.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk/MessageMap.Entry<#A1, #B1>> // pbandk/MessageMap.Entry.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val key // pbandk/MessageMap.Entry.key|{}key[0]
+            final fun <get-key>(): #A1 // pbandk/MessageMap.Entry.key.<get-key>|<get-key>(){}[0]
+        final val protoSize // pbandk/MessageMap.Entry.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk/MessageMap.Entry.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val unknownFields // pbandk/MessageMap.Entry.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk/MessageMap.Entry.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+        final val value // pbandk/MessageMap.Entry.value|{}value[0]
+            final fun <get-value>(): #B1 // pbandk/MessageMap.Entry.value.<get-value>|<get-value>(){}[0]
+
+        final fun plus(pbandk/Message?): pbandk/Message // pbandk/MessageMap.Entry.plus|plus(pbandk.Message?){}[0]
+
+        final class <#A2: kotlin/Any?, #B2: kotlin/Any?> Companion : pbandk/Message.Companion<pbandk/MessageMap.Entry<#A2, #B2>> { // pbandk/MessageMap.Entry.Companion|null[0]
+            constructor <init>(pbandk/FieldDescriptor.Type, pbandk/FieldDescriptor.Type) // pbandk/MessageMap.Entry.Companion.<init>|<init>(pbandk.FieldDescriptor.Type;pbandk.FieldDescriptor.Type){}[0]
+
+            final val descriptor // pbandk/MessageMap.Entry.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk/MessageMap.Entry<#A2, #B2>> // pbandk/MessageMap.Entry.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk/MessageMap.Entry<#A2, #B2> // pbandk/MessageMap.Entry.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+}
+
+final class <#A: kotlin/Any?> pbandk/ListWithSize : kotlin.collections/List<#A> { // pbandk/ListWithSize|null[0]
+    constructor <init>(kotlin.collections/List<#A>, kotlin/Function1<#A, kotlin/Int>) // pbandk/ListWithSize.<init>|<init>(kotlin.collections.List<1:0>;kotlin.Function1<1:0,kotlin.Int>){}[0]
+
+    final val list // pbandk/ListWithSize.list|{}list[0]
+        final fun <get-list>(): kotlin.collections/List<#A> // pbandk/ListWithSize.list.<get-list>|<get-list>(){}[0]
+    final val protoSize // pbandk/ListWithSize.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int? // pbandk/ListWithSize.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val size // pbandk/ListWithSize.size|{}size[0]
+        final fun <get-size>(): kotlin/Int // pbandk/ListWithSize.size.<get-size>|<get-size>(){}[0]
+
+    final fun contains(#A): kotlin/Boolean // pbandk/ListWithSize.contains|contains(1:0){}[0]
+    final fun containsAll(kotlin.collections/Collection<#A>): kotlin/Boolean // pbandk/ListWithSize.containsAll|containsAll(kotlin.collections.Collection<1:0>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk/ListWithSize.equals|equals(kotlin.Any?){}[0]
+    final fun get(kotlin/Int): #A // pbandk/ListWithSize.get|get(kotlin.Int){}[0]
+    final fun hashCode(): kotlin/Int // pbandk/ListWithSize.hashCode|hashCode(){}[0]
+    final fun indexOf(#A): kotlin/Int // pbandk/ListWithSize.indexOf|indexOf(1:0){}[0]
+    final fun isEmpty(): kotlin/Boolean // pbandk/ListWithSize.isEmpty|isEmpty(){}[0]
+    final fun iterator(): kotlin.collections/Iterator<#A> // pbandk/ListWithSize.iterator|iterator(){}[0]
+    final fun lastIndexOf(#A): kotlin/Int // pbandk/ListWithSize.lastIndexOf|lastIndexOf(1:0){}[0]
+    final fun listIterator(): kotlin.collections/ListIterator<#A> // pbandk/ListWithSize.listIterator|listIterator(){}[0]
+    final fun listIterator(kotlin/Int): kotlin.collections/ListIterator<#A> // pbandk/ListWithSize.listIterator|listIterator(kotlin.Int){}[0]
+    final fun subList(kotlin/Int, kotlin/Int): kotlin.collections/List<#A> // pbandk/ListWithSize.subList|subList(kotlin.Int;kotlin.Int){}[0]
+    final fun toString(): kotlin/String // pbandk/ListWithSize.toString|toString(){}[0]
+
+    final class <#A1: kotlin/Any?> Builder : kotlin.collections/MutableList<#A1> { // pbandk/ListWithSize.Builder|null[0]
+        constructor <init>() // pbandk/ListWithSize.Builder.<init>|<init>(){}[0]
+
+        final val list // pbandk/ListWithSize.Builder.list|{}list[0]
+            final fun <get-list>(): kotlin.collections/ArrayList<#A1> // pbandk/ListWithSize.Builder.list.<get-list>|<get-list>(){}[0]
+        final val size // pbandk/ListWithSize.Builder.size|{}size[0]
+            final fun <get-size>(): kotlin/Int // pbandk/ListWithSize.Builder.size.<get-size>|<get-size>(){}[0]
+
+        final fun add(#A1): kotlin/Boolean // pbandk/ListWithSize.Builder.add|add(1:0){}[0]
+        final fun add(kotlin/Int, #A1) // pbandk/ListWithSize.Builder.add|add(kotlin.Int;1:0){}[0]
+        final fun addAll(kotlin.collections/Collection<#A1>): kotlin/Boolean // pbandk/ListWithSize.Builder.addAll|addAll(kotlin.collections.Collection<1:0>){}[0]
+        final fun addAll(kotlin/Int, kotlin.collections/Collection<#A1>): kotlin/Boolean // pbandk/ListWithSize.Builder.addAll|addAll(kotlin.Int;kotlin.collections.Collection<1:0>){}[0]
+        final fun clear() // pbandk/ListWithSize.Builder.clear|clear(){}[0]
+        final fun contains(#A1): kotlin/Boolean // pbandk/ListWithSize.Builder.contains|contains(1:0){}[0]
+        final fun containsAll(kotlin.collections/Collection<#A1>): kotlin/Boolean // pbandk/ListWithSize.Builder.containsAll|containsAll(kotlin.collections.Collection<1:0>){}[0]
+        final fun fixed(): pbandk/ListWithSize<#A1> // pbandk/ListWithSize.Builder.fixed|fixed(){}[0]
+        final fun get(kotlin/Int): #A1 // pbandk/ListWithSize.Builder.get|get(kotlin.Int){}[0]
+        final fun indexOf(#A1): kotlin/Int // pbandk/ListWithSize.Builder.indexOf|indexOf(1:0){}[0]
+        final fun isEmpty(): kotlin/Boolean // pbandk/ListWithSize.Builder.isEmpty|isEmpty(){}[0]
+        final fun iterator(): kotlin.collections/MutableIterator<#A1> // pbandk/ListWithSize.Builder.iterator|iterator(){}[0]
+        final fun lastIndexOf(#A1): kotlin/Int // pbandk/ListWithSize.Builder.lastIndexOf|lastIndexOf(1:0){}[0]
+        final fun listIterator(): kotlin.collections/MutableListIterator<#A1> // pbandk/ListWithSize.Builder.listIterator|listIterator(){}[0]
+        final fun listIterator(kotlin/Int): kotlin.collections/MutableListIterator<#A1> // pbandk/ListWithSize.Builder.listIterator|listIterator(kotlin.Int){}[0]
+        final fun remove(#A1): kotlin/Boolean // pbandk/ListWithSize.Builder.remove|remove(1:0){}[0]
+        final fun removeAll(kotlin.collections/Collection<#A1>): kotlin/Boolean // pbandk/ListWithSize.Builder.removeAll|removeAll(kotlin.collections.Collection<1:0>){}[0]
+        final fun removeAt(kotlin/Int): #A1 // pbandk/ListWithSize.Builder.removeAt|removeAt(kotlin.Int){}[0]
+        final fun retainAll(kotlin.collections/Collection<#A1>): kotlin/Boolean // pbandk/ListWithSize.Builder.retainAll|retainAll(kotlin.collections.Collection<1:0>){}[0]
+        final fun set(kotlin/Int, #A1): #A1 // pbandk/ListWithSize.Builder.set|set(kotlin.Int;1:0){}[0]
+        final fun subList(kotlin/Int, kotlin/Int): kotlin.collections/MutableList<#A1> // pbandk/ListWithSize.Builder.subList|subList(kotlin.Int;kotlin.Int){}[0]
+
+        final object Companion { // pbandk/ListWithSize.Builder.Companion|null[0]
+            final fun <#A3: kotlin/Any?> fixed(pbandk/ListWithSize.Builder<#A3>?): pbandk/ListWithSize<out #A3> // pbandk/ListWithSize.Builder.Companion.fixed|fixed(pbandk.ListWithSize.Builder<0:0>?){0§<kotlin.Any?>}[0]
+        }
+
+        // Targets: [js]
+        final fun asJsArrayView(): kotlin.js.collections/JsArray<#A1> // pbandk/ListWithSize.Builder.asJsArrayView|asJsArrayView(){}[0]
+
+        // Targets: [js]
+        final fun asJsReadonlyArrayView(): kotlin.js.collections/JsReadonlyArray<#A1> // pbandk/ListWithSize.Builder.asJsReadonlyArrayView|asJsReadonlyArrayView(){}[0]
+    }
+
+    // Targets: [js]
+    final fun asJsReadonlyArrayView(): kotlin.js.collections/JsReadonlyArray<#A> // pbandk/ListWithSize.asJsReadonlyArrayView|asJsReadonlyArrayView(){}[0]
+}
+
+final class <#A: pbandk/Message, #B: kotlin/Any?> pbandk/FieldDescriptor { // pbandk/FieldDescriptor|null[0]
+    constructor <init>(kotlin.reflect/KProperty0<pbandk/MessageDescriptor<#A>>, kotlin/String, kotlin/Int, pbandk/FieldDescriptor.Type, kotlin.reflect/KProperty1<#A, #B>, kotlin/Boolean = ..., kotlin/String? = ..., pbandk.wkt/FieldOptions = ...) // pbandk/FieldDescriptor.<init>|<init>(kotlin.reflect.KProperty0<pbandk.MessageDescriptor<1:0>>;kotlin.String;kotlin.Int;pbandk.FieldDescriptor.Type;kotlin.reflect.KProperty1<1:0,1:1>;kotlin.Boolean;kotlin.String?;pbandk.wkt.FieldOptions){}[0]
+
+    final val name // pbandk/FieldDescriptor.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk/FieldDescriptor.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk/FieldDescriptor.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/FieldOptions // pbandk/FieldDescriptor.options.<get-options>|<get-options>(){}[0]
+
+    sealed class Type { // pbandk/FieldDescriptor.Type|null[0]
+        constructor <init>() // pbandk/FieldDescriptor.Type.<init>|<init>(){}[0]
+
+        final class <#A2: kotlin/Any> Repeated : pbandk/FieldDescriptor.Type { // pbandk/FieldDescriptor.Type.Repeated|null[0]
+            constructor <init>(pbandk/FieldDescriptor.Type, kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Repeated.<init>|<init>(pbandk.FieldDescriptor.Type;kotlin.Boolean){}[0]
+
+            final val packed // pbandk/FieldDescriptor.Type.Repeated.packed|{}packed[0]
+                final fun <get-packed>(): kotlin/Boolean // pbandk/FieldDescriptor.Type.Repeated.packed.<get-packed>|<get-packed>(){}[0]
+        }
+
+        final class <#A2: kotlin/Any?, #B2: kotlin/Any?> Map : pbandk/FieldDescriptor.Type { // pbandk/FieldDescriptor.Type.Map|null[0]
+            constructor <init>(pbandk/FieldDescriptor.Type, pbandk/FieldDescriptor.Type) // pbandk/FieldDescriptor.Type.Map.<init>|<init>(pbandk.FieldDescriptor.Type;pbandk.FieldDescriptor.Type){}[0]
+        }
+
+        final class <#A2: pbandk/Message.Enum> Enum : pbandk/FieldDescriptor.Type { // pbandk/FieldDescriptor.Type.Enum|null[0]
+            constructor <init>(pbandk/Message.Enum.Companion<#A2>, kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Enum.<init>|<init>(pbandk.Message.Enum.Companion<1:0>;kotlin.Boolean){}[0]
+        }
+
+        final class <#A2: pbandk/Message> Message : pbandk/FieldDescriptor.Type { // pbandk/FieldDescriptor.Type.Message|null[0]
+            constructor <init>(pbandk/Message.Companion<#A2>) // pbandk/FieldDescriptor.Type.Message.<init>|<init>(pbandk.Message.Companion<1:0>){}[0]
+        }
+
+        sealed class <#A2: kotlin/Any> Primitive : pbandk/FieldDescriptor.Type { // pbandk/FieldDescriptor.Type.Primitive|null[0]
+            constructor <init>(#A2) // pbandk/FieldDescriptor.Type.Primitive.<init>|<init>(1:0){}[0]
+
+            final class Bool : pbandk/FieldDescriptor.Type.Primitive<kotlin/Boolean> { // pbandk/FieldDescriptor.Type.Primitive.Bool|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Bool.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Bytes : pbandk/FieldDescriptor.Type.Primitive<pbandk/ByteArr> { // pbandk/FieldDescriptor.Type.Primitive.Bytes|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Bytes.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Double : pbandk/FieldDescriptor.Type.Primitive<kotlin/Double> { // pbandk/FieldDescriptor.Type.Primitive.Double|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Double.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Fixed32 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Int> { // pbandk/FieldDescriptor.Type.Primitive.Fixed32|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Fixed32.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Fixed64 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Long> { // pbandk/FieldDescriptor.Type.Primitive.Fixed64|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Fixed64.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Float : pbandk/FieldDescriptor.Type.Primitive<kotlin/Float> { // pbandk/FieldDescriptor.Type.Primitive.Float|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Float.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Int32 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Int> { // pbandk/FieldDescriptor.Type.Primitive.Int32|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Int32.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class Int64 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Long> { // pbandk/FieldDescriptor.Type.Primitive.Int64|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.Int64.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class SFixed32 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Int> { // pbandk/FieldDescriptor.Type.Primitive.SFixed32|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.SFixed32.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class SFixed64 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Long> { // pbandk/FieldDescriptor.Type.Primitive.SFixed64|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.SFixed64.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class SInt32 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Int> { // pbandk/FieldDescriptor.Type.Primitive.SInt32|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.SInt32.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class SInt64 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Long> { // pbandk/FieldDescriptor.Type.Primitive.SInt64|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.SInt64.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class String : pbandk/FieldDescriptor.Type.Primitive<kotlin/String> { // pbandk/FieldDescriptor.Type.Primitive.String|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.String.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class UInt32 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Int> { // pbandk/FieldDescriptor.Type.Primitive.UInt32|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.UInt32.<init>|<init>(kotlin.Boolean){}[0]
+            }
+
+            final class UInt64 : pbandk/FieldDescriptor.Type.Primitive<kotlin/Long> { // pbandk/FieldDescriptor.Type.Primitive.UInt64|null[0]
+                constructor <init>(kotlin/Boolean = ...) // pbandk/FieldDescriptor.Type.Primitive.UInt64.<init>|<init>(kotlin.Boolean){}[0]
+            }
+        }
+    }
+}
+
+final class <#A: pbandk/Message> pbandk/MessageDescriptor { // pbandk/MessageDescriptor|null[0]
+    constructor <init>(kotlin/String, kotlin.reflect/KClass<#A>, pbandk/Message.Companion<#A>, kotlin.collections/Collection<pbandk/FieldDescriptor<#A, *>>) // pbandk/MessageDescriptor.<init>|<init>(kotlin.String;kotlin.reflect.KClass<1:0>;pbandk.Message.Companion<1:0>;kotlin.collections.Collection<pbandk.FieldDescriptor<1:0,*>>){}[0]
+
+    final val fields // pbandk/MessageDescriptor.fields|{}fields[0]
+        final fun <get-fields>(): kotlin.collections/Collection<pbandk/FieldDescriptor<#A, *>> // pbandk/MessageDescriptor.fields.<get-fields>|<get-fields>(){}[0]
+    final val fullName // pbandk/MessageDescriptor.fullName|{}fullName[0]
+        final fun <get-fullName>(): kotlin/String // pbandk/MessageDescriptor.fullName.<get-fullName>|<get-fullName>(){}[0]
+    final val messageCompanion // pbandk/MessageDescriptor.messageCompanion|{}messageCompanion[0]
+        final fun <get-messageCompanion>(): pbandk/Message.Companion<#A> // pbandk/MessageDescriptor.messageCompanion.<get-messageCompanion>|<get-messageCompanion>(){}[0]
+    final val name // pbandk/MessageDescriptor.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk/MessageDescriptor.name.<get-name>|<get-name>(){}[0]
+}
+
+final class pbandk.json/JsonConfig { // pbandk.json/JsonConfig|null[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., pbandk/TypeRegistry = ...) // pbandk.json/JsonConfig.<init>|<init>(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;pbandk.TypeRegistry){}[0]
+
+    final val compactOutput // pbandk.json/JsonConfig.compactOutput|{}compactOutput[0]
+        final fun <get-compactOutput>(): kotlin/Boolean // pbandk.json/JsonConfig.compactOutput.<get-compactOutput>|<get-compactOutput>(){}[0]
+    final val ignoreUnknownFieldsInInput // pbandk.json/JsonConfig.ignoreUnknownFieldsInInput|{}ignoreUnknownFieldsInInput[0]
+        final fun <get-ignoreUnknownFieldsInInput>(): kotlin/Boolean // pbandk.json/JsonConfig.ignoreUnknownFieldsInInput.<get-ignoreUnknownFieldsInInput>|<get-ignoreUnknownFieldsInInput>(){}[0]
+    final val outputDefaultStringsAsNull // pbandk.json/JsonConfig.outputDefaultStringsAsNull|{}outputDefaultStringsAsNull[0]
+        final fun <get-outputDefaultStringsAsNull>(): kotlin/Boolean // pbandk.json/JsonConfig.outputDefaultStringsAsNull.<get-outputDefaultStringsAsNull>|<get-outputDefaultStringsAsNull>(){}[0]
+    final val outputDefaultValues // pbandk.json/JsonConfig.outputDefaultValues|{}outputDefaultValues[0]
+        final fun <get-outputDefaultValues>(): kotlin/Boolean // pbandk.json/JsonConfig.outputDefaultValues.<get-outputDefaultValues>|<get-outputDefaultValues>(){}[0]
+    final val outputProtoFieldNames // pbandk.json/JsonConfig.outputProtoFieldNames|{}outputProtoFieldNames[0]
+        final fun <get-outputProtoFieldNames>(): kotlin/Boolean // pbandk.json/JsonConfig.outputProtoFieldNames.<get-outputProtoFieldNames>|<get-outputProtoFieldNames>(){}[0]
+    final val typeRegistry // pbandk.json/JsonConfig.typeRegistry|{}typeRegistry[0]
+        final fun <get-typeRegistry>(): pbandk/TypeRegistry // pbandk.json/JsonConfig.typeRegistry.<get-typeRegistry>|<get-typeRegistry>(){}[0]
+
+    final fun component1(): kotlin/Boolean // pbandk.json/JsonConfig.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean // pbandk.json/JsonConfig.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean // pbandk.json/JsonConfig.component3|component3(){}[0]
+    final fun component4(): kotlin/Boolean // pbandk.json/JsonConfig.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean // pbandk.json/JsonConfig.component5|component5(){}[0]
+    final fun component6(): pbandk/TypeRegistry // pbandk.json/JsonConfig.component6|component6(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., kotlin/Boolean = ..., pbandk/TypeRegistry = ...): pbandk.json/JsonConfig // pbandk.json/JsonConfig.copy|copy(kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;kotlin.Boolean;pbandk.TypeRegistry){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.json/JsonConfig.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.json/JsonConfig.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // pbandk.json/JsonConfig.toString|toString(){}[0]
+
+    final object Companion { // pbandk.json/JsonConfig.Companion|null[0]
+        final val DEFAULT // pbandk.json/JsonConfig.Companion.DEFAULT|{}DEFAULT[0]
+            final fun <get-DEFAULT>(): pbandk.json/JsonConfig // pbandk.json/JsonConfig.Companion.DEFAULT.<get-DEFAULT>|<get-DEFAULT>(){}[0]
+    }
+}
+
+final class pbandk.wkt/Any : pbandk/Message { // pbandk.wkt/Any|null[0]
+    constructor <init>(kotlin/String = ..., pbandk/ByteArr = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Any.<init>|<init>(kotlin.String;pbandk.ByteArr;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Any.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Any> // pbandk.wkt/Any.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/Any.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Any.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val typeUrl // pbandk.wkt/Any.typeUrl|{}typeUrl[0]
+        final fun <get-typeUrl>(): kotlin/String // pbandk.wkt/Any.typeUrl.<get-typeUrl>|<get-typeUrl>(){}[0]
+    final val unknownFields // pbandk.wkt/Any.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Any.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/Any.value|{}value[0]
+        final fun <get-value>(): pbandk/ByteArr // pbandk.wkt/Any.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Any.component1|component1(){}[0]
+    final fun component2(): pbandk/ByteArr // pbandk.wkt/Any.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Any.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., pbandk/ByteArr = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Any // pbandk.wkt/Any.copy|copy(kotlin.String;pbandk.ByteArr;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Any.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Any.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Any // pbandk.wkt/Any.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Any.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Any> { // pbandk.wkt/Any.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Any.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Any // pbandk.wkt/Any.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Any.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Any> // pbandk.wkt/Any.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Any // pbandk.wkt/Any.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Api : pbandk/Message { // pbandk.wkt/Api|null[0]
+    constructor <init>(kotlin/String = ..., kotlin.collections/List<pbandk.wkt/Method> = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., kotlin/String = ..., pbandk.wkt/SourceContext? = ..., kotlin.collections/List<pbandk.wkt/Mixin> = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Api.<init>|<init>(kotlin.String;kotlin.collections.List<pbandk.wkt.Method>;kotlin.collections.List<pbandk.wkt.Option>;kotlin.String;pbandk.wkt.SourceContext?;kotlin.collections.List<pbandk.wkt.Mixin>;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Api.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Api> // pbandk.wkt/Api.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val methods // pbandk.wkt/Api.methods|{}methods[0]
+        final fun <get-methods>(): kotlin.collections/List<pbandk.wkt/Method> // pbandk.wkt/Api.methods.<get-methods>|<get-methods>(){}[0]
+    final val mixins // pbandk.wkt/Api.mixins|{}mixins[0]
+        final fun <get-mixins>(): kotlin.collections/List<pbandk.wkt/Mixin> // pbandk.wkt/Api.mixins.<get-mixins>|<get-mixins>(){}[0]
+    final val name // pbandk.wkt/Api.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Api.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/Api.options|{}options[0]
+        final fun <get-options>(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Api.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/Api.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Api.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val sourceContext // pbandk.wkt/Api.sourceContext|{}sourceContext[0]
+        final fun <get-sourceContext>(): pbandk.wkt/SourceContext? // pbandk.wkt/Api.sourceContext.<get-sourceContext>|<get-sourceContext>(){}[0]
+    final val syntax // pbandk.wkt/Api.syntax|{}syntax[0]
+        final fun <get-syntax>(): pbandk.wkt/Syntax // pbandk.wkt/Api.syntax.<get-syntax>|<get-syntax>(){}[0]
+    final val unknownFields // pbandk.wkt/Api.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Api.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val version // pbandk.wkt/Api.version|{}version[0]
+        final fun <get-version>(): kotlin/String // pbandk.wkt/Api.version.<get-version>|<get-version>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Api.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/Method> // pbandk.wkt/Api.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Api.component3|component3(){}[0]
+    final fun component4(): kotlin/String // pbandk.wkt/Api.component4|component4(){}[0]
+    final fun component5(): pbandk.wkt/SourceContext? // pbandk.wkt/Api.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/List<pbandk.wkt/Mixin> // pbandk.wkt/Api.component6|component6(){}[0]
+    final fun component7(): pbandk.wkt/Syntax // pbandk.wkt/Api.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Api.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<pbandk.wkt/Method> = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., kotlin/String = ..., pbandk.wkt/SourceContext? = ..., kotlin.collections/List<pbandk.wkt/Mixin> = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Api // pbandk.wkt/Api.copy|copy(kotlin.String;kotlin.collections.List<pbandk.wkt.Method>;kotlin.collections.List<pbandk.wkt.Option>;kotlin.String;pbandk.wkt.SourceContext?;kotlin.collections.List<pbandk.wkt.Mixin>;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Api.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Api.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Api // pbandk.wkt/Api.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Api.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Api> { // pbandk.wkt/Api.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Api.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Api // pbandk.wkt/Api.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Api.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Api> // pbandk.wkt/Api.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Api // pbandk.wkt/Api.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/BoolValue : pbandk/Message { // pbandk.wkt/BoolValue|null[0]
+    constructor <init>(kotlin/Boolean = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/BoolValue.<init>|<init>(kotlin.Boolean;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/BoolValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/BoolValue> // pbandk.wkt/BoolValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/BoolValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/BoolValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/BoolValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/BoolValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/BoolValue.value|{}value[0]
+        final fun <get-value>(): kotlin/Boolean // pbandk.wkt/BoolValue.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Boolean // pbandk.wkt/BoolValue.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/BoolValue.component2|component2(){}[0]
+    final fun copy(kotlin/Boolean = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/BoolValue // pbandk.wkt/BoolValue.copy|copy(kotlin.Boolean;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/BoolValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/BoolValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/BoolValue // pbandk.wkt/BoolValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/BoolValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/BoolValue> { // pbandk.wkt/BoolValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/BoolValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/BoolValue // pbandk.wkt/BoolValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/BoolValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/BoolValue> // pbandk.wkt/BoolValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/BoolValue // pbandk.wkt/BoolValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/BytesValue : pbandk/Message { // pbandk.wkt/BytesValue|null[0]
+    constructor <init>(pbandk/ByteArr = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/BytesValue.<init>|<init>(pbandk.ByteArr;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/BytesValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/BytesValue> // pbandk.wkt/BytesValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/BytesValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/BytesValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/BytesValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/BytesValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/BytesValue.value|{}value[0]
+        final fun <get-value>(): pbandk/ByteArr // pbandk.wkt/BytesValue.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): pbandk/ByteArr // pbandk.wkt/BytesValue.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/BytesValue.component2|component2(){}[0]
+    final fun copy(pbandk/ByteArr = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/BytesValue // pbandk.wkt/BytesValue.copy|copy(pbandk.ByteArr;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/BytesValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/BytesValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/BytesValue // pbandk.wkt/BytesValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/BytesValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/BytesValue> { // pbandk.wkt/BytesValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/BytesValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/BytesValue // pbandk.wkt/BytesValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/BytesValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/BytesValue> // pbandk.wkt/BytesValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/BytesValue // pbandk.wkt/BytesValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/DescriptorProto : pbandk/Message { // pbandk.wkt/DescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto.ExtensionRange> = ..., kotlin.collections/List<pbandk.wkt/OneofDescriptorProto> = ..., pbandk.wkt/MessageOptions? = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto.ReservedRange> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/DescriptorProto.<init>|<init>(kotlin.String?;kotlin.collections.List<pbandk.wkt.FieldDescriptorProto>;kotlin.collections.List<pbandk.wkt.FieldDescriptorProto>;kotlin.collections.List<pbandk.wkt.DescriptorProto>;kotlin.collections.List<pbandk.wkt.EnumDescriptorProto>;kotlin.collections.List<pbandk.wkt.DescriptorProto.ExtensionRange>;kotlin.collections.List<pbandk.wkt.OneofDescriptorProto>;pbandk.wkt.MessageOptions?;kotlin.collections.List<pbandk.wkt.DescriptorProto.ReservedRange>;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/DescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DescriptorProto> // pbandk.wkt/DescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val enumType // pbandk.wkt/DescriptorProto.enumType|{}enumType[0]
+        final fun <get-enumType>(): kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> // pbandk.wkt/DescriptorProto.enumType.<get-enumType>|<get-enumType>(){}[0]
+    final val extension // pbandk.wkt/DescriptorProto.extension|{}extension[0]
+        final fun <get-extension>(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/DescriptorProto.extension.<get-extension>|<get-extension>(){}[0]
+    final val extensionRange // pbandk.wkt/DescriptorProto.extensionRange|{}extensionRange[0]
+        final fun <get-extensionRange>(): kotlin.collections/List<pbandk.wkt/DescriptorProto.ExtensionRange> // pbandk.wkt/DescriptorProto.extensionRange.<get-extensionRange>|<get-extensionRange>(){}[0]
+    final val field // pbandk.wkt/DescriptorProto.field|{}field[0]
+        final fun <get-field>(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/DescriptorProto.field.<get-field>|<get-field>(){}[0]
+    final val name // pbandk.wkt/DescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/DescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val nestedType // pbandk.wkt/DescriptorProto.nestedType|{}nestedType[0]
+        final fun <get-nestedType>(): kotlin.collections/List<pbandk.wkt/DescriptorProto> // pbandk.wkt/DescriptorProto.nestedType.<get-nestedType>|<get-nestedType>(){}[0]
+    final val oneofDecl // pbandk.wkt/DescriptorProto.oneofDecl|{}oneofDecl[0]
+        final fun <get-oneofDecl>(): kotlin.collections/List<pbandk.wkt/OneofDescriptorProto> // pbandk.wkt/DescriptorProto.oneofDecl.<get-oneofDecl>|<get-oneofDecl>(){}[0]
+    final val options // pbandk.wkt/DescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/MessageOptions? // pbandk.wkt/DescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/DescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/DescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val reservedName // pbandk.wkt/DescriptorProto.reservedName|{}reservedName[0]
+        final fun <get-reservedName>(): kotlin.collections/List<kotlin/String> // pbandk.wkt/DescriptorProto.reservedName.<get-reservedName>|<get-reservedName>(){}[0]
+    final val reservedRange // pbandk.wkt/DescriptorProto.reservedRange|{}reservedRange[0]
+        final fun <get-reservedRange>(): kotlin.collections/List<pbandk.wkt/DescriptorProto.ReservedRange> // pbandk.wkt/DescriptorProto.reservedRange.<get-reservedRange>|<get-reservedRange>(){}[0]
+    final val unknownFields // pbandk.wkt/DescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/DescriptorProto.component1|component1(){}[0]
+    final fun component10(): kotlin.collections/List<kotlin/String> // pbandk.wkt/DescriptorProto.component10|component10(){}[0]
+    final fun component11(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DescriptorProto.component11|component11(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/DescriptorProto.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/DescriptorProto.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<pbandk.wkt/DescriptorProto> // pbandk.wkt/DescriptorProto.component4|component4(){}[0]
+    final fun component5(): kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> // pbandk.wkt/DescriptorProto.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/List<pbandk.wkt/DescriptorProto.ExtensionRange> // pbandk.wkt/DescriptorProto.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/List<pbandk.wkt/OneofDescriptorProto> // pbandk.wkt/DescriptorProto.component7|component7(){}[0]
+    final fun component8(): pbandk.wkt/MessageOptions? // pbandk.wkt/DescriptorProto.component8|component8(){}[0]
+    final fun component9(): kotlin.collections/List<pbandk.wkt/DescriptorProto.ReservedRange> // pbandk.wkt/DescriptorProto.component9|component9(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto.ExtensionRange> = ..., kotlin.collections/List<pbandk.wkt/OneofDescriptorProto> = ..., pbandk.wkt/MessageOptions? = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto.ReservedRange> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/DescriptorProto // pbandk.wkt/DescriptorProto.copy|copy(kotlin.String?;kotlin.collections.List<pbandk.wkt.FieldDescriptorProto>;kotlin.collections.List<pbandk.wkt.FieldDescriptorProto>;kotlin.collections.List<pbandk.wkt.DescriptorProto>;kotlin.collections.List<pbandk.wkt.EnumDescriptorProto>;kotlin.collections.List<pbandk.wkt.DescriptorProto.ExtensionRange>;kotlin.collections.List<pbandk.wkt.OneofDescriptorProto>;pbandk.wkt.MessageOptions?;kotlin.collections.List<pbandk.wkt.DescriptorProto.ReservedRange>;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/DescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/DescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/DescriptorProto // pbandk.wkt/DescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/DescriptorProto.toString|toString(){}[0]
+
+    final class ExtensionRange : pbandk/Message { // pbandk.wkt/DescriptorProto.ExtensionRange|null[0]
+        constructor <init>(kotlin/Int? = ..., kotlin/Int? = ..., pbandk.wkt/ExtensionRangeOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/DescriptorProto.ExtensionRange.<init>|<init>(kotlin.Int?;kotlin.Int?;pbandk.wkt.ExtensionRangeOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk.wkt/DescriptorProto.ExtensionRange.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DescriptorProto.ExtensionRange> // pbandk.wkt/DescriptorProto.ExtensionRange.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val end // pbandk.wkt/DescriptorProto.ExtensionRange.end|{}end[0]
+            final fun <get-end>(): kotlin/Int? // pbandk.wkt/DescriptorProto.ExtensionRange.end.<get-end>|<get-end>(){}[0]
+        final val options // pbandk.wkt/DescriptorProto.ExtensionRange.options|{}options[0]
+            final fun <get-options>(): pbandk.wkt/ExtensionRangeOptions? // pbandk.wkt/DescriptorProto.ExtensionRange.options.<get-options>|<get-options>(){}[0]
+        final val protoSize // pbandk.wkt/DescriptorProto.ExtensionRange.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/DescriptorProto.ExtensionRange.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val start // pbandk.wkt/DescriptorProto.ExtensionRange.start|{}start[0]
+            final fun <get-start>(): kotlin/Int? // pbandk.wkt/DescriptorProto.ExtensionRange.start.<get-start>|<get-start>(){}[0]
+        final val unknownFields // pbandk.wkt/DescriptorProto.ExtensionRange.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DescriptorProto.ExtensionRange.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+        final fun component1(): kotlin/Int? // pbandk.wkt/DescriptorProto.ExtensionRange.component1|component1(){}[0]
+        final fun component2(): kotlin/Int? // pbandk.wkt/DescriptorProto.ExtensionRange.component2|component2(){}[0]
+        final fun component3(): pbandk.wkt/ExtensionRangeOptions? // pbandk.wkt/DescriptorProto.ExtensionRange.component3|component3(){}[0]
+        final fun component4(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DescriptorProto.ExtensionRange.component4|component4(){}[0]
+        final fun copy(kotlin/Int? = ..., kotlin/Int? = ..., pbandk.wkt/ExtensionRangeOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/DescriptorProto.ExtensionRange // pbandk.wkt/DescriptorProto.ExtensionRange.copy|copy(kotlin.Int?;kotlin.Int?;pbandk.wkt.ExtensionRangeOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/DescriptorProto.ExtensionRange.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/DescriptorProto.ExtensionRange.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/DescriptorProto.ExtensionRange // pbandk.wkt/DescriptorProto.ExtensionRange.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/DescriptorProto.ExtensionRange.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/DescriptorProto.ExtensionRange> { // pbandk.wkt/DescriptorProto.ExtensionRange.Companion|null[0]
+            final val defaultInstance // pbandk.wkt/DescriptorProto.ExtensionRange.Companion.defaultInstance|{}defaultInstance[0]
+                final fun <get-defaultInstance>(): pbandk.wkt/DescriptorProto.ExtensionRange // pbandk.wkt/DescriptorProto.ExtensionRange.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+            final val descriptor // pbandk.wkt/DescriptorProto.ExtensionRange.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DescriptorProto.ExtensionRange> // pbandk.wkt/DescriptorProto.ExtensionRange.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/DescriptorProto.ExtensionRange // pbandk.wkt/DescriptorProto.ExtensionRange.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final class ReservedRange : pbandk/Message { // pbandk.wkt/DescriptorProto.ReservedRange|null[0]
+        constructor <init>(kotlin/Int? = ..., kotlin/Int? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/DescriptorProto.ReservedRange.<init>|<init>(kotlin.Int?;kotlin.Int?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk.wkt/DescriptorProto.ReservedRange.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DescriptorProto.ReservedRange> // pbandk.wkt/DescriptorProto.ReservedRange.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val end // pbandk.wkt/DescriptorProto.ReservedRange.end|{}end[0]
+            final fun <get-end>(): kotlin/Int? // pbandk.wkt/DescriptorProto.ReservedRange.end.<get-end>|<get-end>(){}[0]
+        final val protoSize // pbandk.wkt/DescriptorProto.ReservedRange.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/DescriptorProto.ReservedRange.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val start // pbandk.wkt/DescriptorProto.ReservedRange.start|{}start[0]
+            final fun <get-start>(): kotlin/Int? // pbandk.wkt/DescriptorProto.ReservedRange.start.<get-start>|<get-start>(){}[0]
+        final val unknownFields // pbandk.wkt/DescriptorProto.ReservedRange.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DescriptorProto.ReservedRange.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+        final fun component1(): kotlin/Int? // pbandk.wkt/DescriptorProto.ReservedRange.component1|component1(){}[0]
+        final fun component2(): kotlin/Int? // pbandk.wkt/DescriptorProto.ReservedRange.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DescriptorProto.ReservedRange.component3|component3(){}[0]
+        final fun copy(kotlin/Int? = ..., kotlin/Int? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/DescriptorProto.ReservedRange // pbandk.wkt/DescriptorProto.ReservedRange.copy|copy(kotlin.Int?;kotlin.Int?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/DescriptorProto.ReservedRange.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/DescriptorProto.ReservedRange.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/DescriptorProto.ReservedRange // pbandk.wkt/DescriptorProto.ReservedRange.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/DescriptorProto.ReservedRange.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/DescriptorProto.ReservedRange> { // pbandk.wkt/DescriptorProto.ReservedRange.Companion|null[0]
+            final val defaultInstance // pbandk.wkt/DescriptorProto.ReservedRange.Companion.defaultInstance|{}defaultInstance[0]
+                final fun <get-defaultInstance>(): pbandk.wkt/DescriptorProto.ReservedRange // pbandk.wkt/DescriptorProto.ReservedRange.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+            final val descriptor // pbandk.wkt/DescriptorProto.ReservedRange.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DescriptorProto.ReservedRange> // pbandk.wkt/DescriptorProto.ReservedRange.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/DescriptorProto.ReservedRange // pbandk.wkt/DescriptorProto.ReservedRange.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/DescriptorProto> { // pbandk.wkt/DescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/DescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/DescriptorProto // pbandk.wkt/DescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/DescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DescriptorProto> // pbandk.wkt/DescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/DescriptorProto // pbandk.wkt/DescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/DoubleValue : pbandk/Message { // pbandk.wkt/DoubleValue|null[0]
+    constructor <init>(kotlin/Double = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/DoubleValue.<init>|<init>(kotlin.Double;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/DoubleValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DoubleValue> // pbandk.wkt/DoubleValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/DoubleValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/DoubleValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/DoubleValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DoubleValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/DoubleValue.value|{}value[0]
+        final fun <get-value>(): kotlin/Double // pbandk.wkt/DoubleValue.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Double // pbandk.wkt/DoubleValue.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/DoubleValue.component2|component2(){}[0]
+    final fun copy(kotlin/Double = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/DoubleValue // pbandk.wkt/DoubleValue.copy|copy(kotlin.Double;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/DoubleValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/DoubleValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/DoubleValue // pbandk.wkt/DoubleValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/DoubleValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/DoubleValue> { // pbandk.wkt/DoubleValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/DoubleValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/DoubleValue // pbandk.wkt/DoubleValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/DoubleValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/DoubleValue> // pbandk.wkt/DoubleValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/DoubleValue // pbandk.wkt/DoubleValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Duration : pbandk/Message { // pbandk.wkt/Duration|null[0]
+    constructor <init>(kotlin/Long = ..., kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Duration.<init>|<init>(kotlin.Long;kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Duration.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Duration> // pbandk.wkt/Duration.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val nanos // pbandk.wkt/Duration.nanos|{}nanos[0]
+        final fun <get-nanos>(): kotlin/Int // pbandk.wkt/Duration.nanos.<get-nanos>|<get-nanos>(){}[0]
+    final val protoSize // pbandk.wkt/Duration.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Duration.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val seconds // pbandk.wkt/Duration.seconds|{}seconds[0]
+        final fun <get-seconds>(): kotlin/Long // pbandk.wkt/Duration.seconds.<get-seconds>|<get-seconds>(){}[0]
+    final val unknownFields // pbandk.wkt/Duration.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Duration.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Long // pbandk.wkt/Duration.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // pbandk.wkt/Duration.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Duration.component3|component3(){}[0]
+    final fun copy(kotlin/Long = ..., kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Duration // pbandk.wkt/Duration.copy|copy(kotlin.Long;kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Duration.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Duration.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Duration // pbandk.wkt/Duration.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Duration.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Duration> { // pbandk.wkt/Duration.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Duration.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Duration // pbandk.wkt/Duration.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Duration.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Duration> // pbandk.wkt/Duration.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Duration // pbandk.wkt/Duration.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Empty : pbandk/Message { // pbandk.wkt/Empty|null[0]
+    constructor <init>(kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Empty.<init>|<init>(kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Empty.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Empty> // pbandk.wkt/Empty.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/Empty.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Empty.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/Empty.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Empty.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Empty.component1|component1(){}[0]
+    final fun copy(kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Empty // pbandk.wkt/Empty.copy|copy(kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Empty.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Empty.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Empty // pbandk.wkt/Empty.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Empty.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Empty> { // pbandk.wkt/Empty.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Empty.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Empty // pbandk.wkt/Empty.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Empty.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Empty> // pbandk.wkt/Empty.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Empty // pbandk.wkt/Empty.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Enum : pbandk/Message { // pbandk.wkt/Enum|null[0]
+    constructor <init>(kotlin/String = ..., kotlin.collections/List<pbandk.wkt/EnumValue> = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., pbandk.wkt/SourceContext? = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Enum.<init>|<init>(kotlin.String;kotlin.collections.List<pbandk.wkt.EnumValue>;kotlin.collections.List<pbandk.wkt.Option>;pbandk.wkt.SourceContext?;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Enum.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Enum> // pbandk.wkt/Enum.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val enumvalue // pbandk.wkt/Enum.enumvalue|{}enumvalue[0]
+        final fun <get-enumvalue>(): kotlin.collections/List<pbandk.wkt/EnumValue> // pbandk.wkt/Enum.enumvalue.<get-enumvalue>|<get-enumvalue>(){}[0]
+    final val name // pbandk.wkt/Enum.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Enum.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/Enum.options|{}options[0]
+        final fun <get-options>(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Enum.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/Enum.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Enum.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val sourceContext // pbandk.wkt/Enum.sourceContext|{}sourceContext[0]
+        final fun <get-sourceContext>(): pbandk.wkt/SourceContext? // pbandk.wkt/Enum.sourceContext.<get-sourceContext>|<get-sourceContext>(){}[0]
+    final val syntax // pbandk.wkt/Enum.syntax|{}syntax[0]
+        final fun <get-syntax>(): pbandk.wkt/Syntax // pbandk.wkt/Enum.syntax.<get-syntax>|<get-syntax>(){}[0]
+    final val unknownFields // pbandk.wkt/Enum.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Enum.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Enum.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/EnumValue> // pbandk.wkt/Enum.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Enum.component3|component3(){}[0]
+    final fun component4(): pbandk.wkt/SourceContext? // pbandk.wkt/Enum.component4|component4(){}[0]
+    final fun component5(): pbandk.wkt/Syntax // pbandk.wkt/Enum.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Enum.component6|component6(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<pbandk.wkt/EnumValue> = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., pbandk.wkt/SourceContext? = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Enum // pbandk.wkt/Enum.copy|copy(kotlin.String;kotlin.collections.List<pbandk.wkt.EnumValue>;kotlin.collections.List<pbandk.wkt.Option>;pbandk.wkt.SourceContext?;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Enum.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Enum.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Enum // pbandk.wkt/Enum.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Enum.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Enum> { // pbandk.wkt/Enum.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Enum.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Enum // pbandk.wkt/Enum.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Enum.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Enum> // pbandk.wkt/Enum.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Enum // pbandk.wkt/Enum.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/EnumDescriptorProto : pbandk/Message { // pbandk.wkt/EnumDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/EnumValueDescriptorProto> = ..., pbandk.wkt/EnumOptions? = ..., kotlin.collections/List<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/EnumDescriptorProto.<init>|<init>(kotlin.String?;kotlin.collections.List<pbandk.wkt.EnumValueDescriptorProto>;pbandk.wkt.EnumOptions?;kotlin.collections.List<pbandk.wkt.EnumDescriptorProto.EnumReservedRange>;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/EnumDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumDescriptorProto> // pbandk.wkt/EnumDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/EnumDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/EnumDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/EnumDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/EnumOptions? // pbandk.wkt/EnumDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/EnumDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/EnumDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val reservedName // pbandk.wkt/EnumDescriptorProto.reservedName|{}reservedName[0]
+        final fun <get-reservedName>(): kotlin.collections/List<kotlin/String> // pbandk.wkt/EnumDescriptorProto.reservedName.<get-reservedName>|<get-reservedName>(){}[0]
+    final val reservedRange // pbandk.wkt/EnumDescriptorProto.reservedRange|{}reservedRange[0]
+        final fun <get-reservedRange>(): kotlin.collections/List<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> // pbandk.wkt/EnumDescriptorProto.reservedRange.<get-reservedRange>|<get-reservedRange>(){}[0]
+    final val unknownFields // pbandk.wkt/EnumDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/EnumDescriptorProto.value|{}value[0]
+        final fun <get-value>(): kotlin.collections/List<pbandk.wkt/EnumValueDescriptorProto> // pbandk.wkt/EnumDescriptorProto.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/EnumDescriptorProto.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/EnumValueDescriptorProto> // pbandk.wkt/EnumDescriptorProto.component2|component2(){}[0]
+    final fun component3(): pbandk.wkt/EnumOptions? // pbandk.wkt/EnumDescriptorProto.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> // pbandk.wkt/EnumDescriptorProto.component4|component4(){}[0]
+    final fun component5(): kotlin.collections/List<kotlin/String> // pbandk.wkt/EnumDescriptorProto.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumDescriptorProto.component6|component6(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/EnumValueDescriptorProto> = ..., pbandk.wkt/EnumOptions? = ..., kotlin.collections/List<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/EnumDescriptorProto // pbandk.wkt/EnumDescriptorProto.copy|copy(kotlin.String?;kotlin.collections.List<pbandk.wkt.EnumValueDescriptorProto>;pbandk.wkt.EnumOptions?;kotlin.collections.List<pbandk.wkt.EnumDescriptorProto.EnumReservedRange>;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/EnumDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/EnumDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/EnumDescriptorProto // pbandk.wkt/EnumDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/EnumDescriptorProto.toString|toString(){}[0]
+
+    final class EnumReservedRange : pbandk/Message { // pbandk.wkt/EnumDescriptorProto.EnumReservedRange|null[0]
+        constructor <init>(kotlin/Int? = ..., kotlin/Int? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.<init>|<init>(kotlin.Int?;kotlin.Int?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val end // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.end|{}end[0]
+            final fun <get-end>(): kotlin/Int? // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.end.<get-end>|<get-end>(){}[0]
+        final val protoSize // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val start // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.start|{}start[0]
+            final fun <get-start>(): kotlin/Int? // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.start.<get-start>|<get-start>(){}[0]
+        final val unknownFields // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+        final fun component1(): kotlin/Int? // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.component1|component1(){}[0]
+        final fun component2(): kotlin/Int? // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.component3|component3(){}[0]
+        final fun copy(kotlin/Int? = ..., kotlin/Int? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/EnumDescriptorProto.EnumReservedRange // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.copy|copy(kotlin.Int?;kotlin.Int?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/EnumDescriptorProto.EnumReservedRange // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> { // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.Companion|null[0]
+            final val defaultInstance // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.Companion.defaultInstance|{}defaultInstance[0]
+                final fun <get-defaultInstance>(): pbandk.wkt/EnumDescriptorProto.EnumReservedRange // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+            final val descriptor // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumDescriptorProto.EnumReservedRange> // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/EnumDescriptorProto.EnumReservedRange // pbandk.wkt/EnumDescriptorProto.EnumReservedRange.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/EnumDescriptorProto> { // pbandk.wkt/EnumDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/EnumDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/EnumDescriptorProto // pbandk.wkt/EnumDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/EnumDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumDescriptorProto> // pbandk.wkt/EnumDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/EnumDescriptorProto // pbandk.wkt/EnumDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/EnumOptions : pbandk/ExtendableMessage { // pbandk.wkt/EnumOptions|null[0]
+    constructor <init>(kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/EnumOptions.<init>|<init>(kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val allowAlias // pbandk.wkt/EnumOptions.allowAlias|{}allowAlias[0]
+        final fun <get-allowAlias>(): kotlin/Boolean? // pbandk.wkt/EnumOptions.allowAlias.<get-allowAlias>|<get-allowAlias>(){}[0]
+    final val deprecated // pbandk.wkt/EnumOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/EnumOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/EnumOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumOptions> // pbandk.wkt/EnumOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/EnumOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/EnumOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/EnumOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/EnumOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/EnumOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Boolean? // pbandk.wkt/EnumOptions.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean? // pbandk.wkt/EnumOptions.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/EnumOptions.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumOptions.component4|component4(){}[0]
+    final fun component5(): pbandk/ExtensionFieldSet // pbandk.wkt/EnumOptions.component5|component5(){}[0]
+    final fun copy(kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/EnumOptions // pbandk.wkt/EnumOptions.copy|copy(kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/EnumOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/EnumOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/EnumOptions // pbandk.wkt/EnumOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/EnumOptions.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/EnumOptions> { // pbandk.wkt/EnumOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/EnumOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/EnumOptions // pbandk.wkt/EnumOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/EnumOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumOptions> // pbandk.wkt/EnumOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/EnumOptions // pbandk.wkt/EnumOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/EnumValue : pbandk/Message { // pbandk.wkt/EnumValue|null[0]
+    constructor <init>(kotlin/String = ..., kotlin/Int = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/EnumValue.<init>|<init>(kotlin.String;kotlin.Int;kotlin.collections.List<pbandk.wkt.Option>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/EnumValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumValue> // pbandk.wkt/EnumValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/EnumValue.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/EnumValue.name.<get-name>|<get-name>(){}[0]
+    final val number // pbandk.wkt/EnumValue.number|{}number[0]
+        final fun <get-number>(): kotlin/Int // pbandk.wkt/EnumValue.number.<get-number>|<get-number>(){}[0]
+    final val options // pbandk.wkt/EnumValue.options|{}options[0]
+        final fun <get-options>(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/EnumValue.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/EnumValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/EnumValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/EnumValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/EnumValue.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // pbandk.wkt/EnumValue.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/EnumValue.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumValue.component4|component4(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/Int = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/EnumValue // pbandk.wkt/EnumValue.copy|copy(kotlin.String;kotlin.Int;kotlin.collections.List<pbandk.wkt.Option>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/EnumValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/EnumValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/EnumValue // pbandk.wkt/EnumValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/EnumValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/EnumValue> { // pbandk.wkt/EnumValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/EnumValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/EnumValue // pbandk.wkt/EnumValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/EnumValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumValue> // pbandk.wkt/EnumValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/EnumValue // pbandk.wkt/EnumValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/EnumValueDescriptorProto : pbandk/Message { // pbandk.wkt/EnumValueDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/Int? = ..., pbandk.wkt/EnumValueOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/EnumValueDescriptorProto.<init>|<init>(kotlin.String?;kotlin.Int?;pbandk.wkt.EnumValueOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/EnumValueDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumValueDescriptorProto> // pbandk.wkt/EnumValueDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/EnumValueDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/EnumValueDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val number // pbandk.wkt/EnumValueDescriptorProto.number|{}number[0]
+        final fun <get-number>(): kotlin/Int? // pbandk.wkt/EnumValueDescriptorProto.number.<get-number>|<get-number>(){}[0]
+    final val options // pbandk.wkt/EnumValueDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/EnumValueOptions? // pbandk.wkt/EnumValueDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/EnumValueDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/EnumValueDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/EnumValueDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumValueDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/EnumValueDescriptorProto.component1|component1(){}[0]
+    final fun component2(): kotlin/Int? // pbandk.wkt/EnumValueDescriptorProto.component2|component2(){}[0]
+    final fun component3(): pbandk.wkt/EnumValueOptions? // pbandk.wkt/EnumValueDescriptorProto.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumValueDescriptorProto.component4|component4(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/Int? = ..., pbandk.wkt/EnumValueOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/EnumValueDescriptorProto // pbandk.wkt/EnumValueDescriptorProto.copy|copy(kotlin.String?;kotlin.Int?;pbandk.wkt.EnumValueOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/EnumValueDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/EnumValueDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/EnumValueDescriptorProto // pbandk.wkt/EnumValueDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/EnumValueDescriptorProto.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/EnumValueDescriptorProto> { // pbandk.wkt/EnumValueDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/EnumValueDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/EnumValueDescriptorProto // pbandk.wkt/EnumValueDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/EnumValueDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumValueDescriptorProto> // pbandk.wkt/EnumValueDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/EnumValueDescriptorProto // pbandk.wkt/EnumValueDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/EnumValueOptions : pbandk/ExtendableMessage { // pbandk.wkt/EnumValueOptions|null[0]
+    constructor <init>(kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/EnumValueOptions.<init>|<init>(kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val deprecated // pbandk.wkt/EnumValueOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/EnumValueOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/EnumValueOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumValueOptions> // pbandk.wkt/EnumValueOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/EnumValueOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/EnumValueOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/EnumValueOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/EnumValueOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/EnumValueOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumValueOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Boolean? // pbandk.wkt/EnumValueOptions.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/EnumValueOptions.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/EnumValueOptions.component3|component3(){}[0]
+    final fun component4(): pbandk/ExtensionFieldSet // pbandk.wkt/EnumValueOptions.component4|component4(){}[0]
+    final fun copy(kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/EnumValueOptions // pbandk.wkt/EnumValueOptions.copy|copy(kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/EnumValueOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/EnumValueOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/EnumValueOptions // pbandk.wkt/EnumValueOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/EnumValueOptions.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/EnumValueOptions> { // pbandk.wkt/EnumValueOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/EnumValueOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/EnumValueOptions // pbandk.wkt/EnumValueOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/EnumValueOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/EnumValueOptions> // pbandk.wkt/EnumValueOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/EnumValueOptions // pbandk.wkt/EnumValueOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/ExtensionRangeOptions : pbandk/ExtendableMessage { // pbandk.wkt/ExtensionRangeOptions|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/ExtensionRangeOptions.<init>|<init>(kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val descriptor // pbandk.wkt/ExtensionRangeOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ExtensionRangeOptions> // pbandk.wkt/ExtensionRangeOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/ExtensionRangeOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/ExtensionRangeOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/ExtensionRangeOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/ExtensionRangeOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/ExtensionRangeOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ExtensionRangeOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/ExtensionRangeOptions.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ExtensionRangeOptions.component2|component2(){}[0]
+    final fun component3(): pbandk/ExtensionFieldSet // pbandk.wkt/ExtensionRangeOptions.component3|component3(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/ExtensionRangeOptions // pbandk.wkt/ExtensionRangeOptions.copy|copy(kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/ExtensionRangeOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/ExtensionRangeOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/ExtensionRangeOptions // pbandk.wkt/ExtensionRangeOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/ExtensionRangeOptions.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/ExtensionRangeOptions> { // pbandk.wkt/ExtensionRangeOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/ExtensionRangeOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/ExtensionRangeOptions // pbandk.wkt/ExtensionRangeOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/ExtensionRangeOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ExtensionRangeOptions> // pbandk.wkt/ExtensionRangeOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/ExtensionRangeOptions // pbandk.wkt/ExtensionRangeOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Field : pbandk/Message { // pbandk.wkt/Field|null[0]
+    constructor <init>(pbandk.wkt/Field.Kind = ..., pbandk.wkt/Field.Cardinality = ..., kotlin/Int = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Int = ..., kotlin/Boolean = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., kotlin/String = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Field.<init>|<init>(pbandk.wkt.Field.Kind;pbandk.wkt.Field.Cardinality;kotlin.Int;kotlin.String;kotlin.String;kotlin.Int;kotlin.Boolean;kotlin.collections.List<pbandk.wkt.Option>;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val cardinality // pbandk.wkt/Field.cardinality|{}cardinality[0]
+        final fun <get-cardinality>(): pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.cardinality.<get-cardinality>|<get-cardinality>(){}[0]
+    final val defaultValue // pbandk.wkt/Field.defaultValue|{}defaultValue[0]
+        final fun <get-defaultValue>(): kotlin/String // pbandk.wkt/Field.defaultValue.<get-defaultValue>|<get-defaultValue>(){}[0]
+    final val descriptor // pbandk.wkt/Field.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Field> // pbandk.wkt/Field.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val jsonName // pbandk.wkt/Field.jsonName|{}jsonName[0]
+        final fun <get-jsonName>(): kotlin/String // pbandk.wkt/Field.jsonName.<get-jsonName>|<get-jsonName>(){}[0]
+    final val kind // pbandk.wkt/Field.kind|{}kind[0]
+        final fun <get-kind>(): pbandk.wkt/Field.Kind // pbandk.wkt/Field.kind.<get-kind>|<get-kind>(){}[0]
+    final val name // pbandk.wkt/Field.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Field.name.<get-name>|<get-name>(){}[0]
+    final val number // pbandk.wkt/Field.number|{}number[0]
+        final fun <get-number>(): kotlin/Int // pbandk.wkt/Field.number.<get-number>|<get-number>(){}[0]
+    final val oneofIndex // pbandk.wkt/Field.oneofIndex|{}oneofIndex[0]
+        final fun <get-oneofIndex>(): kotlin/Int // pbandk.wkt/Field.oneofIndex.<get-oneofIndex>|<get-oneofIndex>(){}[0]
+    final val options // pbandk.wkt/Field.options|{}options[0]
+        final fun <get-options>(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Field.options.<get-options>|<get-options>(){}[0]
+    final val packed // pbandk.wkt/Field.packed|{}packed[0]
+        final fun <get-packed>(): kotlin/Boolean // pbandk.wkt/Field.packed.<get-packed>|<get-packed>(){}[0]
+    final val protoSize // pbandk.wkt/Field.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Field.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val typeUrl // pbandk.wkt/Field.typeUrl|{}typeUrl[0]
+        final fun <get-typeUrl>(): kotlin/String // pbandk.wkt/Field.typeUrl.<get-typeUrl>|<get-typeUrl>(){}[0]
+    final val unknownFields // pbandk.wkt/Field.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Field.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): pbandk.wkt/Field.Kind // pbandk.wkt/Field.component1|component1(){}[0]
+    final fun component10(): kotlin/String // pbandk.wkt/Field.component10|component10(){}[0]
+    final fun component11(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Field.component11|component11(){}[0]
+    final fun component2(): pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.component2|component2(){}[0]
+    final fun component3(): kotlin/Int // pbandk.wkt/Field.component3|component3(){}[0]
+    final fun component4(): kotlin/String // pbandk.wkt/Field.component4|component4(){}[0]
+    final fun component5(): kotlin/String // pbandk.wkt/Field.component5|component5(){}[0]
+    final fun component6(): kotlin/Int // pbandk.wkt/Field.component6|component6(){}[0]
+    final fun component7(): kotlin/Boolean // pbandk.wkt/Field.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Field.component8|component8(){}[0]
+    final fun component9(): kotlin/String // pbandk.wkt/Field.component9|component9(){}[0]
+    final fun copy(pbandk.wkt/Field.Kind = ..., pbandk.wkt/Field.Cardinality = ..., kotlin/Int = ..., kotlin/String = ..., kotlin/String = ..., kotlin/Int = ..., kotlin/Boolean = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., kotlin/String = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Field // pbandk.wkt/Field.copy|copy(pbandk.wkt.Field.Kind;pbandk.wkt.Field.Cardinality;kotlin.Int;kotlin.String;kotlin.String;kotlin.Int;kotlin.Boolean;kotlin.collections.List<pbandk.wkt.Option>;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Field.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Field.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Field // pbandk.wkt/Field.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Field.toString|toString(){}[0]
+
+    sealed class Cardinality : pbandk/Message.Enum { // pbandk.wkt/Field.Cardinality|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/Field.Cardinality.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/Field.Cardinality.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/Field.Cardinality.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/Field.Cardinality.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/Field.Cardinality.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Field.Cardinality.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/Field.Cardinality.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/Field.Cardinality.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/Field.Cardinality { // pbandk.wkt/Field.Cardinality.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/Field.Cardinality.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/Field.Cardinality> { // pbandk.wkt/Field.Cardinality.Companion|null[0]
+            final val values // pbandk.wkt/Field.Cardinality.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/Field.Cardinality> // pbandk.wkt/Field.Cardinality.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.Cardinality.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.Cardinality.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object OPTIONAL : pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.Cardinality.OPTIONAL|null[0]
+
+        final object REPEATED : pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.Cardinality.REPEATED|null[0]
+
+        final object REQUIRED : pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.Cardinality.REQUIRED|null[0]
+
+        final object UNKNOWN : pbandk.wkt/Field.Cardinality // pbandk.wkt/Field.Cardinality.UNKNOWN|null[0]
+    }
+
+    sealed class Kind : pbandk/Message.Enum { // pbandk.wkt/Field.Kind|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/Field.Kind.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/Field.Kind.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/Field.Kind.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/Field.Kind.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/Field.Kind.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Field.Kind.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/Field.Kind.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/Field.Kind.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/Field.Kind { // pbandk.wkt/Field.Kind.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/Field.Kind.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/Field.Kind> { // pbandk.wkt/Field.Kind.Companion|null[0]
+            final val values // pbandk.wkt/Field.Kind.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/Field.Kind> // pbandk.wkt/Field.Kind.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object TYPE_BOOL : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_BOOL|null[0]
+
+        final object TYPE_BYTES : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_BYTES|null[0]
+
+        final object TYPE_DOUBLE : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_DOUBLE|null[0]
+
+        final object TYPE_ENUM : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_ENUM|null[0]
+
+        final object TYPE_FIXED32 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_FIXED32|null[0]
+
+        final object TYPE_FIXED64 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_FIXED64|null[0]
+
+        final object TYPE_FLOAT : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_FLOAT|null[0]
+
+        final object TYPE_GROUP : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_GROUP|null[0]
+
+        final object TYPE_INT32 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_INT32|null[0]
+
+        final object TYPE_INT64 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_INT64|null[0]
+
+        final object TYPE_MESSAGE : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_MESSAGE|null[0]
+
+        final object TYPE_SFIXED32 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_SFIXED32|null[0]
+
+        final object TYPE_SFIXED64 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_SFIXED64|null[0]
+
+        final object TYPE_SINT32 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_SINT32|null[0]
+
+        final object TYPE_SINT64 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_SINT64|null[0]
+
+        final object TYPE_STRING : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_STRING|null[0]
+
+        final object TYPE_UINT32 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_UINT32|null[0]
+
+        final object TYPE_UINT64 : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_UINT64|null[0]
+
+        final object TYPE_UNKNOWN : pbandk.wkt/Field.Kind // pbandk.wkt/Field.Kind.TYPE_UNKNOWN|null[0]
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Field> { // pbandk.wkt/Field.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Field.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Field // pbandk.wkt/Field.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Field.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Field> // pbandk.wkt/Field.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Field // pbandk.wkt/Field.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FieldDescriptorProto : pbandk/Message { // pbandk.wkt/FieldDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/Int? = ..., pbandk.wkt/FieldDescriptorProto.Label? = ..., pbandk.wkt/FieldDescriptorProto.Type? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ..., kotlin/String? = ..., pbandk.wkt/FieldOptions? = ..., kotlin/Boolean? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/FieldDescriptorProto.<init>|<init>(kotlin.String?;kotlin.Int?;pbandk.wkt.FieldDescriptorProto.Label?;pbandk.wkt.FieldDescriptorProto.Type?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?;kotlin.String?;pbandk.wkt.FieldOptions?;kotlin.Boolean?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val defaultValue // pbandk.wkt/FieldDescriptorProto.defaultValue|{}defaultValue[0]
+        final fun <get-defaultValue>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.defaultValue.<get-defaultValue>|<get-defaultValue>(){}[0]
+    final val descriptor // pbandk.wkt/FieldDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/FieldDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val extendee // pbandk.wkt/FieldDescriptorProto.extendee|{}extendee[0]
+        final fun <get-extendee>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.extendee.<get-extendee>|<get-extendee>(){}[0]
+    final val jsonName // pbandk.wkt/FieldDescriptorProto.jsonName|{}jsonName[0]
+        final fun <get-jsonName>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.jsonName.<get-jsonName>|<get-jsonName>(){}[0]
+    final val label // pbandk.wkt/FieldDescriptorProto.label|{}label[0]
+        final fun <get-label>(): pbandk.wkt/FieldDescriptorProto.Label? // pbandk.wkt/FieldDescriptorProto.label.<get-label>|<get-label>(){}[0]
+    final val name // pbandk.wkt/FieldDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val number // pbandk.wkt/FieldDescriptorProto.number|{}number[0]
+        final fun <get-number>(): kotlin/Int? // pbandk.wkt/FieldDescriptorProto.number.<get-number>|<get-number>(){}[0]
+    final val oneofIndex // pbandk.wkt/FieldDescriptorProto.oneofIndex|{}oneofIndex[0]
+        final fun <get-oneofIndex>(): kotlin/Int? // pbandk.wkt/FieldDescriptorProto.oneofIndex.<get-oneofIndex>|<get-oneofIndex>(){}[0]
+    final val options // pbandk.wkt/FieldDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/FieldOptions? // pbandk.wkt/FieldDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val proto3Optional // pbandk.wkt/FieldDescriptorProto.proto3Optional|{}proto3Optional[0]
+        final fun <get-proto3Optional>(): kotlin/Boolean? // pbandk.wkt/FieldDescriptorProto.proto3Optional.<get-proto3Optional>|<get-proto3Optional>(){}[0]
+    final val protoSize // pbandk.wkt/FieldDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FieldDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val type // pbandk.wkt/FieldDescriptorProto.type|{}type[0]
+        final fun <get-type>(): pbandk.wkt/FieldDescriptorProto.Type? // pbandk.wkt/FieldDescriptorProto.type.<get-type>|<get-type>(){}[0]
+    final val typeName // pbandk.wkt/FieldDescriptorProto.typeName|{}typeName[0]
+        final fun <get-typeName>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.typeName.<get-typeName>|<get-typeName>(){}[0]
+    final val unknownFields // pbandk.wkt/FieldDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FieldDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.component1|component1(){}[0]
+    final fun component10(): pbandk.wkt/FieldOptions? // pbandk.wkt/FieldDescriptorProto.component10|component10(){}[0]
+    final fun component11(): kotlin/Boolean? // pbandk.wkt/FieldDescriptorProto.component11|component11(){}[0]
+    final fun component12(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FieldDescriptorProto.component12|component12(){}[0]
+    final fun component2(): kotlin/Int? // pbandk.wkt/FieldDescriptorProto.component2|component2(){}[0]
+    final fun component3(): pbandk.wkt/FieldDescriptorProto.Label? // pbandk.wkt/FieldDescriptorProto.component3|component3(){}[0]
+    final fun component4(): pbandk.wkt/FieldDescriptorProto.Type? // pbandk.wkt/FieldDescriptorProto.component4|component4(){}[0]
+    final fun component5(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.component5|component5(){}[0]
+    final fun component6(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.component6|component6(){}[0]
+    final fun component7(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.component7|component7(){}[0]
+    final fun component8(): kotlin/Int? // pbandk.wkt/FieldDescriptorProto.component8|component8(){}[0]
+    final fun component9(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.component9|component9(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/Int? = ..., pbandk.wkt/FieldDescriptorProto.Label? = ..., pbandk.wkt/FieldDescriptorProto.Type? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/Int? = ..., kotlin/String? = ..., pbandk.wkt/FieldOptions? = ..., kotlin/Boolean? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/FieldDescriptorProto // pbandk.wkt/FieldDescriptorProto.copy|copy(kotlin.String?;kotlin.Int?;pbandk.wkt.FieldDescriptorProto.Label?;pbandk.wkt.FieldDescriptorProto.Type?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.Int?;kotlin.String?;pbandk.wkt.FieldOptions?;kotlin.Boolean?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FieldDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FieldDescriptorProto // pbandk.wkt/FieldDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FieldDescriptorProto.toString|toString(){}[0]
+
+    sealed class Label : pbandk/Message.Enum { // pbandk.wkt/FieldDescriptorProto.Label|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/FieldDescriptorProto.Label.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/FieldDescriptorProto.Label.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.Label.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/FieldDescriptorProto.Label.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/FieldDescriptorProto.Label.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldDescriptorProto.Label.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/FieldDescriptorProto.Label.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/FieldDescriptorProto.Label.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/FieldDescriptorProto.Label { // pbandk.wkt/FieldDescriptorProto.Label.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/FieldDescriptorProto.Label.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/FieldDescriptorProto.Label> { // pbandk.wkt/FieldDescriptorProto.Label.Companion|null[0]
+            final val values // pbandk.wkt/FieldDescriptorProto.Label.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto.Label> // pbandk.wkt/FieldDescriptorProto.Label.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/FieldDescriptorProto.Label // pbandk.wkt/FieldDescriptorProto.Label.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/FieldDescriptorProto.Label // pbandk.wkt/FieldDescriptorProto.Label.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object OPTIONAL : pbandk.wkt/FieldDescriptorProto.Label // pbandk.wkt/FieldDescriptorProto.Label.OPTIONAL|null[0]
+
+        final object REPEATED : pbandk.wkt/FieldDescriptorProto.Label // pbandk.wkt/FieldDescriptorProto.Label.REPEATED|null[0]
+
+        final object REQUIRED : pbandk.wkt/FieldDescriptorProto.Label // pbandk.wkt/FieldDescriptorProto.Label.REQUIRED|null[0]
+    }
+
+    sealed class Type : pbandk/Message.Enum { // pbandk.wkt/FieldDescriptorProto.Type|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/FieldDescriptorProto.Type.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/FieldDescriptorProto.Type.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/FieldDescriptorProto.Type.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/FieldDescriptorProto.Type.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/FieldDescriptorProto.Type.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldDescriptorProto.Type.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/FieldDescriptorProto.Type.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/FieldDescriptorProto.Type.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/FieldDescriptorProto.Type { // pbandk.wkt/FieldDescriptorProto.Type.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/FieldDescriptorProto.Type.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object BOOL : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.BOOL|null[0]
+
+        final object BYTES : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.BYTES|null[0]
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/FieldDescriptorProto.Type> { // pbandk.wkt/FieldDescriptorProto.Type.Companion|null[0]
+            final val values // pbandk.wkt/FieldDescriptorProto.Type.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto.Type> // pbandk.wkt/FieldDescriptorProto.Type.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object DOUBLE : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.DOUBLE|null[0]
+
+        final object ENUM : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.ENUM|null[0]
+
+        final object FIXED32 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.FIXED32|null[0]
+
+        final object FIXED64 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.FIXED64|null[0]
+
+        final object FLOAT : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.FLOAT|null[0]
+
+        final object GROUP : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.GROUP|null[0]
+
+        final object INT32 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.INT32|null[0]
+
+        final object INT64 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.INT64|null[0]
+
+        final object MESSAGE : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.MESSAGE|null[0]
+
+        final object SFIXED32 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.SFIXED32|null[0]
+
+        final object SFIXED64 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.SFIXED64|null[0]
+
+        final object SINT32 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.SINT32|null[0]
+
+        final object SINT64 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.SINT64|null[0]
+
+        final object STRING : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.STRING|null[0]
+
+        final object UINT32 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.UINT32|null[0]
+
+        final object UINT64 : pbandk.wkt/FieldDescriptorProto.Type // pbandk.wkt/FieldDescriptorProto.Type.UINT64|null[0]
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FieldDescriptorProto> { // pbandk.wkt/FieldDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FieldDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FieldDescriptorProto // pbandk.wkt/FieldDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FieldDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/FieldDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FieldDescriptorProto // pbandk.wkt/FieldDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FieldMask : pbandk/Message { // pbandk.wkt/FieldMask|null[0]
+    constructor <init>(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/FieldMask.<init>|<init>(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/FieldMask.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FieldMask> // pbandk.wkt/FieldMask.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val paths // pbandk.wkt/FieldMask.paths|{}paths[0]
+        final fun <get-paths>(): kotlin.collections/List<kotlin/String> // pbandk.wkt/FieldMask.paths.<get-paths>|<get-paths>(){}[0]
+    final val protoSize // pbandk.wkt/FieldMask.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FieldMask.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/FieldMask.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FieldMask.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<kotlin/String> // pbandk.wkt/FieldMask.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FieldMask.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/FieldMask // pbandk.wkt/FieldMask.copy|copy(kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldMask.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FieldMask.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FieldMask // pbandk.wkt/FieldMask.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FieldMask.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FieldMask> { // pbandk.wkt/FieldMask.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FieldMask.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FieldMask // pbandk.wkt/FieldMask.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FieldMask.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FieldMask> // pbandk.wkt/FieldMask.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FieldMask // pbandk.wkt/FieldMask.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FieldOptions : pbandk/ExtendableMessage { // pbandk.wkt/FieldOptions|null[0]
+    constructor <init>(pbandk.wkt/FieldOptions.CType? = ..., kotlin/Boolean? = ..., pbandk.wkt/FieldOptions.JSType? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/FieldOptions.<init>|<init>(pbandk.wkt.FieldOptions.CType?;kotlin.Boolean?;pbandk.wkt.FieldOptions.JSType?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val ctype // pbandk.wkt/FieldOptions.ctype|{}ctype[0]
+        final fun <get-ctype>(): pbandk.wkt/FieldOptions.CType? // pbandk.wkt/FieldOptions.ctype.<get-ctype>|<get-ctype>(){}[0]
+    final val deprecated // pbandk.wkt/FieldOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/FieldOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/FieldOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FieldOptions> // pbandk.wkt/FieldOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val jstype // pbandk.wkt/FieldOptions.jstype|{}jstype[0]
+        final fun <get-jstype>(): pbandk.wkt/FieldOptions.JSType? // pbandk.wkt/FieldOptions.jstype.<get-jstype>|<get-jstype>(){}[0]
+    final val lazy // pbandk.wkt/FieldOptions.lazy|{}lazy[0]
+        final fun <get-lazy>(): kotlin/Boolean? // pbandk.wkt/FieldOptions.lazy.<get-lazy>|<get-lazy>(){}[0]
+    final val packed // pbandk.wkt/FieldOptions.packed|{}packed[0]
+        final fun <get-packed>(): kotlin/Boolean? // pbandk.wkt/FieldOptions.packed.<get-packed>|<get-packed>(){}[0]
+    final val protoSize // pbandk.wkt/FieldOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FieldOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/FieldOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/FieldOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/FieldOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FieldOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val weak // pbandk.wkt/FieldOptions.weak|{}weak[0]
+        final fun <get-weak>(): kotlin/Boolean? // pbandk.wkt/FieldOptions.weak.<get-weak>|<get-weak>(){}[0]
+
+    final fun component1(): pbandk.wkt/FieldOptions.CType? // pbandk.wkt/FieldOptions.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean? // pbandk.wkt/FieldOptions.component2|component2(){}[0]
+    final fun component3(): pbandk.wkt/FieldOptions.JSType? // pbandk.wkt/FieldOptions.component3|component3(){}[0]
+    final fun component4(): kotlin/Boolean? // pbandk.wkt/FieldOptions.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean? // pbandk.wkt/FieldOptions.component5|component5(){}[0]
+    final fun component6(): kotlin/Boolean? // pbandk.wkt/FieldOptions.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/FieldOptions.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FieldOptions.component8|component8(){}[0]
+    final fun component9(): pbandk/ExtensionFieldSet // pbandk.wkt/FieldOptions.component9|component9(){}[0]
+    final fun copy(pbandk.wkt/FieldOptions.CType? = ..., kotlin/Boolean? = ..., pbandk.wkt/FieldOptions.JSType? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/FieldOptions // pbandk.wkt/FieldOptions.copy|copy(pbandk.wkt.FieldOptions.CType?;kotlin.Boolean?;pbandk.wkt.FieldOptions.JSType?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FieldOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FieldOptions // pbandk.wkt/FieldOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FieldOptions.toString|toString(){}[0]
+
+    sealed class CType : pbandk/Message.Enum { // pbandk.wkt/FieldOptions.CType|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/FieldOptions.CType.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/FieldOptions.CType.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/FieldOptions.CType.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/FieldOptions.CType.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/FieldOptions.CType.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldOptions.CType.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/FieldOptions.CType.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/FieldOptions.CType.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/FieldOptions.CType { // pbandk.wkt/FieldOptions.CType.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/FieldOptions.CType.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object CORD : pbandk.wkt/FieldOptions.CType // pbandk.wkt/FieldOptions.CType.CORD|null[0]
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/FieldOptions.CType> { // pbandk.wkt/FieldOptions.CType.Companion|null[0]
+            final val values // pbandk.wkt/FieldOptions.CType.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/FieldOptions.CType> // pbandk.wkt/FieldOptions.CType.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/FieldOptions.CType // pbandk.wkt/FieldOptions.CType.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/FieldOptions.CType // pbandk.wkt/FieldOptions.CType.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object STRING : pbandk.wkt/FieldOptions.CType // pbandk.wkt/FieldOptions.CType.STRING|null[0]
+
+        final object STRING_PIECE : pbandk.wkt/FieldOptions.CType // pbandk.wkt/FieldOptions.CType.STRING_PIECE|null[0]
+    }
+
+    sealed class JSType : pbandk/Message.Enum { // pbandk.wkt/FieldOptions.JSType|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/FieldOptions.JSType.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/FieldOptions.JSType.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/FieldOptions.JSType.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/FieldOptions.JSType.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/FieldOptions.JSType.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FieldOptions.JSType.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/FieldOptions.JSType.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/FieldOptions.JSType.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/FieldOptions.JSType { // pbandk.wkt/FieldOptions.JSType.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/FieldOptions.JSType.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/FieldOptions.JSType> { // pbandk.wkt/FieldOptions.JSType.Companion|null[0]
+            final val values // pbandk.wkt/FieldOptions.JSType.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/FieldOptions.JSType> // pbandk.wkt/FieldOptions.JSType.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/FieldOptions.JSType // pbandk.wkt/FieldOptions.JSType.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/FieldOptions.JSType // pbandk.wkt/FieldOptions.JSType.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object JS_NORMAL : pbandk.wkt/FieldOptions.JSType // pbandk.wkt/FieldOptions.JSType.JS_NORMAL|null[0]
+
+        final object JS_NUMBER : pbandk.wkt/FieldOptions.JSType // pbandk.wkt/FieldOptions.JSType.JS_NUMBER|null[0]
+
+        final object JS_STRING : pbandk.wkt/FieldOptions.JSType // pbandk.wkt/FieldOptions.JSType.JS_STRING|null[0]
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FieldOptions> { // pbandk.wkt/FieldOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FieldOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FieldOptions // pbandk.wkt/FieldOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FieldOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FieldOptions> // pbandk.wkt/FieldOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FieldOptions // pbandk.wkt/FieldOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FileDescriptorProto : pbandk/Message { // pbandk.wkt/FileDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/ServiceDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> = ..., pbandk.wkt/FileOptions? = ..., pbandk.wkt/SourceCodeInfo? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/FileDescriptorProto.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<pbandk.wkt.DescriptorProto>;kotlin.collections.List<pbandk.wkt.EnumDescriptorProto>;kotlin.collections.List<pbandk.wkt.ServiceDescriptorProto>;kotlin.collections.List<pbandk.wkt.FieldDescriptorProto>;pbandk.wkt.FileOptions?;pbandk.wkt.SourceCodeInfo?;kotlin.String?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val dependency // pbandk.wkt/FileDescriptorProto.dependency|{}dependency[0]
+        final fun <get-dependency>(): kotlin.collections/List<kotlin/String> // pbandk.wkt/FileDescriptorProto.dependency.<get-dependency>|<get-dependency>(){}[0]
+    final val descriptor // pbandk.wkt/FileDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FileDescriptorProto> // pbandk.wkt/FileDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val enumType // pbandk.wkt/FileDescriptorProto.enumType|{}enumType[0]
+        final fun <get-enumType>(): kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> // pbandk.wkt/FileDescriptorProto.enumType.<get-enumType>|<get-enumType>(){}[0]
+    final val extension // pbandk.wkt/FileDescriptorProto.extension|{}extension[0]
+        final fun <get-extension>(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/FileDescriptorProto.extension.<get-extension>|<get-extension>(){}[0]
+    final val messageType // pbandk.wkt/FileDescriptorProto.messageType|{}messageType[0]
+        final fun <get-messageType>(): kotlin.collections/List<pbandk.wkt/DescriptorProto> // pbandk.wkt/FileDescriptorProto.messageType.<get-messageType>|<get-messageType>(){}[0]
+    final val name // pbandk.wkt/FileDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/FileDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/FileDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/FileOptions? // pbandk.wkt/FileDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val package // pbandk.wkt/FileDescriptorProto.package|{}package[0]
+        final fun <get-package>(): kotlin/String? // pbandk.wkt/FileDescriptorProto.package.<get-package>|<get-package>(){}[0]
+    final val protoSize // pbandk.wkt/FileDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FileDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val publicDependency // pbandk.wkt/FileDescriptorProto.publicDependency|{}publicDependency[0]
+        final fun <get-publicDependency>(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/FileDescriptorProto.publicDependency.<get-publicDependency>|<get-publicDependency>(){}[0]
+    final val service // pbandk.wkt/FileDescriptorProto.service|{}service[0]
+        final fun <get-service>(): kotlin.collections/List<pbandk.wkt/ServiceDescriptorProto> // pbandk.wkt/FileDescriptorProto.service.<get-service>|<get-service>(){}[0]
+    final val sourceCodeInfo // pbandk.wkt/FileDescriptorProto.sourceCodeInfo|{}sourceCodeInfo[0]
+        final fun <get-sourceCodeInfo>(): pbandk.wkt/SourceCodeInfo? // pbandk.wkt/FileDescriptorProto.sourceCodeInfo.<get-sourceCodeInfo>|<get-sourceCodeInfo>(){}[0]
+    final val syntax // pbandk.wkt/FileDescriptorProto.syntax|{}syntax[0]
+        final fun <get-syntax>(): kotlin/String? // pbandk.wkt/FileDescriptorProto.syntax.<get-syntax>|<get-syntax>(){}[0]
+    final val unknownFields // pbandk.wkt/FileDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FileDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val weakDependency // pbandk.wkt/FileDescriptorProto.weakDependency|{}weakDependency[0]
+        final fun <get-weakDependency>(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/FileDescriptorProto.weakDependency.<get-weakDependency>|<get-weakDependency>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/FileDescriptorProto.component1|component1(){}[0]
+    final fun component10(): pbandk.wkt/FileOptions? // pbandk.wkt/FileDescriptorProto.component10|component10(){}[0]
+    final fun component11(): pbandk.wkt/SourceCodeInfo? // pbandk.wkt/FileDescriptorProto.component11|component11(){}[0]
+    final fun component12(): kotlin/String? // pbandk.wkt/FileDescriptorProto.component12|component12(){}[0]
+    final fun component13(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FileDescriptorProto.component13|component13(){}[0]
+    final fun component2(): kotlin/String? // pbandk.wkt/FileDescriptorProto.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<kotlin/String> // pbandk.wkt/FileDescriptorProto.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/FileDescriptorProto.component4|component4(){}[0]
+    final fun component5(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/FileDescriptorProto.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/List<pbandk.wkt/DescriptorProto> // pbandk.wkt/FileDescriptorProto.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> // pbandk.wkt/FileDescriptorProto.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/List<pbandk.wkt/ServiceDescriptorProto> // pbandk.wkt/FileDescriptorProto.component8|component8(){}[0]
+    final fun component9(): kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> // pbandk.wkt/FileDescriptorProto.component9|component9(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<pbandk.wkt/DescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/EnumDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/ServiceDescriptorProto> = ..., kotlin.collections/List<pbandk.wkt/FieldDescriptorProto> = ..., pbandk.wkt/FileOptions? = ..., pbandk.wkt/SourceCodeInfo? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/FileDescriptorProto // pbandk.wkt/FileDescriptorProto.copy|copy(kotlin.String?;kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>;kotlin.collections.List<pbandk.wkt.DescriptorProto>;kotlin.collections.List<pbandk.wkt.EnumDescriptorProto>;kotlin.collections.List<pbandk.wkt.ServiceDescriptorProto>;kotlin.collections.List<pbandk.wkt.FieldDescriptorProto>;pbandk.wkt.FileOptions?;pbandk.wkt.SourceCodeInfo?;kotlin.String?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FileDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FileDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FileDescriptorProto // pbandk.wkt/FileDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FileDescriptorProto.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FileDescriptorProto> { // pbandk.wkt/FileDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FileDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FileDescriptorProto // pbandk.wkt/FileDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FileDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FileDescriptorProto> // pbandk.wkt/FileDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FileDescriptorProto // pbandk.wkt/FileDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FileDescriptorSet : pbandk/Message { // pbandk.wkt/FileDescriptorSet|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/FileDescriptorProto> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/FileDescriptorSet.<init>|<init>(kotlin.collections.List<pbandk.wkt.FileDescriptorProto>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/FileDescriptorSet.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FileDescriptorSet> // pbandk.wkt/FileDescriptorSet.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val file // pbandk.wkt/FileDescriptorSet.file|{}file[0]
+        final fun <get-file>(): kotlin.collections/List<pbandk.wkt/FileDescriptorProto> // pbandk.wkt/FileDescriptorSet.file.<get-file>|<get-file>(){}[0]
+    final val protoSize // pbandk.wkt/FileDescriptorSet.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FileDescriptorSet.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/FileDescriptorSet.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FileDescriptorSet.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/FileDescriptorProto> // pbandk.wkt/FileDescriptorSet.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FileDescriptorSet.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/FileDescriptorProto> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/FileDescriptorSet // pbandk.wkt/FileDescriptorSet.copy|copy(kotlin.collections.List<pbandk.wkt.FileDescriptorProto>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FileDescriptorSet.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FileDescriptorSet.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FileDescriptorSet // pbandk.wkt/FileDescriptorSet.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FileDescriptorSet.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FileDescriptorSet> { // pbandk.wkt/FileDescriptorSet.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FileDescriptorSet.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FileDescriptorSet // pbandk.wkt/FileDescriptorSet.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FileDescriptorSet.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FileDescriptorSet> // pbandk.wkt/FileDescriptorSet.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FileDescriptorSet // pbandk.wkt/FileDescriptorSet.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FileOptions : pbandk/ExtendableMessage { // pbandk.wkt/FileOptions|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., pbandk.wkt/FileOptions.OptimizeMode? = ..., kotlin/String? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/FileOptions.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;pbandk.wkt.FileOptions.OptimizeMode?;kotlin.String?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val ccEnableArenas // pbandk.wkt/FileOptions.ccEnableArenas|{}ccEnableArenas[0]
+        final fun <get-ccEnableArenas>(): kotlin/Boolean? // pbandk.wkt/FileOptions.ccEnableArenas.<get-ccEnableArenas>|<get-ccEnableArenas>(){}[0]
+    final val ccGenericServices // pbandk.wkt/FileOptions.ccGenericServices|{}ccGenericServices[0]
+        final fun <get-ccGenericServices>(): kotlin/Boolean? // pbandk.wkt/FileOptions.ccGenericServices.<get-ccGenericServices>|<get-ccGenericServices>(){}[0]
+    final val csharpNamespace // pbandk.wkt/FileOptions.csharpNamespace|{}csharpNamespace[0]
+        final fun <get-csharpNamespace>(): kotlin/String? // pbandk.wkt/FileOptions.csharpNamespace.<get-csharpNamespace>|<get-csharpNamespace>(){}[0]
+    final val deprecated // pbandk.wkt/FileOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/FileOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/FileOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FileOptions> // pbandk.wkt/FileOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val goPackage // pbandk.wkt/FileOptions.goPackage|{}goPackage[0]
+        final fun <get-goPackage>(): kotlin/String? // pbandk.wkt/FileOptions.goPackage.<get-goPackage>|<get-goPackage>(){}[0]
+    final val javaGenerateEqualsAndHash // pbandk.wkt/FileOptions.javaGenerateEqualsAndHash|{}javaGenerateEqualsAndHash[0]
+        final fun <get-javaGenerateEqualsAndHash>(): kotlin/Boolean? // pbandk.wkt/FileOptions.javaGenerateEqualsAndHash.<get-javaGenerateEqualsAndHash>|<get-javaGenerateEqualsAndHash>(){}[0]
+    final val javaGenericServices // pbandk.wkt/FileOptions.javaGenericServices|{}javaGenericServices[0]
+        final fun <get-javaGenericServices>(): kotlin/Boolean? // pbandk.wkt/FileOptions.javaGenericServices.<get-javaGenericServices>|<get-javaGenericServices>(){}[0]
+    final val javaMultipleFiles // pbandk.wkt/FileOptions.javaMultipleFiles|{}javaMultipleFiles[0]
+        final fun <get-javaMultipleFiles>(): kotlin/Boolean? // pbandk.wkt/FileOptions.javaMultipleFiles.<get-javaMultipleFiles>|<get-javaMultipleFiles>(){}[0]
+    final val javaOuterClassname // pbandk.wkt/FileOptions.javaOuterClassname|{}javaOuterClassname[0]
+        final fun <get-javaOuterClassname>(): kotlin/String? // pbandk.wkt/FileOptions.javaOuterClassname.<get-javaOuterClassname>|<get-javaOuterClassname>(){}[0]
+    final val javaPackage // pbandk.wkt/FileOptions.javaPackage|{}javaPackage[0]
+        final fun <get-javaPackage>(): kotlin/String? // pbandk.wkt/FileOptions.javaPackage.<get-javaPackage>|<get-javaPackage>(){}[0]
+    final val javaStringCheckUtf8 // pbandk.wkt/FileOptions.javaStringCheckUtf8|{}javaStringCheckUtf8[0]
+        final fun <get-javaStringCheckUtf8>(): kotlin/Boolean? // pbandk.wkt/FileOptions.javaStringCheckUtf8.<get-javaStringCheckUtf8>|<get-javaStringCheckUtf8>(){}[0]
+    final val objcClassPrefix // pbandk.wkt/FileOptions.objcClassPrefix|{}objcClassPrefix[0]
+        final fun <get-objcClassPrefix>(): kotlin/String? // pbandk.wkt/FileOptions.objcClassPrefix.<get-objcClassPrefix>|<get-objcClassPrefix>(){}[0]
+    final val optimizeFor // pbandk.wkt/FileOptions.optimizeFor|{}optimizeFor[0]
+        final fun <get-optimizeFor>(): pbandk.wkt/FileOptions.OptimizeMode? // pbandk.wkt/FileOptions.optimizeFor.<get-optimizeFor>|<get-optimizeFor>(){}[0]
+    final val phpClassPrefix // pbandk.wkt/FileOptions.phpClassPrefix|{}phpClassPrefix[0]
+        final fun <get-phpClassPrefix>(): kotlin/String? // pbandk.wkt/FileOptions.phpClassPrefix.<get-phpClassPrefix>|<get-phpClassPrefix>(){}[0]
+    final val phpGenericServices // pbandk.wkt/FileOptions.phpGenericServices|{}phpGenericServices[0]
+        final fun <get-phpGenericServices>(): kotlin/Boolean? // pbandk.wkt/FileOptions.phpGenericServices.<get-phpGenericServices>|<get-phpGenericServices>(){}[0]
+    final val phpMetadataNamespace // pbandk.wkt/FileOptions.phpMetadataNamespace|{}phpMetadataNamespace[0]
+        final fun <get-phpMetadataNamespace>(): kotlin/String? // pbandk.wkt/FileOptions.phpMetadataNamespace.<get-phpMetadataNamespace>|<get-phpMetadataNamespace>(){}[0]
+    final val phpNamespace // pbandk.wkt/FileOptions.phpNamespace|{}phpNamespace[0]
+        final fun <get-phpNamespace>(): kotlin/String? // pbandk.wkt/FileOptions.phpNamespace.<get-phpNamespace>|<get-phpNamespace>(){}[0]
+    final val protoSize // pbandk.wkt/FileOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FileOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val pyGenericServices // pbandk.wkt/FileOptions.pyGenericServices|{}pyGenericServices[0]
+        final fun <get-pyGenericServices>(): kotlin/Boolean? // pbandk.wkt/FileOptions.pyGenericServices.<get-pyGenericServices>|<get-pyGenericServices>(){}[0]
+    final val rubyPackage // pbandk.wkt/FileOptions.rubyPackage|{}rubyPackage[0]
+        final fun <get-rubyPackage>(): kotlin/String? // pbandk.wkt/FileOptions.rubyPackage.<get-rubyPackage>|<get-rubyPackage>(){}[0]
+    final val swiftPrefix // pbandk.wkt/FileOptions.swiftPrefix|{}swiftPrefix[0]
+        final fun <get-swiftPrefix>(): kotlin/String? // pbandk.wkt/FileOptions.swiftPrefix.<get-swiftPrefix>|<get-swiftPrefix>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/FileOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/FileOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/FileOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FileOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/FileOptions.component1|component1(){}[0]
+    final fun component10(): kotlin/Boolean? // pbandk.wkt/FileOptions.component10|component10(){}[0]
+    final fun component11(): kotlin/Boolean? // pbandk.wkt/FileOptions.component11|component11(){}[0]
+    final fun component12(): kotlin/Boolean? // pbandk.wkt/FileOptions.component12|component12(){}[0]
+    final fun component13(): kotlin/Boolean? // pbandk.wkt/FileOptions.component13|component13(){}[0]
+    final fun component14(): kotlin/String? // pbandk.wkt/FileOptions.component14|component14(){}[0]
+    final fun component15(): kotlin/String? // pbandk.wkt/FileOptions.component15|component15(){}[0]
+    final fun component16(): kotlin/String? // pbandk.wkt/FileOptions.component16|component16(){}[0]
+    final fun component17(): kotlin/String? // pbandk.wkt/FileOptions.component17|component17(){}[0]
+    final fun component18(): kotlin/String? // pbandk.wkt/FileOptions.component18|component18(){}[0]
+    final fun component19(): kotlin/String? // pbandk.wkt/FileOptions.component19|component19(){}[0]
+    final fun component2(): kotlin/String? // pbandk.wkt/FileOptions.component2|component2(){}[0]
+    final fun component20(): kotlin/String? // pbandk.wkt/FileOptions.component20|component20(){}[0]
+    final fun component21(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/FileOptions.component21|component21(){}[0]
+    final fun component22(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FileOptions.component22|component22(){}[0]
+    final fun component23(): pbandk/ExtensionFieldSet // pbandk.wkt/FileOptions.component23|component23(){}[0]
+    final fun component3(): kotlin/Boolean? // pbandk.wkt/FileOptions.component3|component3(){}[0]
+    final fun component4(): kotlin/Boolean? // pbandk.wkt/FileOptions.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean? // pbandk.wkt/FileOptions.component5|component5(){}[0]
+    final fun component6(): pbandk.wkt/FileOptions.OptimizeMode? // pbandk.wkt/FileOptions.component6|component6(){}[0]
+    final fun component7(): kotlin/String? // pbandk.wkt/FileOptions.component7|component7(){}[0]
+    final fun component8(): kotlin/Boolean? // pbandk.wkt/FileOptions.component8|component8(){}[0]
+    final fun component9(): kotlin/Boolean? // pbandk.wkt/FileOptions.component9|component9(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., pbandk.wkt/FileOptions.OptimizeMode? = ..., kotlin/String? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/FileOptions // pbandk.wkt/FileOptions.copy|copy(kotlin.String?;kotlin.String?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;pbandk.wkt.FileOptions.OptimizeMode?;kotlin.String?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.String?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FileOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FileOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FileOptions // pbandk.wkt/FileOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FileOptions.toString|toString(){}[0]
+
+    sealed class OptimizeMode : pbandk/Message.Enum { // pbandk.wkt/FileOptions.OptimizeMode|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/FileOptions.OptimizeMode.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/FileOptions.OptimizeMode.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/FileOptions.OptimizeMode.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/FileOptions.OptimizeMode.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/FileOptions.OptimizeMode.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FileOptions.OptimizeMode.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/FileOptions.OptimizeMode.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/FileOptions.OptimizeMode.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/FileOptions.OptimizeMode { // pbandk.wkt/FileOptions.OptimizeMode.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/FileOptions.OptimizeMode.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object CODE_SIZE : pbandk.wkt/FileOptions.OptimizeMode // pbandk.wkt/FileOptions.OptimizeMode.CODE_SIZE|null[0]
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/FileOptions.OptimizeMode> { // pbandk.wkt/FileOptions.OptimizeMode.Companion|null[0]
+            final val values // pbandk.wkt/FileOptions.OptimizeMode.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/FileOptions.OptimizeMode> // pbandk.wkt/FileOptions.OptimizeMode.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/FileOptions.OptimizeMode // pbandk.wkt/FileOptions.OptimizeMode.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/FileOptions.OptimizeMode // pbandk.wkt/FileOptions.OptimizeMode.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object LITE_RUNTIME : pbandk.wkt/FileOptions.OptimizeMode // pbandk.wkt/FileOptions.OptimizeMode.LITE_RUNTIME|null[0]
+
+        final object SPEED : pbandk.wkt/FileOptions.OptimizeMode // pbandk.wkt/FileOptions.OptimizeMode.SPEED|null[0]
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FileOptions> { // pbandk.wkt/FileOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FileOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FileOptions // pbandk.wkt/FileOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FileOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FileOptions> // pbandk.wkt/FileOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FileOptions // pbandk.wkt/FileOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/FloatValue : pbandk/Message { // pbandk.wkt/FloatValue|null[0]
+    constructor <init>(kotlin/Float = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/FloatValue.<init>|<init>(kotlin.Float;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/FloatValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FloatValue> // pbandk.wkt/FloatValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/FloatValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/FloatValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/FloatValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FloatValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/FloatValue.value|{}value[0]
+        final fun <get-value>(): kotlin/Float // pbandk.wkt/FloatValue.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Float // pbandk.wkt/FloatValue.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/FloatValue.component2|component2(){}[0]
+    final fun copy(kotlin/Float = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/FloatValue // pbandk.wkt/FloatValue.copy|copy(kotlin.Float;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/FloatValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/FloatValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/FloatValue // pbandk.wkt/FloatValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/FloatValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/FloatValue> { // pbandk.wkt/FloatValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/FloatValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/FloatValue // pbandk.wkt/FloatValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/FloatValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/FloatValue> // pbandk.wkt/FloatValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/FloatValue // pbandk.wkt/FloatValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/GeneratedCodeInfo : pbandk/Message { // pbandk.wkt/GeneratedCodeInfo|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/GeneratedCodeInfo.Annotation> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/GeneratedCodeInfo.<init>|<init>(kotlin.collections.List<pbandk.wkt.GeneratedCodeInfo.Annotation>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val annotation // pbandk.wkt/GeneratedCodeInfo.annotation|{}annotation[0]
+        final fun <get-annotation>(): kotlin.collections/List<pbandk.wkt/GeneratedCodeInfo.Annotation> // pbandk.wkt/GeneratedCodeInfo.annotation.<get-annotation>|<get-annotation>(){}[0]
+    final val descriptor // pbandk.wkt/GeneratedCodeInfo.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/GeneratedCodeInfo> // pbandk.wkt/GeneratedCodeInfo.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/GeneratedCodeInfo.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/GeneratedCodeInfo.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/GeneratedCodeInfo.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/GeneratedCodeInfo.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/GeneratedCodeInfo.Annotation> // pbandk.wkt/GeneratedCodeInfo.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/GeneratedCodeInfo.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/GeneratedCodeInfo.Annotation> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/GeneratedCodeInfo // pbandk.wkt/GeneratedCodeInfo.copy|copy(kotlin.collections.List<pbandk.wkt.GeneratedCodeInfo.Annotation>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/GeneratedCodeInfo.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/GeneratedCodeInfo.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/GeneratedCodeInfo // pbandk.wkt/GeneratedCodeInfo.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/GeneratedCodeInfo.toString|toString(){}[0]
+
+    final class Annotation : pbandk/Message { // pbandk.wkt/GeneratedCodeInfo.Annotation|null[0]
+        constructor <init>(kotlin.collections/List<kotlin/Int> = ..., kotlin/String? = ..., kotlin/Int? = ..., kotlin/Int? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/GeneratedCodeInfo.Annotation.<init>|<init>(kotlin.collections.List<kotlin.Int>;kotlin.String?;kotlin.Int?;kotlin.Int?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val begin // pbandk.wkt/GeneratedCodeInfo.Annotation.begin|{}begin[0]
+            final fun <get-begin>(): kotlin/Int? // pbandk.wkt/GeneratedCodeInfo.Annotation.begin.<get-begin>|<get-begin>(){}[0]
+        final val descriptor // pbandk.wkt/GeneratedCodeInfo.Annotation.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/GeneratedCodeInfo.Annotation> // pbandk.wkt/GeneratedCodeInfo.Annotation.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val end // pbandk.wkt/GeneratedCodeInfo.Annotation.end|{}end[0]
+            final fun <get-end>(): kotlin/Int? // pbandk.wkt/GeneratedCodeInfo.Annotation.end.<get-end>|<get-end>(){}[0]
+        final val path // pbandk.wkt/GeneratedCodeInfo.Annotation.path|{}path[0]
+            final fun <get-path>(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/GeneratedCodeInfo.Annotation.path.<get-path>|<get-path>(){}[0]
+        final val protoSize // pbandk.wkt/GeneratedCodeInfo.Annotation.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/GeneratedCodeInfo.Annotation.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val sourceFile // pbandk.wkt/GeneratedCodeInfo.Annotation.sourceFile|{}sourceFile[0]
+            final fun <get-sourceFile>(): kotlin/String? // pbandk.wkt/GeneratedCodeInfo.Annotation.sourceFile.<get-sourceFile>|<get-sourceFile>(){}[0]
+        final val unknownFields // pbandk.wkt/GeneratedCodeInfo.Annotation.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/GeneratedCodeInfo.Annotation.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+        final fun component1(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/GeneratedCodeInfo.Annotation.component1|component1(){}[0]
+        final fun component2(): kotlin/String? // pbandk.wkt/GeneratedCodeInfo.Annotation.component2|component2(){}[0]
+        final fun component3(): kotlin/Int? // pbandk.wkt/GeneratedCodeInfo.Annotation.component3|component3(){}[0]
+        final fun component4(): kotlin/Int? // pbandk.wkt/GeneratedCodeInfo.Annotation.component4|component4(){}[0]
+        final fun component5(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/GeneratedCodeInfo.Annotation.component5|component5(){}[0]
+        final fun copy(kotlin.collections/List<kotlin/Int> = ..., kotlin/String? = ..., kotlin/Int? = ..., kotlin/Int? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/GeneratedCodeInfo.Annotation // pbandk.wkt/GeneratedCodeInfo.Annotation.copy|copy(kotlin.collections.List<kotlin.Int>;kotlin.String?;kotlin.Int?;kotlin.Int?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/GeneratedCodeInfo.Annotation.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/GeneratedCodeInfo.Annotation.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/GeneratedCodeInfo.Annotation // pbandk.wkt/GeneratedCodeInfo.Annotation.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/GeneratedCodeInfo.Annotation.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/GeneratedCodeInfo.Annotation> { // pbandk.wkt/GeneratedCodeInfo.Annotation.Companion|null[0]
+            final val defaultInstance // pbandk.wkt/GeneratedCodeInfo.Annotation.Companion.defaultInstance|{}defaultInstance[0]
+                final fun <get-defaultInstance>(): pbandk.wkt/GeneratedCodeInfo.Annotation // pbandk.wkt/GeneratedCodeInfo.Annotation.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+            final val descriptor // pbandk.wkt/GeneratedCodeInfo.Annotation.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/GeneratedCodeInfo.Annotation> // pbandk.wkt/GeneratedCodeInfo.Annotation.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/GeneratedCodeInfo.Annotation // pbandk.wkt/GeneratedCodeInfo.Annotation.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/GeneratedCodeInfo> { // pbandk.wkt/GeneratedCodeInfo.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/GeneratedCodeInfo.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/GeneratedCodeInfo // pbandk.wkt/GeneratedCodeInfo.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/GeneratedCodeInfo.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/GeneratedCodeInfo> // pbandk.wkt/GeneratedCodeInfo.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/GeneratedCodeInfo // pbandk.wkt/GeneratedCodeInfo.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Int32Value : pbandk/Message { // pbandk.wkt/Int32Value|null[0]
+    constructor <init>(kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Int32Value.<init>|<init>(kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Int32Value.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Int32Value> // pbandk.wkt/Int32Value.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/Int32Value.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Int32Value.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/Int32Value.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Int32Value.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/Int32Value.value|{}value[0]
+        final fun <get-value>(): kotlin/Int // pbandk.wkt/Int32Value.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Int // pbandk.wkt/Int32Value.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Int32Value.component2|component2(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Int32Value // pbandk.wkt/Int32Value.copy|copy(kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Int32Value.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Int32Value.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Int32Value // pbandk.wkt/Int32Value.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Int32Value.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Int32Value> { // pbandk.wkt/Int32Value.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Int32Value.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Int32Value // pbandk.wkt/Int32Value.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Int32Value.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Int32Value> // pbandk.wkt/Int32Value.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Int32Value // pbandk.wkt/Int32Value.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Int64Value : pbandk/Message { // pbandk.wkt/Int64Value|null[0]
+    constructor <init>(kotlin/Long = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Int64Value.<init>|<init>(kotlin.Long;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Int64Value.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Int64Value> // pbandk.wkt/Int64Value.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/Int64Value.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Int64Value.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/Int64Value.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Int64Value.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/Int64Value.value|{}value[0]
+        final fun <get-value>(): kotlin/Long // pbandk.wkt/Int64Value.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Long // pbandk.wkt/Int64Value.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Int64Value.component2|component2(){}[0]
+    final fun copy(kotlin/Long = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Int64Value // pbandk.wkt/Int64Value.copy|copy(kotlin.Long;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Int64Value.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Int64Value.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Int64Value // pbandk.wkt/Int64Value.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Int64Value.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Int64Value> { // pbandk.wkt/Int64Value.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Int64Value.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Int64Value // pbandk.wkt/Int64Value.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Int64Value.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Int64Value> // pbandk.wkt/Int64Value.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Int64Value // pbandk.wkt/Int64Value.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/ListValue : pbandk/Message { // pbandk.wkt/ListValue|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/Value> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/ListValue.<init>|<init>(kotlin.collections.List<pbandk.wkt.Value>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/ListValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ListValue> // pbandk.wkt/ListValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/ListValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/ListValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/ListValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ListValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val values // pbandk.wkt/ListValue.values|{}values[0]
+        final fun <get-values>(): kotlin.collections/List<pbandk.wkt/Value> // pbandk.wkt/ListValue.values.<get-values>|<get-values>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/Value> // pbandk.wkt/ListValue.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ListValue.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/Value> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/ListValue // pbandk.wkt/ListValue.copy|copy(kotlin.collections.List<pbandk.wkt.Value>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/ListValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/ListValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/ListValue // pbandk.wkt/ListValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/ListValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/ListValue> { // pbandk.wkt/ListValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/ListValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/ListValue // pbandk.wkt/ListValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/ListValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ListValue> // pbandk.wkt/ListValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/ListValue // pbandk.wkt/ListValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/MessageOptions : pbandk/ExtendableMessage { // pbandk.wkt/MessageOptions|null[0]
+    constructor <init>(kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/MessageOptions.<init>|<init>(kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val deprecated // pbandk.wkt/MessageOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/MessageOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/MessageOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/MessageOptions> // pbandk.wkt/MessageOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val mapEntry // pbandk.wkt/MessageOptions.mapEntry|{}mapEntry[0]
+        final fun <get-mapEntry>(): kotlin/Boolean? // pbandk.wkt/MessageOptions.mapEntry.<get-mapEntry>|<get-mapEntry>(){}[0]
+    final val messageSetWireFormat // pbandk.wkt/MessageOptions.messageSetWireFormat|{}messageSetWireFormat[0]
+        final fun <get-messageSetWireFormat>(): kotlin/Boolean? // pbandk.wkt/MessageOptions.messageSetWireFormat.<get-messageSetWireFormat>|<get-messageSetWireFormat>(){}[0]
+    final val noStandardDescriptorAccessor // pbandk.wkt/MessageOptions.noStandardDescriptorAccessor|{}noStandardDescriptorAccessor[0]
+        final fun <get-noStandardDescriptorAccessor>(): kotlin/Boolean? // pbandk.wkt/MessageOptions.noStandardDescriptorAccessor.<get-noStandardDescriptorAccessor>|<get-noStandardDescriptorAccessor>(){}[0]
+    final val protoSize // pbandk.wkt/MessageOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/MessageOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/MessageOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/MessageOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/MessageOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/MessageOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Boolean? // pbandk.wkt/MessageOptions.component1|component1(){}[0]
+    final fun component2(): kotlin/Boolean? // pbandk.wkt/MessageOptions.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean? // pbandk.wkt/MessageOptions.component3|component3(){}[0]
+    final fun component4(): kotlin/Boolean? // pbandk.wkt/MessageOptions.component4|component4(){}[0]
+    final fun component5(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/MessageOptions.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/MessageOptions.component6|component6(){}[0]
+    final fun component7(): pbandk/ExtensionFieldSet // pbandk.wkt/MessageOptions.component7|component7(){}[0]
+    final fun copy(kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/MessageOptions // pbandk.wkt/MessageOptions.copy|copy(kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/MessageOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/MessageOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/MessageOptions // pbandk.wkt/MessageOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/MessageOptions.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/MessageOptions> { // pbandk.wkt/MessageOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/MessageOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/MessageOptions // pbandk.wkt/MessageOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/MessageOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/MessageOptions> // pbandk.wkt/MessageOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/MessageOptions // pbandk.wkt/MessageOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Method : pbandk/Message { // pbandk.wkt/Method|null[0]
+    constructor <init>(kotlin/String = ..., kotlin/String = ..., kotlin/Boolean = ..., kotlin/String = ..., kotlin/Boolean = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Method.<init>|<init>(kotlin.String;kotlin.String;kotlin.Boolean;kotlin.String;kotlin.Boolean;kotlin.collections.List<pbandk.wkt.Option>;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Method.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Method> // pbandk.wkt/Method.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/Method.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Method.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/Method.options|{}options[0]
+        final fun <get-options>(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Method.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/Method.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Method.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val requestStreaming // pbandk.wkt/Method.requestStreaming|{}requestStreaming[0]
+        final fun <get-requestStreaming>(): kotlin/Boolean // pbandk.wkt/Method.requestStreaming.<get-requestStreaming>|<get-requestStreaming>(){}[0]
+    final val requestTypeUrl // pbandk.wkt/Method.requestTypeUrl|{}requestTypeUrl[0]
+        final fun <get-requestTypeUrl>(): kotlin/String // pbandk.wkt/Method.requestTypeUrl.<get-requestTypeUrl>|<get-requestTypeUrl>(){}[0]
+    final val responseStreaming // pbandk.wkt/Method.responseStreaming|{}responseStreaming[0]
+        final fun <get-responseStreaming>(): kotlin/Boolean // pbandk.wkt/Method.responseStreaming.<get-responseStreaming>|<get-responseStreaming>(){}[0]
+    final val responseTypeUrl // pbandk.wkt/Method.responseTypeUrl|{}responseTypeUrl[0]
+        final fun <get-responseTypeUrl>(): kotlin/String // pbandk.wkt/Method.responseTypeUrl.<get-responseTypeUrl>|<get-responseTypeUrl>(){}[0]
+    final val syntax // pbandk.wkt/Method.syntax|{}syntax[0]
+        final fun <get-syntax>(): pbandk.wkt/Syntax // pbandk.wkt/Method.syntax.<get-syntax>|<get-syntax>(){}[0]
+    final val unknownFields // pbandk.wkt/Method.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Method.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Method.component1|component1(){}[0]
+    final fun component2(): kotlin/String // pbandk.wkt/Method.component2|component2(){}[0]
+    final fun component3(): kotlin/Boolean // pbandk.wkt/Method.component3|component3(){}[0]
+    final fun component4(): kotlin/String // pbandk.wkt/Method.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean // pbandk.wkt/Method.component5|component5(){}[0]
+    final fun component6(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Method.component6|component6(){}[0]
+    final fun component7(): pbandk.wkt/Syntax // pbandk.wkt/Method.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Method.component8|component8(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin/Boolean = ..., kotlin/String = ..., kotlin/Boolean = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Method // pbandk.wkt/Method.copy|copy(kotlin.String;kotlin.String;kotlin.Boolean;kotlin.String;kotlin.Boolean;kotlin.collections.List<pbandk.wkt.Option>;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Method.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Method.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Method // pbandk.wkt/Method.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Method.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Method> { // pbandk.wkt/Method.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Method.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Method // pbandk.wkt/Method.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Method.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Method> // pbandk.wkt/Method.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Method // pbandk.wkt/Method.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/MethodDescriptorProto : pbandk/Message { // pbandk.wkt/MethodDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., pbandk.wkt/MethodOptions? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/MethodDescriptorProto.<init>|<init>(kotlin.String?;kotlin.String?;kotlin.String?;pbandk.wkt.MethodOptions?;kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val clientStreaming // pbandk.wkt/MethodDescriptorProto.clientStreaming|{}clientStreaming[0]
+        final fun <get-clientStreaming>(): kotlin/Boolean? // pbandk.wkt/MethodDescriptorProto.clientStreaming.<get-clientStreaming>|<get-clientStreaming>(){}[0]
+    final val descriptor // pbandk.wkt/MethodDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/MethodDescriptorProto> // pbandk.wkt/MethodDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val inputType // pbandk.wkt/MethodDescriptorProto.inputType|{}inputType[0]
+        final fun <get-inputType>(): kotlin/String? // pbandk.wkt/MethodDescriptorProto.inputType.<get-inputType>|<get-inputType>(){}[0]
+    final val name // pbandk.wkt/MethodDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/MethodDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/MethodDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/MethodOptions? // pbandk.wkt/MethodDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val outputType // pbandk.wkt/MethodDescriptorProto.outputType|{}outputType[0]
+        final fun <get-outputType>(): kotlin/String? // pbandk.wkt/MethodDescriptorProto.outputType.<get-outputType>|<get-outputType>(){}[0]
+    final val protoSize // pbandk.wkt/MethodDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/MethodDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val serverStreaming // pbandk.wkt/MethodDescriptorProto.serverStreaming|{}serverStreaming[0]
+        final fun <get-serverStreaming>(): kotlin/Boolean? // pbandk.wkt/MethodDescriptorProto.serverStreaming.<get-serverStreaming>|<get-serverStreaming>(){}[0]
+    final val unknownFields // pbandk.wkt/MethodDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/MethodDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/MethodDescriptorProto.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // pbandk.wkt/MethodDescriptorProto.component2|component2(){}[0]
+    final fun component3(): kotlin/String? // pbandk.wkt/MethodDescriptorProto.component3|component3(){}[0]
+    final fun component4(): pbandk.wkt/MethodOptions? // pbandk.wkt/MethodDescriptorProto.component4|component4(){}[0]
+    final fun component5(): kotlin/Boolean? // pbandk.wkt/MethodDescriptorProto.component5|component5(){}[0]
+    final fun component6(): kotlin/Boolean? // pbandk.wkt/MethodDescriptorProto.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/MethodDescriptorProto.component7|component7(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin/String? = ..., kotlin/String? = ..., pbandk.wkt/MethodOptions? = ..., kotlin/Boolean? = ..., kotlin/Boolean? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/MethodDescriptorProto // pbandk.wkt/MethodDescriptorProto.copy|copy(kotlin.String?;kotlin.String?;kotlin.String?;pbandk.wkt.MethodOptions?;kotlin.Boolean?;kotlin.Boolean?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/MethodDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/MethodDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/MethodDescriptorProto // pbandk.wkt/MethodDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/MethodDescriptorProto.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/MethodDescriptorProto> { // pbandk.wkt/MethodDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/MethodDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/MethodDescriptorProto // pbandk.wkt/MethodDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/MethodDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/MethodDescriptorProto> // pbandk.wkt/MethodDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/MethodDescriptorProto // pbandk.wkt/MethodDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/MethodOptions : pbandk/ExtendableMessage { // pbandk.wkt/MethodOptions|null[0]
+    constructor <init>(kotlin/Boolean? = ..., pbandk.wkt/MethodOptions.IdempotencyLevel? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/MethodOptions.<init>|<init>(kotlin.Boolean?;pbandk.wkt.MethodOptions.IdempotencyLevel?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val deprecated // pbandk.wkt/MethodOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/MethodOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/MethodOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/MethodOptions> // pbandk.wkt/MethodOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val idempotencyLevel // pbandk.wkt/MethodOptions.idempotencyLevel|{}idempotencyLevel[0]
+        final fun <get-idempotencyLevel>(): pbandk.wkt/MethodOptions.IdempotencyLevel? // pbandk.wkt/MethodOptions.idempotencyLevel.<get-idempotencyLevel>|<get-idempotencyLevel>(){}[0]
+    final val protoSize // pbandk.wkt/MethodOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/MethodOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/MethodOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/MethodOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/MethodOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/MethodOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Boolean? // pbandk.wkt/MethodOptions.component1|component1(){}[0]
+    final fun component2(): pbandk.wkt/MethodOptions.IdempotencyLevel? // pbandk.wkt/MethodOptions.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/MethodOptions.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/MethodOptions.component4|component4(){}[0]
+    final fun component5(): pbandk/ExtensionFieldSet // pbandk.wkt/MethodOptions.component5|component5(){}[0]
+    final fun copy(kotlin/Boolean? = ..., pbandk.wkt/MethodOptions.IdempotencyLevel? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/MethodOptions // pbandk.wkt/MethodOptions.copy|copy(kotlin.Boolean?;pbandk.wkt.MethodOptions.IdempotencyLevel?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/MethodOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/MethodOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/MethodOptions // pbandk.wkt/MethodOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/MethodOptions.toString|toString(){}[0]
+
+    sealed class IdempotencyLevel : pbandk/Message.Enum { // pbandk.wkt/MethodOptions.IdempotencyLevel|null[0]
+        constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/MethodOptions.IdempotencyLevel.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+        open val name // pbandk.wkt/MethodOptions.IdempotencyLevel.name|{}name[0]
+            open fun <get-name>(): kotlin/String? // pbandk.wkt/MethodOptions.IdempotencyLevel.name.<get-name>|<get-name>(){}[0]
+        open val value // pbandk.wkt/MethodOptions.IdempotencyLevel.value|{}value[0]
+            open fun <get-value>(): kotlin/Int // pbandk.wkt/MethodOptions.IdempotencyLevel.value.<get-value>|<get-value>(){}[0]
+
+        open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/MethodOptions.IdempotencyLevel.equals|equals(kotlin.Any?){}[0]
+        open fun hashCode(): kotlin/Int // pbandk.wkt/MethodOptions.IdempotencyLevel.hashCode|hashCode(){}[0]
+        open fun toString(): kotlin/String // pbandk.wkt/MethodOptions.IdempotencyLevel.toString|toString(){}[0]
+
+        final class UNRECOGNIZED : pbandk.wkt/MethodOptions.IdempotencyLevel { // pbandk.wkt/MethodOptions.IdempotencyLevel.UNRECOGNIZED|null[0]
+            constructor <init>(kotlin/Int) // pbandk.wkt/MethodOptions.IdempotencyLevel.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+        }
+
+        final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/MethodOptions.IdempotencyLevel> { // pbandk.wkt/MethodOptions.IdempotencyLevel.Companion|null[0]
+            final val values // pbandk.wkt/MethodOptions.IdempotencyLevel.Companion.values|{}values[0]
+                final fun <get-values>(): kotlin.collections/List<pbandk.wkt/MethodOptions.IdempotencyLevel> // pbandk.wkt/MethodOptions.IdempotencyLevel.Companion.values.<get-values>|<get-values>(){}[0]
+
+            final fun fromName(kotlin/String): pbandk.wkt/MethodOptions.IdempotencyLevel // pbandk.wkt/MethodOptions.IdempotencyLevel.Companion.fromName|fromName(kotlin.String){}[0]
+            final fun fromValue(kotlin/Int): pbandk.wkt/MethodOptions.IdempotencyLevel // pbandk.wkt/MethodOptions.IdempotencyLevel.Companion.fromValue|fromValue(kotlin.Int){}[0]
+        }
+
+        final object IDEMPOTENCY_UNKNOWN : pbandk.wkt/MethodOptions.IdempotencyLevel // pbandk.wkt/MethodOptions.IdempotencyLevel.IDEMPOTENCY_UNKNOWN|null[0]
+
+        final object IDEMPOTENT : pbandk.wkt/MethodOptions.IdempotencyLevel // pbandk.wkt/MethodOptions.IdempotencyLevel.IDEMPOTENT|null[0]
+
+        final object NO_SIDE_EFFECTS : pbandk.wkt/MethodOptions.IdempotencyLevel // pbandk.wkt/MethodOptions.IdempotencyLevel.NO_SIDE_EFFECTS|null[0]
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/MethodOptions> { // pbandk.wkt/MethodOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/MethodOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/MethodOptions // pbandk.wkt/MethodOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/MethodOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/MethodOptions> // pbandk.wkt/MethodOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/MethodOptions // pbandk.wkt/MethodOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Mixin : pbandk/Message { // pbandk.wkt/Mixin|null[0]
+    constructor <init>(kotlin/String = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Mixin.<init>|<init>(kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Mixin.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Mixin> // pbandk.wkt/Mixin.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/Mixin.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Mixin.name.<get-name>|<get-name>(){}[0]
+    final val protoSize // pbandk.wkt/Mixin.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Mixin.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val root // pbandk.wkt/Mixin.root|{}root[0]
+        final fun <get-root>(): kotlin/String // pbandk.wkt/Mixin.root.<get-root>|<get-root>(){}[0]
+    final val unknownFields // pbandk.wkt/Mixin.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Mixin.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Mixin.component1|component1(){}[0]
+    final fun component2(): kotlin/String // pbandk.wkt/Mixin.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Mixin.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Mixin // pbandk.wkt/Mixin.copy|copy(kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Mixin.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Mixin.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Mixin // pbandk.wkt/Mixin.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Mixin.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Mixin> { // pbandk.wkt/Mixin.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Mixin.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Mixin // pbandk.wkt/Mixin.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Mixin.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Mixin> // pbandk.wkt/Mixin.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Mixin // pbandk.wkt/Mixin.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/OneofDescriptorProto : pbandk/Message { // pbandk.wkt/OneofDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., pbandk.wkt/OneofOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/OneofDescriptorProto.<init>|<init>(kotlin.String?;pbandk.wkt.OneofOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/OneofDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/OneofDescriptorProto> // pbandk.wkt/OneofDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/OneofDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/OneofDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/OneofDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/OneofOptions? // pbandk.wkt/OneofDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/OneofDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/OneofDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/OneofDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/OneofDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/OneofDescriptorProto.component1|component1(){}[0]
+    final fun component2(): pbandk.wkt/OneofOptions? // pbandk.wkt/OneofDescriptorProto.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/OneofDescriptorProto.component3|component3(){}[0]
+    final fun copy(kotlin/String? = ..., pbandk.wkt/OneofOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/OneofDescriptorProto // pbandk.wkt/OneofDescriptorProto.copy|copy(kotlin.String?;pbandk.wkt.OneofOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/OneofDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/OneofDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/OneofDescriptorProto // pbandk.wkt/OneofDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/OneofDescriptorProto.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/OneofDescriptorProto> { // pbandk.wkt/OneofDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/OneofDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/OneofDescriptorProto // pbandk.wkt/OneofDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/OneofDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/OneofDescriptorProto> // pbandk.wkt/OneofDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/OneofDescriptorProto // pbandk.wkt/OneofDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/OneofOptions : pbandk/ExtendableMessage { // pbandk.wkt/OneofOptions|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/OneofOptions.<init>|<init>(kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val descriptor // pbandk.wkt/OneofOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/OneofOptions> // pbandk.wkt/OneofOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/OneofOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/OneofOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/OneofOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/OneofOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/OneofOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/OneofOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/OneofOptions.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/OneofOptions.component2|component2(){}[0]
+    final fun component3(): pbandk/ExtensionFieldSet // pbandk.wkt/OneofOptions.component3|component3(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/OneofOptions // pbandk.wkt/OneofOptions.copy|copy(kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/OneofOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/OneofOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/OneofOptions // pbandk.wkt/OneofOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/OneofOptions.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/OneofOptions> { // pbandk.wkt/OneofOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/OneofOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/OneofOptions // pbandk.wkt/OneofOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/OneofOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/OneofOptions> // pbandk.wkt/OneofOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/OneofOptions // pbandk.wkt/OneofOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Option : pbandk/Message { // pbandk.wkt/Option|null[0]
+    constructor <init>(kotlin/String = ..., pbandk.wkt/Any? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Option.<init>|<init>(kotlin.String;pbandk.wkt.Any?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Option.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Option> // pbandk.wkt/Option.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val name // pbandk.wkt/Option.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Option.name.<get-name>|<get-name>(){}[0]
+    final val protoSize // pbandk.wkt/Option.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Option.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/Option.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Option.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/Option.value|{}value[0]
+        final fun <get-value>(): pbandk.wkt/Any? // pbandk.wkt/Option.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Option.component1|component1(){}[0]
+    final fun component2(): pbandk.wkt/Any? // pbandk.wkt/Option.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Option.component3|component3(){}[0]
+    final fun copy(kotlin/String = ..., pbandk.wkt/Any? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Option // pbandk.wkt/Option.copy|copy(kotlin.String;pbandk.wkt.Any?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Option.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Option.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Option // pbandk.wkt/Option.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Option.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Option> { // pbandk.wkt/Option.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Option.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Option // pbandk.wkt/Option.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Option.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Option> // pbandk.wkt/Option.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Option // pbandk.wkt/Option.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/ServiceDescriptorProto : pbandk/Message { // pbandk.wkt/ServiceDescriptorProto|null[0]
+    constructor <init>(kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/MethodDescriptorProto> = ..., pbandk.wkt/ServiceOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/ServiceDescriptorProto.<init>|<init>(kotlin.String?;kotlin.collections.List<pbandk.wkt.MethodDescriptorProto>;pbandk.wkt.ServiceOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/ServiceDescriptorProto.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ServiceDescriptorProto> // pbandk.wkt/ServiceDescriptorProto.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val method // pbandk.wkt/ServiceDescriptorProto.method|{}method[0]
+        final fun <get-method>(): kotlin.collections/List<pbandk.wkt/MethodDescriptorProto> // pbandk.wkt/ServiceDescriptorProto.method.<get-method>|<get-method>(){}[0]
+    final val name // pbandk.wkt/ServiceDescriptorProto.name|{}name[0]
+        final fun <get-name>(): kotlin/String? // pbandk.wkt/ServiceDescriptorProto.name.<get-name>|<get-name>(){}[0]
+    final val options // pbandk.wkt/ServiceDescriptorProto.options|{}options[0]
+        final fun <get-options>(): pbandk.wkt/ServiceOptions? // pbandk.wkt/ServiceDescriptorProto.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/ServiceDescriptorProto.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/ServiceDescriptorProto.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/ServiceDescriptorProto.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ServiceDescriptorProto.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String? // pbandk.wkt/ServiceDescriptorProto.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/MethodDescriptorProto> // pbandk.wkt/ServiceDescriptorProto.component2|component2(){}[0]
+    final fun component3(): pbandk.wkt/ServiceOptions? // pbandk.wkt/ServiceDescriptorProto.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ServiceDescriptorProto.component4|component4(){}[0]
+    final fun copy(kotlin/String? = ..., kotlin.collections/List<pbandk.wkt/MethodDescriptorProto> = ..., pbandk.wkt/ServiceOptions? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/ServiceDescriptorProto // pbandk.wkt/ServiceDescriptorProto.copy|copy(kotlin.String?;kotlin.collections.List<pbandk.wkt.MethodDescriptorProto>;pbandk.wkt.ServiceOptions?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/ServiceDescriptorProto.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/ServiceDescriptorProto.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/ServiceDescriptorProto // pbandk.wkt/ServiceDescriptorProto.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/ServiceDescriptorProto.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/ServiceDescriptorProto> { // pbandk.wkt/ServiceDescriptorProto.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/ServiceDescriptorProto.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/ServiceDescriptorProto // pbandk.wkt/ServiceDescriptorProto.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/ServiceDescriptorProto.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ServiceDescriptorProto> // pbandk.wkt/ServiceDescriptorProto.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/ServiceDescriptorProto // pbandk.wkt/ServiceDescriptorProto.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/ServiceOptions : pbandk/ExtendableMessage { // pbandk.wkt/ServiceOptions|null[0]
+    constructor <init>(kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...) // pbandk.wkt/ServiceOptions.<init>|<init>(kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+
+    final val deprecated // pbandk.wkt/ServiceOptions.deprecated|{}deprecated[0]
+        final fun <get-deprecated>(): kotlin/Boolean? // pbandk.wkt/ServiceOptions.deprecated.<get-deprecated>|<get-deprecated>(){}[0]
+    final val descriptor // pbandk.wkt/ServiceOptions.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ServiceOptions> // pbandk.wkt/ServiceOptions.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/ServiceOptions.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/ServiceOptions.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val uninterpretedOption // pbandk.wkt/ServiceOptions.uninterpretedOption|{}uninterpretedOption[0]
+        final fun <get-uninterpretedOption>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/ServiceOptions.uninterpretedOption.<get-uninterpretedOption>|<get-uninterpretedOption>(){}[0]
+    final val unknownFields // pbandk.wkt/ServiceOptions.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ServiceOptions.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Boolean? // pbandk.wkt/ServiceOptions.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/UninterpretedOption> // pbandk.wkt/ServiceOptions.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/ServiceOptions.component3|component3(){}[0]
+    final fun component4(): pbandk/ExtensionFieldSet // pbandk.wkt/ServiceOptions.component4|component4(){}[0]
+    final fun copy(kotlin/Boolean? = ..., kotlin.collections/List<pbandk.wkt/UninterpretedOption> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ..., pbandk/ExtensionFieldSet = ...): pbandk.wkt/ServiceOptions // pbandk.wkt/ServiceOptions.copy|copy(kotlin.Boolean?;kotlin.collections.List<pbandk.wkt.UninterpretedOption>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>;pbandk.ExtensionFieldSet){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/ServiceOptions.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/ServiceOptions.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/ServiceOptions // pbandk.wkt/ServiceOptions.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/ServiceOptions.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/ServiceOptions> { // pbandk.wkt/ServiceOptions.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/ServiceOptions.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/ServiceOptions // pbandk.wkt/ServiceOptions.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/ServiceOptions.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/ServiceOptions> // pbandk.wkt/ServiceOptions.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/ServiceOptions // pbandk.wkt/ServiceOptions.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/SourceCodeInfo : pbandk/Message { // pbandk.wkt/SourceCodeInfo|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/SourceCodeInfo.Location> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/SourceCodeInfo.<init>|<init>(kotlin.collections.List<pbandk.wkt.SourceCodeInfo.Location>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/SourceCodeInfo.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/SourceCodeInfo> // pbandk.wkt/SourceCodeInfo.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val location // pbandk.wkt/SourceCodeInfo.location|{}location[0]
+        final fun <get-location>(): kotlin.collections/List<pbandk.wkt/SourceCodeInfo.Location> // pbandk.wkt/SourceCodeInfo.location.<get-location>|<get-location>(){}[0]
+    final val protoSize // pbandk.wkt/SourceCodeInfo.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/SourceCodeInfo.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/SourceCodeInfo.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/SourceCodeInfo.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/SourceCodeInfo.Location> // pbandk.wkt/SourceCodeInfo.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/SourceCodeInfo.component2|component2(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/SourceCodeInfo.Location> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/SourceCodeInfo // pbandk.wkt/SourceCodeInfo.copy|copy(kotlin.collections.List<pbandk.wkt.SourceCodeInfo.Location>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/SourceCodeInfo.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/SourceCodeInfo.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/SourceCodeInfo // pbandk.wkt/SourceCodeInfo.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/SourceCodeInfo.toString|toString(){}[0]
+
+    final class Location : pbandk/Message { // pbandk.wkt/SourceCodeInfo.Location|null[0]
+        constructor <init>(kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/SourceCodeInfo.Location.<init>|<init>(kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>;kotlin.String?;kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk.wkt/SourceCodeInfo.Location.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/SourceCodeInfo.Location> // pbandk.wkt/SourceCodeInfo.Location.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val leadingComments // pbandk.wkt/SourceCodeInfo.Location.leadingComments|{}leadingComments[0]
+            final fun <get-leadingComments>(): kotlin/String? // pbandk.wkt/SourceCodeInfo.Location.leadingComments.<get-leadingComments>|<get-leadingComments>(){}[0]
+        final val leadingDetachedComments // pbandk.wkt/SourceCodeInfo.Location.leadingDetachedComments|{}leadingDetachedComments[0]
+            final fun <get-leadingDetachedComments>(): kotlin.collections/List<kotlin/String> // pbandk.wkt/SourceCodeInfo.Location.leadingDetachedComments.<get-leadingDetachedComments>|<get-leadingDetachedComments>(){}[0]
+        final val path // pbandk.wkt/SourceCodeInfo.Location.path|{}path[0]
+            final fun <get-path>(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/SourceCodeInfo.Location.path.<get-path>|<get-path>(){}[0]
+        final val protoSize // pbandk.wkt/SourceCodeInfo.Location.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/SourceCodeInfo.Location.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val span // pbandk.wkt/SourceCodeInfo.Location.span|{}span[0]
+            final fun <get-span>(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/SourceCodeInfo.Location.span.<get-span>|<get-span>(){}[0]
+        final val trailingComments // pbandk.wkt/SourceCodeInfo.Location.trailingComments|{}trailingComments[0]
+            final fun <get-trailingComments>(): kotlin/String? // pbandk.wkt/SourceCodeInfo.Location.trailingComments.<get-trailingComments>|<get-trailingComments>(){}[0]
+        final val unknownFields // pbandk.wkt/SourceCodeInfo.Location.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/SourceCodeInfo.Location.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+        final fun component1(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/SourceCodeInfo.Location.component1|component1(){}[0]
+        final fun component2(): kotlin.collections/List<kotlin/Int> // pbandk.wkt/SourceCodeInfo.Location.component2|component2(){}[0]
+        final fun component3(): kotlin/String? // pbandk.wkt/SourceCodeInfo.Location.component3|component3(){}[0]
+        final fun component4(): kotlin/String? // pbandk.wkt/SourceCodeInfo.Location.component4|component4(){}[0]
+        final fun component5(): kotlin.collections/List<kotlin/String> // pbandk.wkt/SourceCodeInfo.Location.component5|component5(){}[0]
+        final fun component6(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/SourceCodeInfo.Location.component6|component6(){}[0]
+        final fun copy(kotlin.collections/List<kotlin/Int> = ..., kotlin.collections/List<kotlin/Int> = ..., kotlin/String? = ..., kotlin/String? = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/SourceCodeInfo.Location // pbandk.wkt/SourceCodeInfo.Location.copy|copy(kotlin.collections.List<kotlin.Int>;kotlin.collections.List<kotlin.Int>;kotlin.String?;kotlin.String?;kotlin.collections.List<kotlin.String>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/SourceCodeInfo.Location.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/SourceCodeInfo.Location.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/SourceCodeInfo.Location // pbandk.wkt/SourceCodeInfo.Location.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/SourceCodeInfo.Location.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/SourceCodeInfo.Location> { // pbandk.wkt/SourceCodeInfo.Location.Companion|null[0]
+            final val defaultInstance // pbandk.wkt/SourceCodeInfo.Location.Companion.defaultInstance|{}defaultInstance[0]
+                final fun <get-defaultInstance>(): pbandk.wkt/SourceCodeInfo.Location // pbandk.wkt/SourceCodeInfo.Location.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+            final val descriptor // pbandk.wkt/SourceCodeInfo.Location.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/SourceCodeInfo.Location> // pbandk.wkt/SourceCodeInfo.Location.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/SourceCodeInfo.Location // pbandk.wkt/SourceCodeInfo.Location.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/SourceCodeInfo> { // pbandk.wkt/SourceCodeInfo.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/SourceCodeInfo.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/SourceCodeInfo // pbandk.wkt/SourceCodeInfo.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/SourceCodeInfo.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/SourceCodeInfo> // pbandk.wkt/SourceCodeInfo.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/SourceCodeInfo // pbandk.wkt/SourceCodeInfo.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/SourceContext : pbandk/Message { // pbandk.wkt/SourceContext|null[0]
+    constructor <init>(kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/SourceContext.<init>|<init>(kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/SourceContext.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/SourceContext> // pbandk.wkt/SourceContext.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val fileName // pbandk.wkt/SourceContext.fileName|{}fileName[0]
+        final fun <get-fileName>(): kotlin/String // pbandk.wkt/SourceContext.fileName.<get-fileName>|<get-fileName>(){}[0]
+    final val protoSize // pbandk.wkt/SourceContext.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/SourceContext.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/SourceContext.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/SourceContext.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/SourceContext.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/SourceContext.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/SourceContext // pbandk.wkt/SourceContext.copy|copy(kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/SourceContext.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/SourceContext.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/SourceContext // pbandk.wkt/SourceContext.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/SourceContext.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/SourceContext> { // pbandk.wkt/SourceContext.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/SourceContext.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/SourceContext // pbandk.wkt/SourceContext.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/SourceContext.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/SourceContext> // pbandk.wkt/SourceContext.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/SourceContext // pbandk.wkt/SourceContext.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/StringValue : pbandk/Message { // pbandk.wkt/StringValue|null[0]
+    constructor <init>(kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/StringValue.<init>|<init>(kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/StringValue.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/StringValue> // pbandk.wkt/StringValue.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/StringValue.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/StringValue.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/StringValue.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/StringValue.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/StringValue.value|{}value[0]
+        final fun <get-value>(): kotlin/String // pbandk.wkt/StringValue.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/StringValue.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/StringValue.component2|component2(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/StringValue // pbandk.wkt/StringValue.copy|copy(kotlin.String;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/StringValue.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/StringValue.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/StringValue // pbandk.wkt/StringValue.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/StringValue.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/StringValue> { // pbandk.wkt/StringValue.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/StringValue.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/StringValue // pbandk.wkt/StringValue.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/StringValue.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/StringValue> // pbandk.wkt/StringValue.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/StringValue // pbandk.wkt/StringValue.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Struct : pbandk/Message { // pbandk.wkt/Struct|null[0]
+    constructor <init>(kotlin.collections/Map<kotlin/String, pbandk.wkt/Value?> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Struct.<init>|<init>(kotlin.collections.Map<kotlin.String,pbandk.wkt.Value?>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Struct.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Struct> // pbandk.wkt/Struct.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val fields // pbandk.wkt/Struct.fields|{}fields[0]
+        final fun <get-fields>(): kotlin.collections/Map<kotlin/String, pbandk.wkt/Value?> // pbandk.wkt/Struct.fields.<get-fields>|<get-fields>(){}[0]
+    final val protoSize // pbandk.wkt/Struct.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Struct.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/Struct.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Struct.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/Map<kotlin/String, pbandk.wkt/Value?> // pbandk.wkt/Struct.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Struct.component2|component2(){}[0]
+    final fun copy(kotlin.collections/Map<kotlin/String, pbandk.wkt/Value?> = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Struct // pbandk.wkt/Struct.copy|copy(kotlin.collections.Map<kotlin.String,pbandk.wkt.Value?>;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Struct.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Struct.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Struct // pbandk.wkt/Struct.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Struct.toString|toString(){}[0]
+
+    final class FieldsEntry : kotlin.collections/Map.Entry<kotlin/String, pbandk.wkt/Value?>, pbandk/Message { // pbandk.wkt/Struct.FieldsEntry|null[0]
+        constructor <init>(kotlin/String = ..., pbandk.wkt/Value? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Struct.FieldsEntry.<init>|<init>(kotlin.String;pbandk.wkt.Value?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk.wkt/Struct.FieldsEntry.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Struct.FieldsEntry> // pbandk.wkt/Struct.FieldsEntry.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val key // pbandk.wkt/Struct.FieldsEntry.key|{}key[0]
+            final fun <get-key>(): kotlin/String // pbandk.wkt/Struct.FieldsEntry.key.<get-key>|<get-key>(){}[0]
+        final val protoSize // pbandk.wkt/Struct.FieldsEntry.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Struct.FieldsEntry.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val unknownFields // pbandk.wkt/Struct.FieldsEntry.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Struct.FieldsEntry.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+        final val value // pbandk.wkt/Struct.FieldsEntry.value|{}value[0]
+            final fun <get-value>(): pbandk.wkt/Value? // pbandk.wkt/Struct.FieldsEntry.value.<get-value>|<get-value>(){}[0]
+
+        final fun component1(): kotlin/String // pbandk.wkt/Struct.FieldsEntry.component1|component1(){}[0]
+        final fun component2(): pbandk.wkt/Value? // pbandk.wkt/Struct.FieldsEntry.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Struct.FieldsEntry.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., pbandk.wkt/Value? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Struct.FieldsEntry // pbandk.wkt/Struct.FieldsEntry.copy|copy(kotlin.String;pbandk.wkt.Value?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Struct.FieldsEntry.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/Struct.FieldsEntry.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/Struct.FieldsEntry // pbandk.wkt/Struct.FieldsEntry.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/Struct.FieldsEntry.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/Struct.FieldsEntry> { // pbandk.wkt/Struct.FieldsEntry.Companion|null[0]
+            final val defaultInstance // pbandk.wkt/Struct.FieldsEntry.Companion.defaultInstance|{}defaultInstance[0]
+                final fun <get-defaultInstance>(): pbandk.wkt/Struct.FieldsEntry // pbandk.wkt/Struct.FieldsEntry.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+            final val descriptor // pbandk.wkt/Struct.FieldsEntry.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Struct.FieldsEntry> // pbandk.wkt/Struct.FieldsEntry.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Struct.FieldsEntry // pbandk.wkt/Struct.FieldsEntry.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Struct> { // pbandk.wkt/Struct.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Struct.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Struct // pbandk.wkt/Struct.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Struct.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Struct> // pbandk.wkt/Struct.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Struct // pbandk.wkt/Struct.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Timestamp : pbandk/Message { // pbandk.wkt/Timestamp|null[0]
+    constructor <init>(kotlin/Long = ..., kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Timestamp.<init>|<init>(kotlin.Long;kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Timestamp.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Timestamp> // pbandk.wkt/Timestamp.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val nanos // pbandk.wkt/Timestamp.nanos|{}nanos[0]
+        final fun <get-nanos>(): kotlin/Int // pbandk.wkt/Timestamp.nanos.<get-nanos>|<get-nanos>(){}[0]
+    final val protoSize // pbandk.wkt/Timestamp.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Timestamp.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val seconds // pbandk.wkt/Timestamp.seconds|{}seconds[0]
+        final fun <get-seconds>(): kotlin/Long // pbandk.wkt/Timestamp.seconds.<get-seconds>|<get-seconds>(){}[0]
+    final val unknownFields // pbandk.wkt/Timestamp.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Timestamp.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/Long // pbandk.wkt/Timestamp.component1|component1(){}[0]
+    final fun component2(): kotlin/Int // pbandk.wkt/Timestamp.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Timestamp.component3|component3(){}[0]
+    final fun copy(kotlin/Long = ..., kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Timestamp // pbandk.wkt/Timestamp.copy|copy(kotlin.Long;kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Timestamp.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Timestamp.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Timestamp // pbandk.wkt/Timestamp.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Timestamp.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Timestamp> { // pbandk.wkt/Timestamp.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Timestamp.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Timestamp // pbandk.wkt/Timestamp.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Timestamp.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Timestamp> // pbandk.wkt/Timestamp.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Timestamp // pbandk.wkt/Timestamp.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Type : pbandk/Message { // pbandk.wkt/Type|null[0]
+    constructor <init>(kotlin/String = ..., kotlin.collections/List<pbandk.wkt/Field> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., pbandk.wkt/SourceContext? = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Type.<init>|<init>(kotlin.String;kotlin.collections.List<pbandk.wkt.Field>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<pbandk.wkt.Option>;pbandk.wkt.SourceContext?;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/Type.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Type> // pbandk.wkt/Type.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val fields // pbandk.wkt/Type.fields|{}fields[0]
+        final fun <get-fields>(): kotlin.collections/List<pbandk.wkt/Field> // pbandk.wkt/Type.fields.<get-fields>|<get-fields>(){}[0]
+    final val name // pbandk.wkt/Type.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk.wkt/Type.name.<get-name>|<get-name>(){}[0]
+    final val oneofs // pbandk.wkt/Type.oneofs|{}oneofs[0]
+        final fun <get-oneofs>(): kotlin.collections/List<kotlin/String> // pbandk.wkt/Type.oneofs.<get-oneofs>|<get-oneofs>(){}[0]
+    final val options // pbandk.wkt/Type.options|{}options[0]
+        final fun <get-options>(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Type.options.<get-options>|<get-options>(){}[0]
+    final val protoSize // pbandk.wkt/Type.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Type.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val sourceContext // pbandk.wkt/Type.sourceContext|{}sourceContext[0]
+        final fun <get-sourceContext>(): pbandk.wkt/SourceContext? // pbandk.wkt/Type.sourceContext.<get-sourceContext>|<get-sourceContext>(){}[0]
+    final val syntax // pbandk.wkt/Type.syntax|{}syntax[0]
+        final fun <get-syntax>(): pbandk.wkt/Syntax // pbandk.wkt/Type.syntax.<get-syntax>|<get-syntax>(){}[0]
+    final val unknownFields // pbandk.wkt/Type.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Type.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin/String // pbandk.wkt/Type.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk.wkt/Field> // pbandk.wkt/Type.component2|component2(){}[0]
+    final fun component3(): kotlin.collections/List<kotlin/String> // pbandk.wkt/Type.component3|component3(){}[0]
+    final fun component4(): kotlin.collections/List<pbandk.wkt/Option> // pbandk.wkt/Type.component4|component4(){}[0]
+    final fun component5(): pbandk.wkt/SourceContext? // pbandk.wkt/Type.component5|component5(){}[0]
+    final fun component6(): pbandk.wkt/Syntax // pbandk.wkt/Type.component6|component6(){}[0]
+    final fun component7(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Type.component7|component7(){}[0]
+    final fun copy(kotlin/String = ..., kotlin.collections/List<pbandk.wkt/Field> = ..., kotlin.collections/List<kotlin/String> = ..., kotlin.collections/List<pbandk.wkt/Option> = ..., pbandk.wkt/SourceContext? = ..., pbandk.wkt/Syntax = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Type // pbandk.wkt/Type.copy|copy(kotlin.String;kotlin.collections.List<pbandk.wkt.Field>;kotlin.collections.List<kotlin.String>;kotlin.collections.List<pbandk.wkt.Option>;pbandk.wkt.SourceContext?;pbandk.wkt.Syntax;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Type.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Type.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Type // pbandk.wkt/Type.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Type.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Type> { // pbandk.wkt/Type.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Type.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Type // pbandk.wkt/Type.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Type.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Type> // pbandk.wkt/Type.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Type // pbandk.wkt/Type.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/UInt32Value : pbandk/Message { // pbandk.wkt/UInt32Value|null[0]
+    constructor <init>(kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/UInt32Value.<init>|<init>(kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/UInt32Value.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UInt32Value> // pbandk.wkt/UInt32Value.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/UInt32Value.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/UInt32Value.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/UInt32Value.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UInt32Value.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/UInt32Value.value|{}value[0]
+        final fun <get-value>(): kotlin/Int // pbandk.wkt/UInt32Value.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Int // pbandk.wkt/UInt32Value.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UInt32Value.component2|component2(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/UInt32Value // pbandk.wkt/UInt32Value.copy|copy(kotlin.Int;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/UInt32Value.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/UInt32Value.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/UInt32Value // pbandk.wkt/UInt32Value.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/UInt32Value.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/UInt32Value> { // pbandk.wkt/UInt32Value.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/UInt32Value.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/UInt32Value // pbandk.wkt/UInt32Value.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/UInt32Value.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UInt32Value> // pbandk.wkt/UInt32Value.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/UInt32Value // pbandk.wkt/UInt32Value.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/UInt64Value : pbandk/Message { // pbandk.wkt/UInt64Value|null[0]
+    constructor <init>(kotlin/Long = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/UInt64Value.<init>|<init>(kotlin.Long;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val descriptor // pbandk.wkt/UInt64Value.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UInt64Value> // pbandk.wkt/UInt64Value.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val protoSize // pbandk.wkt/UInt64Value.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/UInt64Value.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val unknownFields // pbandk.wkt/UInt64Value.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UInt64Value.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+    final val value // pbandk.wkt/UInt64Value.value|{}value[0]
+        final fun <get-value>(): kotlin/Long // pbandk.wkt/UInt64Value.value.<get-value>|<get-value>(){}[0]
+
+    final fun component1(): kotlin/Long // pbandk.wkt/UInt64Value.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UInt64Value.component2|component2(){}[0]
+    final fun copy(kotlin/Long = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/UInt64Value // pbandk.wkt/UInt64Value.copy|copy(kotlin.Long;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/UInt64Value.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/UInt64Value.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/UInt64Value // pbandk.wkt/UInt64Value.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/UInt64Value.toString|toString(){}[0]
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/UInt64Value> { // pbandk.wkt/UInt64Value.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/UInt64Value.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/UInt64Value // pbandk.wkt/UInt64Value.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/UInt64Value.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UInt64Value> // pbandk.wkt/UInt64Value.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/UInt64Value // pbandk.wkt/UInt64Value.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/UninterpretedOption : pbandk/Message { // pbandk.wkt/UninterpretedOption|null[0]
+    constructor <init>(kotlin.collections/List<pbandk.wkt/UninterpretedOption.NamePart> = ..., kotlin/String? = ..., kotlin/Long? = ..., kotlin/Long? = ..., kotlin/Double? = ..., pbandk/ByteArr? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/UninterpretedOption.<init>|<init>(kotlin.collections.List<pbandk.wkt.UninterpretedOption.NamePart>;kotlin.String?;kotlin.Long?;kotlin.Long?;kotlin.Double?;pbandk.ByteArr?;kotlin.String?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val aggregateValue // pbandk.wkt/UninterpretedOption.aggregateValue|{}aggregateValue[0]
+        final fun <get-aggregateValue>(): kotlin/String? // pbandk.wkt/UninterpretedOption.aggregateValue.<get-aggregateValue>|<get-aggregateValue>(){}[0]
+    final val descriptor // pbandk.wkt/UninterpretedOption.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UninterpretedOption> // pbandk.wkt/UninterpretedOption.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val doubleValue // pbandk.wkt/UninterpretedOption.doubleValue|{}doubleValue[0]
+        final fun <get-doubleValue>(): kotlin/Double? // pbandk.wkt/UninterpretedOption.doubleValue.<get-doubleValue>|<get-doubleValue>(){}[0]
+    final val identifierValue // pbandk.wkt/UninterpretedOption.identifierValue|{}identifierValue[0]
+        final fun <get-identifierValue>(): kotlin/String? // pbandk.wkt/UninterpretedOption.identifierValue.<get-identifierValue>|<get-identifierValue>(){}[0]
+    final val name // pbandk.wkt/UninterpretedOption.name|{}name[0]
+        final fun <get-name>(): kotlin.collections/List<pbandk.wkt/UninterpretedOption.NamePart> // pbandk.wkt/UninterpretedOption.name.<get-name>|<get-name>(){}[0]
+    final val negativeIntValue // pbandk.wkt/UninterpretedOption.negativeIntValue|{}negativeIntValue[0]
+        final fun <get-negativeIntValue>(): kotlin/Long? // pbandk.wkt/UninterpretedOption.negativeIntValue.<get-negativeIntValue>|<get-negativeIntValue>(){}[0]
+    final val positiveIntValue // pbandk.wkt/UninterpretedOption.positiveIntValue|{}positiveIntValue[0]
+        final fun <get-positiveIntValue>(): kotlin/Long? // pbandk.wkt/UninterpretedOption.positiveIntValue.<get-positiveIntValue>|<get-positiveIntValue>(){}[0]
+    final val protoSize // pbandk.wkt/UninterpretedOption.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/UninterpretedOption.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val stringValue // pbandk.wkt/UninterpretedOption.stringValue|{}stringValue[0]
+        final fun <get-stringValue>(): pbandk/ByteArr? // pbandk.wkt/UninterpretedOption.stringValue.<get-stringValue>|<get-stringValue>(){}[0]
+    final val unknownFields // pbandk.wkt/UninterpretedOption.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UninterpretedOption.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): kotlin.collections/List<pbandk.wkt/UninterpretedOption.NamePart> // pbandk.wkt/UninterpretedOption.component1|component1(){}[0]
+    final fun component2(): kotlin/String? // pbandk.wkt/UninterpretedOption.component2|component2(){}[0]
+    final fun component3(): kotlin/Long? // pbandk.wkt/UninterpretedOption.component3|component3(){}[0]
+    final fun component4(): kotlin/Long? // pbandk.wkt/UninterpretedOption.component4|component4(){}[0]
+    final fun component5(): kotlin/Double? // pbandk.wkt/UninterpretedOption.component5|component5(){}[0]
+    final fun component6(): pbandk/ByteArr? // pbandk.wkt/UninterpretedOption.component6|component6(){}[0]
+    final fun component7(): kotlin/String? // pbandk.wkt/UninterpretedOption.component7|component7(){}[0]
+    final fun component8(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UninterpretedOption.component8|component8(){}[0]
+    final fun copy(kotlin.collections/List<pbandk.wkt/UninterpretedOption.NamePart> = ..., kotlin/String? = ..., kotlin/Long? = ..., kotlin/Long? = ..., kotlin/Double? = ..., pbandk/ByteArr? = ..., kotlin/String? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/UninterpretedOption // pbandk.wkt/UninterpretedOption.copy|copy(kotlin.collections.List<pbandk.wkt.UninterpretedOption.NamePart>;kotlin.String?;kotlin.Long?;kotlin.Long?;kotlin.Double?;pbandk.ByteArr?;kotlin.String?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/UninterpretedOption.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/UninterpretedOption.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/UninterpretedOption // pbandk.wkt/UninterpretedOption.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/UninterpretedOption.toString|toString(){}[0]
+
+    final class NamePart : pbandk/Message { // pbandk.wkt/UninterpretedOption.NamePart|null[0]
+        constructor <init>(kotlin/String, kotlin/Boolean, kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/UninterpretedOption.NamePart.<init>|<init>(kotlin.String;kotlin.Boolean;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+        final val descriptor // pbandk.wkt/UninterpretedOption.NamePart.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UninterpretedOption.NamePart> // pbandk.wkt/UninterpretedOption.NamePart.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+        final val isExtension // pbandk.wkt/UninterpretedOption.NamePart.isExtension|{}isExtension[0]
+            final fun <get-isExtension>(): kotlin/Boolean // pbandk.wkt/UninterpretedOption.NamePart.isExtension.<get-isExtension>|<get-isExtension>(){}[0]
+        final val namePart // pbandk.wkt/UninterpretedOption.NamePart.namePart|{}namePart[0]
+            final fun <get-namePart>(): kotlin/String // pbandk.wkt/UninterpretedOption.NamePart.namePart.<get-namePart>|<get-namePart>(){}[0]
+        final val protoSize // pbandk.wkt/UninterpretedOption.NamePart.protoSize|{}protoSize[0]
+            final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/UninterpretedOption.NamePart.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+        final val unknownFields // pbandk.wkt/UninterpretedOption.NamePart.unknownFields|{}unknownFields[0]
+            final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UninterpretedOption.NamePart.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+        final fun component1(): kotlin/String // pbandk.wkt/UninterpretedOption.NamePart.component1|component1(){}[0]
+        final fun component2(): kotlin/Boolean // pbandk.wkt/UninterpretedOption.NamePart.component2|component2(){}[0]
+        final fun component3(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/UninterpretedOption.NamePart.component3|component3(){}[0]
+        final fun copy(kotlin/String = ..., kotlin/Boolean = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/UninterpretedOption.NamePart // pbandk.wkt/UninterpretedOption.NamePart.copy|copy(kotlin.String;kotlin.Boolean;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/UninterpretedOption.NamePart.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk.wkt/UninterpretedOption.NamePart.hashCode|hashCode(){}[0]
+        final fun plus(pbandk/Message?): pbandk.wkt/UninterpretedOption.NamePart // pbandk.wkt/UninterpretedOption.NamePart.plus|plus(pbandk.Message?){}[0]
+        final fun toString(): kotlin/String // pbandk.wkt/UninterpretedOption.NamePart.toString|toString(){}[0]
+
+        final object Companion : pbandk/Message.Companion<pbandk.wkt/UninterpretedOption.NamePart> { // pbandk.wkt/UninterpretedOption.NamePart.Companion|null[0]
+            final val descriptor // pbandk.wkt/UninterpretedOption.NamePart.Companion.descriptor|{}descriptor[0]
+                final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UninterpretedOption.NamePart> // pbandk.wkt/UninterpretedOption.NamePart.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+            final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/UninterpretedOption.NamePart // pbandk.wkt/UninterpretedOption.NamePart.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/UninterpretedOption> { // pbandk.wkt/UninterpretedOption.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/UninterpretedOption.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/UninterpretedOption // pbandk.wkt/UninterpretedOption.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/UninterpretedOption.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/UninterpretedOption> // pbandk.wkt/UninterpretedOption.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/UninterpretedOption // pbandk.wkt/UninterpretedOption.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk.wkt/Value : pbandk/Message { // pbandk.wkt/Value|null[0]
+    constructor <init>(pbandk.wkt/Value.Kind<*>? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...) // pbandk.wkt/Value.<init>|<init>(pbandk.wkt.Value.Kind<*>?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+
+    final val boolValue // pbandk.wkt/Value.boolValue|{}boolValue[0]
+        final fun <get-boolValue>(): kotlin/Boolean? // pbandk.wkt/Value.boolValue.<get-boolValue>|<get-boolValue>(){}[0]
+    final val descriptor // pbandk.wkt/Value.descriptor|{}descriptor[0]
+        final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Value> // pbandk.wkt/Value.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+    final val kind // pbandk.wkt/Value.kind|{}kind[0]
+        final fun <get-kind>(): pbandk.wkt/Value.Kind<*>? // pbandk.wkt/Value.kind.<get-kind>|<get-kind>(){}[0]
+    final val listValue // pbandk.wkt/Value.listValue|{}listValue[0]
+        final fun <get-listValue>(): pbandk.wkt/ListValue? // pbandk.wkt/Value.listValue.<get-listValue>|<get-listValue>(){}[0]
+    final val nullValue // pbandk.wkt/Value.nullValue|{}nullValue[0]
+        final fun <get-nullValue>(): pbandk.wkt/NullValue? // pbandk.wkt/Value.nullValue.<get-nullValue>|<get-nullValue>(){}[0]
+    final val numberValue // pbandk.wkt/Value.numberValue|{}numberValue[0]
+        final fun <get-numberValue>(): kotlin/Double? // pbandk.wkt/Value.numberValue.<get-numberValue>|<get-numberValue>(){}[0]
+    final val protoSize // pbandk.wkt/Value.protoSize|{}protoSize[0]
+        final fun <get-protoSize>(): kotlin/Int // pbandk.wkt/Value.protoSize.<get-protoSize>|<get-protoSize>(){}[0]
+    final val stringValue // pbandk.wkt/Value.stringValue|{}stringValue[0]
+        final fun <get-stringValue>(): kotlin/String? // pbandk.wkt/Value.stringValue.<get-stringValue>|<get-stringValue>(){}[0]
+    final val structValue // pbandk.wkt/Value.structValue|{}structValue[0]
+        final fun <get-structValue>(): pbandk.wkt/Struct? // pbandk.wkt/Value.structValue.<get-structValue>|<get-structValue>(){}[0]
+    final val unknownFields // pbandk.wkt/Value.unknownFields|{}unknownFields[0]
+        final fun <get-unknownFields>(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Value.unknownFields.<get-unknownFields>|<get-unknownFields>(){}[0]
+
+    final fun component1(): pbandk.wkt/Value.Kind<*>? // pbandk.wkt/Value.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> // pbandk.wkt/Value.component2|component2(){}[0]
+    final fun copy(pbandk.wkt/Value.Kind<*>? = ..., kotlin.collections/Map<kotlin/Int, pbandk/UnknownField> = ...): pbandk.wkt/Value // pbandk.wkt/Value.copy|copy(pbandk.wkt.Value.Kind<*>?;kotlin.collections.Map<kotlin.Int,pbandk.UnknownField>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Value.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk.wkt/Value.hashCode|hashCode(){}[0]
+    final fun plus(pbandk/Message?): pbandk.wkt/Value // pbandk.wkt/Value.plus|plus(pbandk.Message?){}[0]
+    final fun toString(): kotlin/String // pbandk.wkt/Value.toString|toString(){}[0]
+
+    sealed class <#A1: kotlin/Any?> Kind : pbandk/Message.OneOf<#A1> { // pbandk.wkt/Value.Kind|null[0]
+        constructor <init>(#A1) // pbandk.wkt/Value.Kind.<init>|<init>(1:0){}[0]
+
+        final class BoolValue : pbandk.wkt/Value.Kind<kotlin/Boolean> { // pbandk.wkt/Value.Kind.BoolValue|null[0]
+            constructor <init>(kotlin/Boolean = ...) // pbandk.wkt/Value.Kind.BoolValue.<init>|<init>(kotlin.Boolean){}[0]
+        }
+
+        final class ListValue : pbandk.wkt/Value.Kind<pbandk.wkt/ListValue> { // pbandk.wkt/Value.Kind.ListValue|null[0]
+            constructor <init>(pbandk.wkt/ListValue) // pbandk.wkt/Value.Kind.ListValue.<init>|<init>(pbandk.wkt.ListValue){}[0]
+        }
+
+        final class NullValue : pbandk.wkt/Value.Kind<pbandk.wkt/NullValue> { // pbandk.wkt/Value.Kind.NullValue|null[0]
+            constructor <init>(pbandk.wkt/NullValue = ...) // pbandk.wkt/Value.Kind.NullValue.<init>|<init>(pbandk.wkt.NullValue){}[0]
+        }
+
+        final class NumberValue : pbandk.wkt/Value.Kind<kotlin/Double> { // pbandk.wkt/Value.Kind.NumberValue|null[0]
+            constructor <init>(kotlin/Double = ...) // pbandk.wkt/Value.Kind.NumberValue.<init>|<init>(kotlin.Double){}[0]
+        }
+
+        final class StringValue : pbandk.wkt/Value.Kind<kotlin/String> { // pbandk.wkt/Value.Kind.StringValue|null[0]
+            constructor <init>(kotlin/String = ...) // pbandk.wkt/Value.Kind.StringValue.<init>|<init>(kotlin.String){}[0]
+        }
+
+        final class StructValue : pbandk.wkt/Value.Kind<pbandk.wkt/Struct> { // pbandk.wkt/Value.Kind.StructValue|null[0]
+            constructor <init>(pbandk.wkt/Struct) // pbandk.wkt/Value.Kind.StructValue.<init>|<init>(pbandk.wkt.Struct){}[0]
+        }
+    }
+
+    final object Companion : pbandk/Message.Companion<pbandk.wkt/Value> { // pbandk.wkt/Value.Companion|null[0]
+        final val defaultInstance // pbandk.wkt/Value.Companion.defaultInstance|{}defaultInstance[0]
+            final fun <get-defaultInstance>(): pbandk.wkt/Value // pbandk.wkt/Value.Companion.defaultInstance.<get-defaultInstance>|<get-defaultInstance>(){}[0]
+        final val descriptor // pbandk.wkt/Value.Companion.descriptor|{}descriptor[0]
+            final fun <get-descriptor>(): pbandk/MessageDescriptor<pbandk.wkt/Value> // pbandk.wkt/Value.Companion.descriptor.<get-descriptor>|<get-descriptor>(){}[0]
+
+        final fun decodeWith(pbandk/MessageDecoder): pbandk.wkt/Value // pbandk.wkt/Value.Companion.decodeWith|decodeWith(pbandk.MessageDecoder){}[0]
+    }
+}
+
+final class pbandk/ByteArr { // pbandk/ByteArr|null[0]
+    constructor <init>(kotlin/ByteArray) // pbandk/ByteArr.<init>|<init>(kotlin.ByteArray){}[0]
+
+    final val array // pbandk/ByteArr.array|{}array[0]
+        final fun <get-array>(): kotlin/ByteArray // pbandk/ByteArr.array.<get-array>|<get-array>(){}[0]
+
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk/ByteArr.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk/ByteArr.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // pbandk/ByteArr.toString|toString(){}[0]
+
+    final object Companion { // pbandk/ByteArr.Companion|null[0]
+        final val empty // pbandk/ByteArr.Companion.empty|{}empty[0]
+            final fun <get-empty>(): pbandk/ByteArr // pbandk/ByteArr.Companion.empty.<get-empty>|<get-empty>(){}[0]
+    }
+}
+
+final class pbandk/ExtensionFieldSet { // pbandk/ExtensionFieldSet|null[0]
+    constructor <init>() // pbandk/ExtensionFieldSet.<init>|<init>(){}[0]
+}
+
+final class pbandk/InvalidProtocolBufferException : kotlin/RuntimeException { // pbandk/InvalidProtocolBufferException|null[0]
+    final object Companion { // pbandk/InvalidProtocolBufferException.Companion|null[0]
+        final fun missingRequiredField(kotlin/String): pbandk/InvalidProtocolBufferException // pbandk/InvalidProtocolBufferException.Companion.missingRequiredField|missingRequiredField(kotlin.String){}[0]
+    }
+}
+
+final class pbandk/UnknownField { // pbandk/UnknownField|null[0]
+    constructor <init>(kotlin/Int, kotlin.collections/List<pbandk/UnknownField.Value>) // pbandk/UnknownField.<init>|<init>(kotlin.Int;kotlin.collections.List<pbandk.UnknownField.Value>){}[0]
+
+    final val fieldNum // pbandk/UnknownField.fieldNum|{}fieldNum[0]
+        final fun <get-fieldNum>(): kotlin/Int // pbandk/UnknownField.fieldNum.<get-fieldNum>|<get-fieldNum>(){}[0]
+    final val values // pbandk/UnknownField.values|{}values[0]
+        final fun <get-values>(): kotlin.collections/List<pbandk/UnknownField.Value> // pbandk/UnknownField.values.<get-values>|<get-values>(){}[0]
+
+    final fun component1(): kotlin/Int // pbandk/UnknownField.component1|component1(){}[0]
+    final fun component2(): kotlin.collections/List<pbandk/UnknownField.Value> // pbandk/UnknownField.component2|component2(){}[0]
+    final fun copy(kotlin/Int = ..., kotlin.collections/List<pbandk/UnknownField.Value> = ...): pbandk/UnknownField // pbandk/UnknownField.copy|copy(kotlin.Int;kotlin.collections.List<pbandk.UnknownField.Value>){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // pbandk/UnknownField.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // pbandk/UnknownField.hashCode|hashCode(){}[0]
+    final fun toString(): kotlin/String // pbandk/UnknownField.toString|toString(){}[0]
+
+    final class Value { // pbandk/UnknownField.Value|null[0]
+        constructor <init>(kotlin/Int, kotlin/ByteArray) // pbandk/UnknownField.Value.<init>|<init>(kotlin.Int;kotlin.ByteArray){}[0]
+        constructor <init>(kotlin/Int, pbandk/ByteArr) // pbandk/UnknownField.Value.<init>|<init>(kotlin.Int;pbandk.ByteArr){}[0]
+
+        final val rawBytes // pbandk/UnknownField.Value.rawBytes|{}rawBytes[0]
+            final fun <get-rawBytes>(): pbandk/ByteArr // pbandk/UnknownField.Value.rawBytes.<get-rawBytes>|<get-rawBytes>(){}[0]
+        final val wireType // pbandk/UnknownField.Value.wireType|{}wireType[0]
+            final fun <get-wireType>(): kotlin/Int // pbandk/UnknownField.Value.wireType.<get-wireType>|<get-wireType>(){}[0]
+
+        final fun component1(): kotlin/Int // pbandk/UnknownField.Value.component1|component1(){}[0]
+        final fun component2(): pbandk/ByteArr // pbandk/UnknownField.Value.component2|component2(){}[0]
+        final fun copy(kotlin/Int = ..., pbandk/ByteArr = ...): pbandk/UnknownField.Value // pbandk/UnknownField.Value.copy|copy(kotlin.Int;pbandk.ByteArr){}[0]
+        final fun equals(kotlin/Any?): kotlin/Boolean // pbandk/UnknownField.Value.equals|equals(kotlin.Any?){}[0]
+        final fun hashCode(): kotlin/Int // pbandk/UnknownField.Value.hashCode|hashCode(){}[0]
+        final fun toString(): kotlin/String // pbandk/UnknownField.Value.toString|toString(){}[0]
+    }
+}
+
+sealed class pbandk.wkt/NullValue : pbandk/Message.Enum { // pbandk.wkt/NullValue|null[0]
+    constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/NullValue.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+    open val name // pbandk.wkt/NullValue.name|{}name[0]
+        open fun <get-name>(): kotlin/String? // pbandk.wkt/NullValue.name.<get-name>|<get-name>(){}[0]
+    open val value // pbandk.wkt/NullValue.value|{}value[0]
+        open fun <get-value>(): kotlin/Int // pbandk.wkt/NullValue.value.<get-value>|<get-value>(){}[0]
+
+    open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/NullValue.equals|equals(kotlin.Any?){}[0]
+    open fun hashCode(): kotlin/Int // pbandk.wkt/NullValue.hashCode|hashCode(){}[0]
+    open fun toString(): kotlin/String // pbandk.wkt/NullValue.toString|toString(){}[0]
+
+    final class UNRECOGNIZED : pbandk.wkt/NullValue { // pbandk.wkt/NullValue.UNRECOGNIZED|null[0]
+        constructor <init>(kotlin/Int) // pbandk.wkt/NullValue.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+    }
+
+    final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/NullValue> { // pbandk.wkt/NullValue.Companion|null[0]
+        final val values // pbandk.wkt/NullValue.Companion.values|{}values[0]
+            final fun <get-values>(): kotlin.collections/List<pbandk.wkt/NullValue> // pbandk.wkt/NullValue.Companion.values.<get-values>|<get-values>(){}[0]
+
+        final fun fromName(kotlin/String): pbandk.wkt/NullValue // pbandk.wkt/NullValue.Companion.fromName|fromName(kotlin.String){}[0]
+        final fun fromValue(kotlin/Int): pbandk.wkt/NullValue // pbandk.wkt/NullValue.Companion.fromValue|fromValue(kotlin.Int){}[0]
+    }
+
+    final object NULL_VALUE : pbandk.wkt/NullValue // pbandk.wkt/NullValue.NULL_VALUE|null[0]
+}
+
+sealed class pbandk.wkt/Syntax : pbandk/Message.Enum { // pbandk.wkt/Syntax|null[0]
+    constructor <init>(kotlin/Int, kotlin/String? = ...) // pbandk.wkt/Syntax.<init>|<init>(kotlin.Int;kotlin.String?){}[0]
+
+    open val name // pbandk.wkt/Syntax.name|{}name[0]
+        open fun <get-name>(): kotlin/String? // pbandk.wkt/Syntax.name.<get-name>|<get-name>(){}[0]
+    open val value // pbandk.wkt/Syntax.value|{}value[0]
+        open fun <get-value>(): kotlin/Int // pbandk.wkt/Syntax.value.<get-value>|<get-value>(){}[0]
+
+    open fun equals(kotlin/Any?): kotlin/Boolean // pbandk.wkt/Syntax.equals|equals(kotlin.Any?){}[0]
+    open fun hashCode(): kotlin/Int // pbandk.wkt/Syntax.hashCode|hashCode(){}[0]
+    open fun toString(): kotlin/String // pbandk.wkt/Syntax.toString|toString(){}[0]
+
+    final class UNRECOGNIZED : pbandk.wkt/Syntax { // pbandk.wkt/Syntax.UNRECOGNIZED|null[0]
+        constructor <init>(kotlin/Int) // pbandk.wkt/Syntax.UNRECOGNIZED.<init>|<init>(kotlin.Int){}[0]
+    }
+
+    final object Companion : pbandk/Message.Enum.Companion<pbandk.wkt/Syntax> { // pbandk.wkt/Syntax.Companion|null[0]
+        final val values // pbandk.wkt/Syntax.Companion.values|{}values[0]
+            final fun <get-values>(): kotlin.collections/List<pbandk.wkt/Syntax> // pbandk.wkt/Syntax.Companion.values.<get-values>|<get-values>(){}[0]
+
+        final fun fromName(kotlin/String): pbandk.wkt/Syntax // pbandk.wkt/Syntax.Companion.fromName|fromName(kotlin.String){}[0]
+        final fun fromValue(kotlin/Int): pbandk.wkt/Syntax // pbandk.wkt/Syntax.Companion.fromValue|fromValue(kotlin.Int){}[0]
+    }
+
+    final object PROTO2 : pbandk.wkt/Syntax // pbandk.wkt/Syntax.PROTO2|null[0]
+
+    final object PROTO3 : pbandk.wkt/Syntax // pbandk.wkt/Syntax.PROTO3|null[0]
+}
+
+final fun (pbandk.wkt/Any?).pbandk.wkt/orDefault(): pbandk.wkt/Any // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Any?(){}[0]
+final fun (pbandk.wkt/Api?).pbandk.wkt/orDefault(): pbandk.wkt/Api // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Api?(){}[0]
+final fun (pbandk.wkt/BoolValue?).pbandk.wkt/orDefault(): pbandk.wkt/BoolValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.BoolValue?(){}[0]
+final fun (pbandk.wkt/BytesValue?).pbandk.wkt/orDefault(): pbandk.wkt/BytesValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.BytesValue?(){}[0]
+final fun (pbandk.wkt/DescriptorProto.ExtensionRange?).pbandk.wkt/orDefault(): pbandk.wkt/DescriptorProto.ExtensionRange // pbandk.wkt/orDefault|orDefault@pbandk.wkt.DescriptorProto.ExtensionRange?(){}[0]
+final fun (pbandk.wkt/DescriptorProto.ReservedRange?).pbandk.wkt/orDefault(): pbandk.wkt/DescriptorProto.ReservedRange // pbandk.wkt/orDefault|orDefault@pbandk.wkt.DescriptorProto.ReservedRange?(){}[0]
+final fun (pbandk.wkt/DescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/DescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.DescriptorProto?(){}[0]
+final fun (pbandk.wkt/DoubleValue?).pbandk.wkt/orDefault(): pbandk.wkt/DoubleValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.DoubleValue?(){}[0]
+final fun (pbandk.wkt/Duration?).pbandk.wkt/orDefault(): pbandk.wkt/Duration // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Duration?(){}[0]
+final fun (pbandk.wkt/Empty?).pbandk.wkt/orDefault(): pbandk.wkt/Empty // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Empty?(){}[0]
+final fun (pbandk.wkt/Enum?).pbandk.wkt/orDefault(): pbandk.wkt/Enum // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Enum?(){}[0]
+final fun (pbandk.wkt/EnumDescriptorProto.EnumReservedRange?).pbandk.wkt/orDefault(): pbandk.wkt/EnumDescriptorProto.EnumReservedRange // pbandk.wkt/orDefault|orDefault@pbandk.wkt.EnumDescriptorProto.EnumReservedRange?(){}[0]
+final fun (pbandk.wkt/EnumDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/EnumDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.EnumDescriptorProto?(){}[0]
+final fun (pbandk.wkt/EnumOptions?).pbandk.wkt/orDefault(): pbandk.wkt/EnumOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.EnumOptions?(){}[0]
+final fun (pbandk.wkt/EnumValue?).pbandk.wkt/orDefault(): pbandk.wkt/EnumValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.EnumValue?(){}[0]
+final fun (pbandk.wkt/EnumValueDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/EnumValueDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.EnumValueDescriptorProto?(){}[0]
+final fun (pbandk.wkt/EnumValueOptions?).pbandk.wkt/orDefault(): pbandk.wkt/EnumValueOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.EnumValueOptions?(){}[0]
+final fun (pbandk.wkt/ExtensionRangeOptions?).pbandk.wkt/orDefault(): pbandk.wkt/ExtensionRangeOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.ExtensionRangeOptions?(){}[0]
+final fun (pbandk.wkt/Field?).pbandk.wkt/orDefault(): pbandk.wkt/Field // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Field?(){}[0]
+final fun (pbandk.wkt/FieldDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/FieldDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FieldDescriptorProto?(){}[0]
+final fun (pbandk.wkt/FieldMask?).pbandk.wkt/orDefault(): pbandk.wkt/FieldMask // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FieldMask?(){}[0]
+final fun (pbandk.wkt/FieldOptions?).pbandk.wkt/orDefault(): pbandk.wkt/FieldOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FieldOptions?(){}[0]
+final fun (pbandk.wkt/FileDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/FileDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FileDescriptorProto?(){}[0]
+final fun (pbandk.wkt/FileDescriptorSet?).pbandk.wkt/orDefault(): pbandk.wkt/FileDescriptorSet // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FileDescriptorSet?(){}[0]
+final fun (pbandk.wkt/FileOptions?).pbandk.wkt/orDefault(): pbandk.wkt/FileOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FileOptions?(){}[0]
+final fun (pbandk.wkt/FloatValue?).pbandk.wkt/orDefault(): pbandk.wkt/FloatValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.FloatValue?(){}[0]
+final fun (pbandk.wkt/GeneratedCodeInfo.Annotation?).pbandk.wkt/orDefault(): pbandk.wkt/GeneratedCodeInfo.Annotation // pbandk.wkt/orDefault|orDefault@pbandk.wkt.GeneratedCodeInfo.Annotation?(){}[0]
+final fun (pbandk.wkt/GeneratedCodeInfo?).pbandk.wkt/orDefault(): pbandk.wkt/GeneratedCodeInfo // pbandk.wkt/orDefault|orDefault@pbandk.wkt.GeneratedCodeInfo?(){}[0]
+final fun (pbandk.wkt/Int32Value?).pbandk.wkt/orDefault(): pbandk.wkt/Int32Value // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Int32Value?(){}[0]
+final fun (pbandk.wkt/Int64Value?).pbandk.wkt/orDefault(): pbandk.wkt/Int64Value // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Int64Value?(){}[0]
+final fun (pbandk.wkt/ListValue?).pbandk.wkt/orDefault(): pbandk.wkt/ListValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.ListValue?(){}[0]
+final fun (pbandk.wkt/MessageOptions?).pbandk.wkt/orDefault(): pbandk.wkt/MessageOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.MessageOptions?(){}[0]
+final fun (pbandk.wkt/Method?).pbandk.wkt/orDefault(): pbandk.wkt/Method // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Method?(){}[0]
+final fun (pbandk.wkt/MethodDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/MethodDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.MethodDescriptorProto?(){}[0]
+final fun (pbandk.wkt/MethodOptions?).pbandk.wkt/orDefault(): pbandk.wkt/MethodOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.MethodOptions?(){}[0]
+final fun (pbandk.wkt/Mixin?).pbandk.wkt/orDefault(): pbandk.wkt/Mixin // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Mixin?(){}[0]
+final fun (pbandk.wkt/OneofDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/OneofDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.OneofDescriptorProto?(){}[0]
+final fun (pbandk.wkt/OneofOptions?).pbandk.wkt/orDefault(): pbandk.wkt/OneofOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.OneofOptions?(){}[0]
+final fun (pbandk.wkt/Option?).pbandk.wkt/orDefault(): pbandk.wkt/Option // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Option?(){}[0]
+final fun (pbandk.wkt/ServiceDescriptorProto?).pbandk.wkt/orDefault(): pbandk.wkt/ServiceDescriptorProto // pbandk.wkt/orDefault|orDefault@pbandk.wkt.ServiceDescriptorProto?(){}[0]
+final fun (pbandk.wkt/ServiceOptions?).pbandk.wkt/orDefault(): pbandk.wkt/ServiceOptions // pbandk.wkt/orDefault|orDefault@pbandk.wkt.ServiceOptions?(){}[0]
+final fun (pbandk.wkt/SourceCodeInfo.Location?).pbandk.wkt/orDefault(): pbandk.wkt/SourceCodeInfo.Location // pbandk.wkt/orDefault|orDefault@pbandk.wkt.SourceCodeInfo.Location?(){}[0]
+final fun (pbandk.wkt/SourceCodeInfo?).pbandk.wkt/orDefault(): pbandk.wkt/SourceCodeInfo // pbandk.wkt/orDefault|orDefault@pbandk.wkt.SourceCodeInfo?(){}[0]
+final fun (pbandk.wkt/SourceContext?).pbandk.wkt/orDefault(): pbandk.wkt/SourceContext // pbandk.wkt/orDefault|orDefault@pbandk.wkt.SourceContext?(){}[0]
+final fun (pbandk.wkt/StringValue?).pbandk.wkt/orDefault(): pbandk.wkt/StringValue // pbandk.wkt/orDefault|orDefault@pbandk.wkt.StringValue?(){}[0]
+final fun (pbandk.wkt/Struct.FieldsEntry?).pbandk.wkt/orDefault(): pbandk.wkt/Struct.FieldsEntry // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Struct.FieldsEntry?(){}[0]
+final fun (pbandk.wkt/Struct?).pbandk.wkt/orDefault(): pbandk.wkt/Struct // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Struct?(){}[0]
+final fun (pbandk.wkt/Timestamp?).pbandk.wkt/orDefault(): pbandk.wkt/Timestamp // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Timestamp?(){}[0]
+final fun (pbandk.wkt/Type?).pbandk.wkt/orDefault(): pbandk.wkt/Type // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Type?(){}[0]
+final fun (pbandk.wkt/UInt32Value?).pbandk.wkt/orDefault(): pbandk.wkt/UInt32Value // pbandk.wkt/orDefault|orDefault@pbandk.wkt.UInt32Value?(){}[0]
+final fun (pbandk.wkt/UInt64Value?).pbandk.wkt/orDefault(): pbandk.wkt/UInt64Value // pbandk.wkt/orDefault|orDefault@pbandk.wkt.UInt64Value?(){}[0]
+final fun (pbandk.wkt/UninterpretedOption?).pbandk.wkt/orDefault(): pbandk.wkt/UninterpretedOption // pbandk.wkt/orDefault|orDefault@pbandk.wkt.UninterpretedOption?(){}[0]
+final fun (pbandk.wkt/Value?).pbandk.wkt/orDefault(): pbandk.wkt/Value // pbandk.wkt/orDefault|orDefault@pbandk.wkt.Value?(){}[0]
+final fun (pbandk/TypeRegistry).pbandk/contains(pbandk/Message.Companion<*>): kotlin/Boolean // pbandk/contains|contains@pbandk.TypeRegistry(pbandk.Message.Companion<*>){}[0]
+final fun (pbandk/TypeRegistry).pbandk/contains(pbandk/MessageDescriptor<*>): kotlin/Boolean // pbandk/contains|contains@pbandk.TypeRegistry(pbandk.MessageDescriptor<*>){}[0]
+final fun (pbandk/TypeRegistry).pbandk/containsTypeUrl(kotlin/String): kotlin/Boolean // pbandk/containsTypeUrl|containsTypeUrl@pbandk.TypeRegistry(kotlin.String){}[0]
+final fun (pbandk/TypeRegistry).pbandk/getTypeUrl(kotlin/String): pbandk/MessageDescriptor<*>? // pbandk/getTypeUrl|getTypeUrl@pbandk.TypeRegistry(kotlin.String){}[0]
+final fun (pbandk/TypeRegistry.Builder).pbandk/add(pbandk/Message.Companion<*>) // pbandk/add|add@pbandk.TypeRegistry.Builder(pbandk.Message.Companion<*>){}[0]
+final fun <#A: pbandk/Message, #B: kotlin/Any?> (#A).pbandk/getFieldValue(pbandk/FieldDescriptor<out #A, out #B>): #B // pbandk/getFieldValue|getFieldValue@0:0(pbandk.FieldDescriptor<out|0:0,out|0:1>){0§<pbandk.Message>;1§<kotlin.Any?>}[0]
+final fun <#A: pbandk/Message> (#A).pbandk.json/encodeToJsonString(pbandk.json/JsonConfig = ...): kotlin/String // pbandk.json/encodeToJsonString|encodeToJsonString@0:0(pbandk.json.JsonConfig){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (#A).pbandk/encodeToByteArray(): kotlin/ByteArray // pbandk/encodeToByteArray|encodeToByteArray@0:0(){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (#A).pbandk/encodeWith(pbandk/MessageEncoder) // pbandk/encodeWith|encodeWith@0:0(pbandk.MessageEncoder){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (#A?).pbandk/plus(#A?): #A? // pbandk/plus|plus@0:0?(0:0?){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (pbandk.wkt/Any).pbandk/isA(pbandk/Message.Companion<#A>): kotlin/Boolean // pbandk/isA|isA@pbandk.wkt.Any(pbandk.Message.Companion<0:0>){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (pbandk.wkt/Any).pbandk/unpack(pbandk/Message.Companion<#A>): #A // pbandk/unpack|unpack@pbandk.wkt.Any(pbandk.Message.Companion<0:0>){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (pbandk.wkt/Any.Companion).pbandk/pack(#A, kotlin/String = ...): pbandk.wkt/Any // pbandk/pack|pack@pbandk.wkt.Any.Companion(0:0;kotlin.String){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (pbandk/Message.Companion<#A>).pbandk.json/decodeFromJsonString(kotlin/String, pbandk.json/JsonConfig = ...): #A // pbandk.json/decodeFromJsonString|decodeFromJsonString@pbandk.Message.Companion<0:0>(kotlin.String;pbandk.json.JsonConfig){0§<pbandk.Message>}[0]
+final fun <#A: pbandk/Message> (pbandk/Message.Companion<#A>).pbandk/decodeFromByteArray(kotlin/ByteArray): #A // pbandk/decodeFromByteArray|decodeFromByteArray@pbandk.Message.Companion<0:0>(kotlin.ByteArray){0§<pbandk.Message>}[0]
+final fun pbandk/typeRegistry(kotlin/Function1<pbandk/TypeRegistry.Builder, kotlin/Unit>): pbandk/TypeRegistry // pbandk/typeRegistry|typeRegistry(kotlin.Function1<pbandk.TypeRegistry.Builder,kotlin.Unit>){}[0]
+
+// Targets: [native]
+open annotation class pbandk/Export : kotlin/Annotation { // pbandk/Export|null[0]
+    constructor <init>() // pbandk/Export.<init>|<init>(){}[0]
+}
+
+// Targets: [native]
+open annotation class pbandk/JsName : kotlin/Annotation { // pbandk/JsName|null[0]
+    constructor <init>(kotlin/String) // pbandk/JsName.<init>|<init>(kotlin.String){}[0]
+
+    final val name // pbandk/JsName.name|{}name[0]
+        final fun <get-name>(): kotlin/String // pbandk/JsName.name.<get-name>|<get-name>(){}[0]
+}

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -1,3 +1,4 @@
+import kotlinx.validation.ExperimentalBCVApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -17,6 +18,10 @@ repositories {
 
 apiValidation {
     nonPublicMarkers.add("pbandk.PbandkInternal")
+    @OptIn(ExperimentalBCVApi::class)
+    klib {
+        enabled = true
+    }
 }
 
 kotlin {
@@ -33,18 +38,30 @@ kotlin {
         nodejs {}
     }
 
-    iosArm64()
-    iosX64()
-    iosSimulatorArm64()
-
-    tvosArm64()
-    tvosX64()
-    tvosSimulatorArm64()
-
-    linuxArm64()
-    linuxX64()
-    macosArm64()
+    // Native targets, according to https://kotlinlang.org/docs/native-target-support.html
+    // Tier 1
     macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+    // Tier 2
+    linuxX64()
+    linuxArm64()
+    //watchosSimulatorArm64()
+    //watchosX64()
+    //watchosArm32()
+    //watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    iosArm64()
+    // Tier 3
+    //androidNativeArm32()
+    //androidNativeArm64()
+    //androidNativeX86()
+    //androidNativeX64()
+    //mingwX64()
+    //watchosDeviceArm64()
 
     sourceSets {
         all {

--- a/runtime/src/commonMain/kotlin/pbandk/ExtensionFieldSet.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ExtensionFieldSet.kt
@@ -1,8 +1,9 @@
 package pbandk
 
 import pbandk.internal.AtomicReference
+import kotlin.js.JsExport
 
-@PublicForGeneratedCode
+@JsExport
 public class ExtensionFieldSet {
     private val map = AtomicReference<Map<Int, Any>>(emptyMap())
 

--- a/runtime/src/commonMain/kotlin/pbandk/FieldDescriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/FieldDescriptor.kt
@@ -7,7 +7,10 @@ import kotlin.reflect.KProperty0
 import kotlin.reflect.KProperty1
 
 @JsExport
-public class FieldDescriptor<M : Message, T> @PublicForGeneratedCode constructor(
+public class FieldDescriptor<M : Message, T>
+@JsExport.Ignore
+@PublicForGeneratedCode
+constructor(
     messageDescriptor: KProperty0<MessageDescriptor<M>>,
     @ExperimentalProtoReflection
     public val name: String,
@@ -24,6 +27,7 @@ public class FieldDescriptor<M : Message, T> @PublicForGeneratedCode constructor
     // [MessageDescriptor] constructor. To avoid the circular dependency, this property is declared lazy.
     internal val messageDescriptor: MessageDescriptor<M> by lazy { messageDescriptor.get() }
 
+    @JsExport.Ignore
     @PublicForGeneratedCode
     public sealed class Type {
         internal abstract val hasPresence: Boolean
@@ -134,7 +138,7 @@ public class FieldDescriptor<M : Message, T> @PublicForGeneratedCode constructor
         ) : Type() {
             override val isPackable: Boolean get() = true
             override val wireType: WireType get() = WireType.VARINT
-            override val defaultValue: Any? = enumCompanion.fromValue(0)
+            override val defaultValue: Any = enumCompanion.fromValue(0)
             override fun isDefaultValue(value: Any?) = (value as? pbandk.Message.Enum)?.value == 0
         }
 
@@ -144,7 +148,7 @@ public class FieldDescriptor<M : Message, T> @PublicForGeneratedCode constructor
             override val hasPresence get() = false
             override val isPackable: Boolean get() = false
             override val wireType: WireType get() = valueType.wireType
-            override val defaultValue: Any? = emptyList<T>()
+            override val defaultValue: Any = emptyList<T>()
             override fun isDefaultValue(value: Any?) = (value as? List<*>)?.isEmpty() == true
         }
 
@@ -155,10 +159,8 @@ public class FieldDescriptor<M : Message, T> @PublicForGeneratedCode constructor
             override val hasPresence get() = false
             override val isPackable: Boolean get() = false
             override val wireType: WireType get() = WireType.LENGTH_DELIMITED
-            override val defaultValue: Any? = emptyMap<K, V>()
+            override val defaultValue: Any = emptyMap<K, V>()
             override fun isDefaultValue(value: Any?) = (value as? kotlin.collections.Map<*, *>)?.isEmpty() == true
         }
     }
-
-
 }

--- a/runtime/src/commonMain/kotlin/pbandk/ListWithSize.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/ListWithSize.kt
@@ -1,12 +1,7 @@
 package pbandk
 
-import kotlin.js.JsExport
-import kotlin.js.JsName
-
 @PublicForGeneratedCode
-@JsExport
 public class ListWithSize<T> internal constructor(public val list: List<T>, public val protoSize: Int?) : List<T> by list {
-    @JsName("initWithSizeFn")
     public constructor(list: List<T>, sizeFn: (T) -> Int) : this(list, list.sumOf(sizeFn))
 
     override fun equals(other: Any?): Boolean = list == other
@@ -15,7 +10,6 @@ public class ListWithSize<T> internal constructor(public val list: List<T>, publ
 
     @PublicForGeneratedCode
     public class Builder<T> private constructor(public val list: ArrayList<T>): MutableList<T> by list {
-        @JsName("init")
         public constructor() : this(ArrayList())
 
         public fun fixed(): ListWithSize<T> = ListWithSize(list.also { it.trimToSize() }, protoSize = null)

--- a/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageDescriptor.kt
@@ -4,7 +4,10 @@ import kotlin.js.JsExport
 import kotlin.reflect.KClass
 
 @JsExport
-public class MessageDescriptor<T : Message> @PublicForGeneratedCode constructor(
+public class MessageDescriptor<T : Message>
+@JsExport.Ignore
+@PublicForGeneratedCode
+constructor(
     /**
      * The message type's fully-qualified name, within the proto language's namespace. This differs from
      * the Kotlin name. For example, given this `.proto`:

--- a/runtime/src/commonMain/kotlin/pbandk/MessageMap.kt
+++ b/runtime/src/commonMain/kotlin/pbandk/MessageMap.kt
@@ -1,10 +1,8 @@
 package pbandk
 
-import kotlin.js.JsExport
 import kotlin.reflect.KClass
 
 @PublicForGeneratedCode
-@JsExport
 public class MessageMap<K, V> internal constructor(override val entries: Set<Entry<K, V>>) : AbstractMap<K, V>() {
     @PublicForGeneratedCode
     public class Builder<K, V> {

--- a/runtime/src/jsMain/kotlin/pbandk/internal/Util.js.kt
+++ b/runtime/src/jsMain/kotlin/pbandk/internal/Util.js.kt
@@ -12,4 +12,5 @@ public inline fun ByteArray.asUint8Array(): Uint8Array =
     unsafeCast<Int8Array>().run { Uint8Array(buffer, byteOffset, length) }
 
 @PbandkInternal
+@Suppress("NOTHING_TO_INLINE")
 public inline fun Uint8Array.asByteArray(): ByteArray = Int8Array(buffer, byteOffset, length).unsafeCast<ByteArray>()

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -23,18 +23,30 @@ kotlin {
         }
     }
 
-    iosArm64()
-    iosX64()
-    iosSimulatorArm64()
-
-    tvosArm64()
-    tvosX64()
-    tvosSimulatorArm64()
-
-    linuxArm64()
-    linuxX64()
-    macosArm64()
+    // Native targets, according to https://kotlinlang.org/docs/native-target-support.html
+    // Tier 1
     macosX64()
+    macosArm64()
+    iosSimulatorArm64()
+    iosX64()
+    // Tier 2
+    linuxX64()
+    linuxArm64()
+    //watchosSimulatorArm64()
+    //watchosX64()
+    //watchosArm32()
+    //watchosArm64()
+    tvosSimulatorArm64()
+    tvosX64()
+    tvosArm64()
+    iosArm64()
+    // Tier 3
+    //androidNativeArm32()
+    //androidNativeArm64()
+    //androidNativeX86()
+    //androidNativeX64()
+    //mingwX64()
+    //watchosDeviceArm64()
 
     sourceSets {
         commonMain {


### PR DESCRIPTION
- **Update to Kotlin 2.0.10 and associated dependencies**
- **Resolve conflicts between @PublicForGeneratedCode and @JsExport**
- **Remove obsolete gradle workarounds in the example projects**
