### PR TITLE
Reduce chunk size for message descriptors in generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+* Reduced the likelihood of getting a `MethodTooLargeException` when generating code for protobuf messages that contain many fields with custom options. (PR [#277], fixes [#252])
+
 [#233]: https://github.com/streem/pbandk/issues/233
+[#252]: https://github.com/streem/pbandk/issues/252
 [#270]: https://github.com/streem/pbandk/pull/270
 [#273]: https://github.com/streem/pbandk/pull/273
 [#276]: https://github.com/streem/pbandk/pull/276
+[#277]: https://github.com/streem/pbandk/pull/277
 
 
 ## [0.15.0] - 2024-08-05

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto2.kt
@@ -178,1187 +178,1195 @@ public data class TestAllTypesProto2(
             messageClass = pbandk.conformance.pb.TestAllTypesProto2::class,
             messageCompanion = this,
             fields = buildList(117) {
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int32",
-                        number = 1,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "optionalInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int64",
-                        number = 2,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int64(hasPresence = true),
-                        jsonName = "optionalInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint32",
-                        number = 3,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
-                        jsonName = "optionalUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint64",
-                        number = 4,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
-                        jsonName = "optionalUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sint32",
-                        number = 5,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true),
-                        jsonName = "optionalSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sint64",
-                        number = 6,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true),
-                        jsonName = "optionalSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_fixed32",
-                        number = 7,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Fixed32(hasPresence = true),
-                        jsonName = "optionalFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_fixed64",
-                        number = 8,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Fixed64(hasPresence = true),
-                        jsonName = "optionalFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sfixed32",
-                        number = 9,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SFixed32(hasPresence = true),
-                        jsonName = "optionalSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sfixed64",
-                        number = 10,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SFixed64(hasPresence = true),
-                        jsonName = "optionalSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_float",
-                        number = 11,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
-                        jsonName = "optionalFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_double",
-                        number = 12,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
-                        jsonName = "optionalDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bool",
-                        number = 13,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
-                        jsonName = "optionalBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string",
-                        number = 14,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
-                        jsonName = "optionalString",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bytes",
-                        number = 15,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
-                        jsonName = "optionalBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_nested_message",
-                        number = 18,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion),
-                        jsonName = "optionalNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_foreign_message",
-                        number = 19,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessageProto2.Companion),
-                        jsonName = "optionalForeignMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_nested_enum",
-                        number = 21,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion, hasPresence = true),
-                        jsonName = "optionalNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_foreign_enum",
-                        number = 22,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnumProto2.Companion, hasPresence = true),
-                        jsonName = "optionalForeignEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string_piece",
-                        number = 24,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
-                        jsonName = "optionalStringPiece",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalStringPiece
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_cord",
-                        number = 25,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
-                        jsonName = "optionalCord",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::optionalCord
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "recursive_message",
-                        number = 27,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.Companion),
-                        jsonName = "recursiveMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::recursiveMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int32",
-                        number = 31,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
-                        jsonName = "repeatedInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int64",
-                        number = 32,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
-                        jsonName = "repeatedInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint32",
-                        number = 33,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
-                        jsonName = "repeatedUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint64",
-                        number = 34,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
-                        jsonName = "repeatedUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sint32",
-                        number = 35,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
-                        jsonName = "repeatedSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sint64",
-                        number = 36,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
-                        jsonName = "repeatedSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fixed32",
-                        number = 37,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
-                        jsonName = "repeatedFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fixed64",
-                        number = 38,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
-                        jsonName = "repeatedFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sfixed32",
-                        number = 39,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
-                        jsonName = "repeatedSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sfixed64",
-                        number = 40,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
-                        jsonName = "repeatedSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_float",
-                        number = 41,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
-                        jsonName = "repeatedFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_double",
-                        number = 42,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
-                        jsonName = "repeatedDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bool",
-                        number = 43,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
-                        jsonName = "repeatedBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string",
-                        number = 44,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedString",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bytes",
-                        number = 45,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
-                        jsonName = "repeatedBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_nested_message",
-                        number = 48,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion)),
-                        jsonName = "repeatedNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_foreign_message",
-                        number = 49,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignMessageProto2>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessageProto2.Companion)),
-                        jsonName = "repeatedForeignMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_nested_enum",
-                        number = 51,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion)),
-                        jsonName = "repeatedNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_foreign_enum",
-                        number = 52,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignEnumProto2>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnumProto2.Companion)),
-                        jsonName = "repeatedForeignEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string_piece",
-                        number = 54,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedStringPiece",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedStringPiece
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_cord",
-                        number = 55,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedCord",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::repeatedCord
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_int32",
-                        number = 56,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true)),
-                        jsonName = "mapInt32Int32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapInt32Int32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int64_int64",
-                        number = 57,
-                        type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(hasPresence = true)),
-                        jsonName = "mapInt64Int64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapInt64Int64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_uint32_uint32",
-                        number = 58,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true)),
-                        jsonName = "mapUint32Uint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapUint32Uint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_uint64_uint64",
-                        number = 59,
-                        type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true)),
-                        jsonName = "mapUint64Uint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapUint64Uint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sint32_sint32",
-                        number = 60,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true)),
-                        jsonName = "mapSint32Sint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapSint32Sint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sint64_sint64",
-                        number = 61,
-                        type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true)),
-                        jsonName = "mapSint64Sint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapSint64Sint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_fixed32_fixed32",
-                        number = 62,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(hasPresence = true)),
-                        jsonName = "mapFixed32Fixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapFixed32Fixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_fixed64_fixed64",
-                        number = 63,
-                        type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(hasPresence = true)),
-                        jsonName = "mapFixed64Fixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapFixed64Fixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sfixed32_sfixed32",
-                        number = 64,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(hasPresence = true)),
-                        jsonName = "mapSfixed32Sfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapSfixed32Sfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sfixed64_sfixed64",
-                        number = 65,
-                        type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(hasPresence = true)),
-                        jsonName = "mapSfixed64Sfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapSfixed64Sfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_float",
-                        number = 66,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Float?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true)),
-                        jsonName = "mapInt32Float",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapInt32Float
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_double",
-                        number = 67,
-                        type = pbandk.FieldDescriptor.Type.Map<Int?, Double?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true)),
-                        jsonName = "mapInt32Double",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapInt32Double
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_bool_bool",
-                        number = 68,
-                        type = pbandk.FieldDescriptor.Type.Map<Boolean?, Boolean?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true)),
-                        jsonName = "mapBoolBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapBoolBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_string",
-                        number = 69,
-                        type = pbandk.FieldDescriptor.Type.Map<String?, String?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true)),
-                        jsonName = "mapStringString",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapStringString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_bytes",
-                        number = 70,
-                        type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.ByteArr?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true)),
-                        jsonName = "mapStringBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapStringBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_nested_message",
-                        number = 71,
-                        type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.TestAllTypesProto2.NestedMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion)),
-                        jsonName = "mapStringNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapStringNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_foreign_message",
-                        number = 72,
-                        type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.ForeignMessageProto2?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessageProto2.Companion)),
-                        jsonName = "mapStringForeignMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapStringForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_nested_enum",
-                        number = 73,
-                        type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.TestAllTypesProto2.NestedEnum?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion, hasPresence = true)),
-                        jsonName = "mapStringNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapStringNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_foreign_enum",
-                        number = 74,
-                        type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.ForeignEnumProto2?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnumProto2.Companion, hasPresence = true)),
-                        jsonName = "mapStringForeignEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::mapStringForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_int32",
-                        number = 75,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
-                        jsonName = "packedInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_int64",
-                        number = 76,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
-                        jsonName = "packedInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_uint32",
-                        number = 77,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "packedUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_uint64",
-                        number = 78,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
-                        jsonName = "packedUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sint32",
-                        number = 79,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
-                        jsonName = "packedSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sint64",
-                        number = 80,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
-                        jsonName = "packedSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_fixed32",
-                        number = 81,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
-                        jsonName = "packedFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_fixed64",
-                        number = 82,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
-                        jsonName = "packedFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sfixed32",
-                        number = 83,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
-                        jsonName = "packedSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sfixed64",
-                        number = 84,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
-                        jsonName = "packedSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_float",
-                        number = 85,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
-                        jsonName = "packedFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_double",
-                        number = 86,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
-                        jsonName = "packedDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_bool",
-                        number = 87,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
-                        jsonName = "packedBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_nested_enum",
-                        number = 88,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion), packed = true),
-                        jsonName = "packedNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::packedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_int32",
-                        number = 89,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
-                        jsonName = "unpackedInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_int64",
-                        number = 90,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
-                        jsonName = "unpackedInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_uint32",
-                        number = 91,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
-                        jsonName = "unpackedUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_uint64",
-                        number = 92,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
-                        jsonName = "unpackedUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sint32",
-                        number = 93,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
-                        jsonName = "unpackedSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sint64",
-                        number = 94,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
-                        jsonName = "unpackedSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_fixed32",
-                        number = 95,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
-                        jsonName = "unpackedFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_fixed64",
-                        number = 96,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
-                        jsonName = "unpackedFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sfixed32",
-                        number = 97,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
-                        jsonName = "unpackedSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sfixed64",
-                        number = 98,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
-                        jsonName = "unpackedSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_float",
-                        number = 99,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
-                        jsonName = "unpackedFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_double",
-                        number = 100,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
-                        jsonName = "unpackedDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_bool",
-                        number = 101,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
-                        jsonName = "unpackedBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_nested_enum",
-                        number = 102,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion)),
-                        jsonName = "unpackedNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::unpackedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_uint32",
-                        number = 111,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_nested_message",
-                        number = 112,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion),
-                        oneofMember = true,
-                        jsonName = "oneofNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_string",
-                        number = 113,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofString",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_bytes",
-                        number = 114,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_bool",
-                        number = 115,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_uint64",
-                        number = 116,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_float",
-                        number = 117,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_double",
-                        number = 118,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_enum",
-                        number = 119,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion, hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::oneofEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "fieldname1",
-                        number = 401,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldname1",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldname1
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_name2",
-                        number = 402,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName2",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName2
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "_field_name3",
-                        number = 403,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FieldName3",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName3
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__name4_",
-                        number = 404,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName4",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::field_name4
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field0name5",
-                        number = 405,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "field0name5",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::field0name5
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_0_name6",
-                        number = 406,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "field0Name6",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::field0Name6
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "fieldName7",
-                        number = 407,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName7",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName7
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FieldName8",
-                        number = 408,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FieldName8",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName8
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_Name9",
-                        number = 409,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName9",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName9
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "Field_Name10",
-                        number = 410,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FieldName10",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName10
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FIELD_NAME11",
-                        number = 411,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FIELDNAME11",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fIELDNAME11
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FIELD_name12",
-                        number = 412,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FIELDName12",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fIELDName12
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "__field_name13",
-                        number = 413,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FieldName13",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::_fieldName13
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "__Field_name14",
-                        number = 414,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FieldName14",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::_FieldName14
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__name15",
-                        number = 415,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName15",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::field_name15
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__Name16",
-                        number = 416,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName16",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::field_Name16
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_name17__",
-                        number = 417,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "fieldName17",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName17_
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "Field_name18__",
-                        number = 418,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
-                        jsonName = "FieldName18",
-                        value = pbandk.conformance.pb.TestAllTypesProto2::fieldName18_
-                    )
-                )
+                addFields0()
+                addFields1()
             }
         )
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.conformance.pb.TestAllTypesProto2, *>>.addFields0() {
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int32",
+                    number = 1,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "optionalInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int64",
+                    number = 2,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int64(hasPresence = true),
+                    jsonName = "optionalInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint32",
+                    number = 3,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
+                    jsonName = "optionalUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint64",
+                    number = 4,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
+                    jsonName = "optionalUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sint32",
+                    number = 5,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true),
+                    jsonName = "optionalSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sint64",
+                    number = 6,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true),
+                    jsonName = "optionalSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_fixed32",
+                    number = 7,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Fixed32(hasPresence = true),
+                    jsonName = "optionalFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_fixed64",
+                    number = 8,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Fixed64(hasPresence = true),
+                    jsonName = "optionalFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sfixed32",
+                    number = 9,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SFixed32(hasPresence = true),
+                    jsonName = "optionalSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sfixed64",
+                    number = 10,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SFixed64(hasPresence = true),
+                    jsonName = "optionalSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_float",
+                    number = 11,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
+                    jsonName = "optionalFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_double",
+                    number = 12,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
+                    jsonName = "optionalDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bool",
+                    number = 13,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
+                    jsonName = "optionalBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string",
+                    number = 14,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                    jsonName = "optionalString",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bytes",
+                    number = 15,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
+                    jsonName = "optionalBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_nested_message",
+                    number = 18,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion),
+                    jsonName = "optionalNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_foreign_message",
+                    number = 19,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessageProto2.Companion),
+                    jsonName = "optionalForeignMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_nested_enum",
+                    number = 21,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion, hasPresence = true),
+                    jsonName = "optionalNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_foreign_enum",
+                    number = 22,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnumProto2.Companion, hasPresence = true),
+                    jsonName = "optionalForeignEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string_piece",
+                    number = 24,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                    jsonName = "optionalStringPiece",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalStringPiece
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_cord",
+                    number = 25,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                    jsonName = "optionalCord",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::optionalCord
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "recursive_message",
+                    number = 27,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.Companion),
+                    jsonName = "recursiveMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::recursiveMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int32",
+                    number = 31,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
+                    jsonName = "repeatedInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int64",
+                    number = 32,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
+                    jsonName = "repeatedInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint32",
+                    number = 33,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
+                    jsonName = "repeatedUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint64",
+                    number = 34,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
+                    jsonName = "repeatedUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sint32",
+                    number = 35,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
+                    jsonName = "repeatedSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sint64",
+                    number = 36,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
+                    jsonName = "repeatedSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fixed32",
+                    number = 37,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
+                    jsonName = "repeatedFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fixed64",
+                    number = 38,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
+                    jsonName = "repeatedFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sfixed32",
+                    number = 39,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
+                    jsonName = "repeatedSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sfixed64",
+                    number = 40,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
+                    jsonName = "repeatedSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_float",
+                    number = 41,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
+                    jsonName = "repeatedFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_double",
+                    number = 42,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
+                    jsonName = "repeatedDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bool",
+                    number = 43,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
+                    jsonName = "repeatedBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string",
+                    number = 44,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedString",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bytes",
+                    number = 45,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
+                    jsonName = "repeatedBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_nested_message",
+                    number = 48,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion)),
+                    jsonName = "repeatedNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_foreign_message",
+                    number = 49,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignMessageProto2>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessageProto2.Companion)),
+                    jsonName = "repeatedForeignMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_nested_enum",
+                    number = 51,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion)),
+                    jsonName = "repeatedNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_foreign_enum",
+                    number = 52,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignEnumProto2>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnumProto2.Companion)),
+                    jsonName = "repeatedForeignEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string_piece",
+                    number = 54,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedStringPiece",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedStringPiece
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_cord",
+                    number = 55,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedCord",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::repeatedCord
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_int32",
+                    number = 56,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true)),
+                    jsonName = "mapInt32Int32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapInt32Int32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int64_int64",
+                    number = 57,
+                    type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(hasPresence = true)),
+                    jsonName = "mapInt64Int64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapInt64Int64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_uint32_uint32",
+                    number = 58,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true)),
+                    jsonName = "mapUint32Uint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapUint32Uint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_uint64_uint64",
+                    number = 59,
+                    type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true)),
+                    jsonName = "mapUint64Uint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapUint64Uint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sint32_sint32",
+                    number = 60,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(hasPresence = true)),
+                    jsonName = "mapSint32Sint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapSint32Sint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sint64_sint64",
+                    number = 61,
+                    type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(hasPresence = true)),
+                    jsonName = "mapSint64Sint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapSint64Sint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_fixed32_fixed32",
+                    number = 62,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(hasPresence = true)),
+                    jsonName = "mapFixed32Fixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapFixed32Fixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_fixed64_fixed64",
+                    number = 63,
+                    type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(hasPresence = true)),
+                    jsonName = "mapFixed64Fixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapFixed64Fixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sfixed32_sfixed32",
+                    number = 64,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Int?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(hasPresence = true)),
+                    jsonName = "mapSfixed32Sfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapSfixed32Sfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sfixed64_sfixed64",
+                    number = 65,
+                    type = pbandk.FieldDescriptor.Type.Map<Long?, Long?>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(hasPresence = true)),
+                    jsonName = "mapSfixed64Sfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapSfixed64Sfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_float",
+                    number = 66,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Float?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true)),
+                    jsonName = "mapInt32Float",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapInt32Float
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_double",
+                    number = 67,
+                    type = pbandk.FieldDescriptor.Type.Map<Int?, Double?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true)),
+                    jsonName = "mapInt32Double",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapInt32Double
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_bool_bool",
+                    number = 68,
+                    type = pbandk.FieldDescriptor.Type.Map<Boolean?, Boolean?>(keyType = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true)),
+                    jsonName = "mapBoolBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapBoolBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_string",
+                    number = 69,
+                    type = pbandk.FieldDescriptor.Type.Map<String?, String?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true)),
+                    jsonName = "mapStringString",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapStringString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_bytes",
+                    number = 70,
+                    type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.ByteArr?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true)),
+                    jsonName = "mapStringBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapStringBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_nested_message",
+                    number = 71,
+                    type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.TestAllTypesProto2.NestedMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion)),
+                    jsonName = "mapStringNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapStringNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_foreign_message",
+                    number = 72,
+                    type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.ForeignMessageProto2?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessageProto2.Companion)),
+                    jsonName = "mapStringForeignMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapStringForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_nested_enum",
+                    number = 73,
+                    type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.TestAllTypesProto2.NestedEnum?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion, hasPresence = true)),
+                    jsonName = "mapStringNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapStringNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_foreign_enum",
+                    number = 74,
+                    type = pbandk.FieldDescriptor.Type.Map<String?, pbandk.conformance.pb.ForeignEnumProto2?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnumProto2.Companion, hasPresence = true)),
+                    jsonName = "mapStringForeignEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::mapStringForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_int32",
+                    number = 75,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
+                    jsonName = "packedInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_int64",
+                    number = 76,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
+                    jsonName = "packedInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_uint32",
+                    number = 77,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
+                    jsonName = "packedUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_uint64",
+                    number = 78,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
+                    jsonName = "packedUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sint32",
+                    number = 79,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
+                    jsonName = "packedSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sint64",
+                    number = 80,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
+                    jsonName = "packedSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_fixed32",
+                    number = 81,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
+                    jsonName = "packedFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_fixed64",
+                    number = 82,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
+                    jsonName = "packedFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sfixed32",
+                    number = 83,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
+                    jsonName = "packedSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sfixed64",
+                    number = 84,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
+                    jsonName = "packedSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_float",
+                    number = 85,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
+                    jsonName = "packedFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_double",
+                    number = 86,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
+                    jsonName = "packedDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_bool",
+                    number = 87,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
+                    jsonName = "packedBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_nested_enum",
+                    number = 88,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion), packed = true),
+                    jsonName = "packedNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::packedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_int32",
+                    number = 89,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
+                    jsonName = "unpackedInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_int64",
+                    number = 90,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
+                    jsonName = "unpackedInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_uint32",
+                    number = 91,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
+                    jsonName = "unpackedUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_uint64",
+                    number = 92,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
+                    jsonName = "unpackedUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sint32",
+                    number = 93,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
+                    jsonName = "unpackedSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sint64",
+                    number = 94,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
+                    jsonName = "unpackedSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_fixed32",
+                    number = 95,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
+                    jsonName = "unpackedFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_fixed64",
+                    number = 96,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
+                    jsonName = "unpackedFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sfixed32",
+                    number = 97,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
+                    jsonName = "unpackedSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sfixed64",
+                    number = 98,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
+                    jsonName = "unpackedSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_float",
+                    number = 99,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
+                    jsonName = "unpackedFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_double",
+                    number = 100,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
+                    jsonName = "unpackedDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_bool",
+                    number = 101,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
+                    jsonName = "unpackedBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_nested_enum",
+                    number = 102,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto2.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion)),
+                    jsonName = "unpackedNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::unpackedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_uint32",
+                    number = 111,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_nested_message",
+                    number = 112,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedMessage.Companion),
+                    oneofMember = true,
+                    jsonName = "oneofNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_string",
+                    number = 113,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofString",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_bytes",
+                    number = 114,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_bool",
+                    number = 115,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_uint64",
+                    number = 116,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_float",
+                    number = 117,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_double",
+                    number = 118,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_enum",
+                    number = 119,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto2.NestedEnum.Companion, hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::oneofEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "fieldname1",
+                    number = 401,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldname1",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldname1
+                )
+            )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.conformance.pb.TestAllTypesProto2, *>>.addFields1() {
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_name2",
+                    number = 402,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName2",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName2
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "_field_name3",
+                    number = 403,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FieldName3",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName3
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__name4_",
+                    number = 404,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName4",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::field_name4
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field0name5",
+                    number = 405,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "field0name5",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::field0name5
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_0_name6",
+                    number = 406,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "field0Name6",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::field0Name6
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "fieldName7",
+                    number = 407,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName7",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName7
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FieldName8",
+                    number = 408,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FieldName8",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName8
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_Name9",
+                    number = 409,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName9",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName9
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "Field_Name10",
+                    number = 410,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FieldName10",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName10
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FIELD_NAME11",
+                    number = 411,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FIELDNAME11",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fIELDNAME11
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FIELD_name12",
+                    number = 412,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FIELDName12",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fIELDName12
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "__field_name13",
+                    number = 413,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FieldName13",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::_fieldName13
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "__Field_name14",
+                    number = 414,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FieldName14",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::_FieldName14
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__name15",
+                    number = 415,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName15",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::field_name15
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__Name16",
+                    number = 416,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName16",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::field_Name16
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_name17__",
+                    number = 417,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "fieldName17",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName17_
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "Field_name18__",
+                    number = 418,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(hasPresence = true),
+                    jsonName = "FieldName18",
+                    value = pbandk.conformance.pb.TestAllTypesProto2::fieldName18_
+                )
+            )
+        }
     }
 
     public sealed class NestedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {

--- a/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
+++ b/conformance/lib/src/commonMain/kotlin/pbandk/conformance/pb/test_messages_proto3.kt
@@ -208,1507 +208,1515 @@ public data class TestAllTypesProto3(
             messageClass = pbandk.conformance.pb.TestAllTypesProto3::class,
             messageCompanion = this,
             fields = buildList(149) {
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int32",
-                        number = 1,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "optionalInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int64",
-                        number = 2,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int64(),
-                        jsonName = "optionalInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint32",
-                        number = 3,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt32(),
-                        jsonName = "optionalUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint64",
-                        number = 4,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt64(),
-                        jsonName = "optionalUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sint32",
-                        number = 5,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SInt32(),
-                        jsonName = "optionalSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sint64",
-                        number = 6,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SInt64(),
-                        jsonName = "optionalSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_fixed32",
-                        number = 7,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Fixed32(),
-                        jsonName = "optionalFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_fixed64",
-                        number = 8,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Fixed64(),
-                        jsonName = "optionalFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sfixed32",
-                        number = 9,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SFixed32(),
-                        jsonName = "optionalSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sfixed64",
-                        number = 10,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SFixed64(),
-                        jsonName = "optionalSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_float",
-                        number = 11,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Float(),
-                        jsonName = "optionalFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_double",
-                        number = 12,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(),
-                        jsonName = "optionalDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bool",
-                        number = 13,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
-                        jsonName = "optionalBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string",
-                        number = 14,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "optionalString",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bytes",
-                        number = 15,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(),
-                        jsonName = "optionalBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_nested_message",
-                        number = 18,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion),
-                        jsonName = "optionalNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_foreign_message",
-                        number = 19,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessage.Companion),
-                        jsonName = "optionalForeignMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_nested_enum",
-                        number = 21,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion),
-                        jsonName = "optionalNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_foreign_enum",
-                        number = 22,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnum.Companion),
-                        jsonName = "optionalForeignEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_aliased_enum",
-                        number = 23,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum.Companion),
-                        jsonName = "optionalAliasedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalAliasedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string_piece",
-                        number = 24,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "optionalStringPiece",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalStringPiece
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_cord",
-                        number = 25,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "optionalCord",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalCord
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "recursive_message",
-                        number = 27,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.Companion),
-                        jsonName = "recursiveMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::recursiveMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int32",
-                        number = 31,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
-                        jsonName = "repeatedInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int64",
-                        number = 32,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
-                        jsonName = "repeatedInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint32",
-                        number = 33,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "repeatedUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint64",
-                        number = 34,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
-                        jsonName = "repeatedUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sint32",
-                        number = 35,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
-                        jsonName = "repeatedSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sint64",
-                        number = 36,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
-                        jsonName = "repeatedSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fixed32",
-                        number = 37,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
-                        jsonName = "repeatedFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fixed64",
-                        number = 38,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
-                        jsonName = "repeatedFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sfixed32",
-                        number = 39,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
-                        jsonName = "repeatedSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sfixed64",
-                        number = 40,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
-                        jsonName = "repeatedSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_float",
-                        number = 41,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
-                        jsonName = "repeatedFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_double",
-                        number = 42,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
-                        jsonName = "repeatedDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bool",
-                        number = 43,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
-                        jsonName = "repeatedBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string",
-                        number = 44,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedString",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bytes",
-                        number = 45,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
-                        jsonName = "repeatedBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_nested_message",
-                        number = 48,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion)),
-                        jsonName = "repeatedNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_foreign_message",
-                        number = 49,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessage.Companion)),
-                        jsonName = "repeatedForeignMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_nested_enum",
-                        number = 51,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
-                        jsonName = "repeatedNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_foreign_enum",
-                        number = 52,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnum.Companion), packed = true),
-                        jsonName = "repeatedForeignEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string_piece",
-                        number = 54,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedStringPiece",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedStringPiece
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_cord",
-                        number = 55,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedCord",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedCord
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_int32",
-                        number = 56,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
-                        jsonName = "mapInt32Int32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapInt32Int32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int64_int64",
-                        number = 57,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
-                        jsonName = "mapInt64Int64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapInt64Int64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_uint32_uint32",
-                        number = 58,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
-                        jsonName = "mapUint32Uint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapUint32Uint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_uint64_uint64",
-                        number = 59,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
-                        jsonName = "mapUint64Uint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapUint64Uint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sint32_sint32",
-                        number = 60,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
-                        jsonName = "mapSint32Sint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapSint32Sint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sint64_sint64",
-                        number = 61,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
-                        jsonName = "mapSint64Sint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapSint64Sint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_fixed32_fixed32",
-                        number = 62,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
-                        jsonName = "mapFixed32Fixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapFixed32Fixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_fixed64_fixed64",
-                        number = 63,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
-                        jsonName = "mapFixed64Fixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapFixed64Fixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sfixed32_sfixed32",
-                        number = 64,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
-                        jsonName = "mapSfixed32Sfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapSfixed32Sfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sfixed64_sfixed64",
-                        number = 65,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
-                        jsonName = "mapSfixed64Sfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapSfixed64Sfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_float",
-                        number = 66,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Float>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
-                        jsonName = "mapInt32Float",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapInt32Float
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_double",
-                        number = 67,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Double>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
-                        jsonName = "mapInt32Double",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapInt32Double
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_bool_bool",
-                        number = 68,
-                        type = pbandk.FieldDescriptor.Type.Map<Boolean, Boolean>(keyType = pbandk.FieldDescriptor.Type.Primitive.Bool(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
-                        jsonName = "mapBoolBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapBoolBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_string",
-                        number = 69,
-                        type = pbandk.FieldDescriptor.Type.Map<String, String>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "mapStringString",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapStringString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_bytes",
-                        number = 70,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.ByteArr>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
-                        jsonName = "mapStringBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapStringBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_nested_message",
-                        number = 71,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.TestAllTypesProto3.NestedMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion)),
-                        jsonName = "mapStringNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapStringNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_foreign_message",
-                        number = 72,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.ForeignMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessage.Companion)),
-                        jsonName = "mapStringForeignMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapStringForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_nested_enum",
-                        number = 73,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion)),
-                        jsonName = "mapStringNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapStringNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_foreign_enum",
-                        number = 74,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.ForeignEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnum.Companion)),
-                        jsonName = "mapStringForeignEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::mapStringForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_int32",
-                        number = 75,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
-                        jsonName = "packedInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_int64",
-                        number = 76,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
-                        jsonName = "packedInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_uint32",
-                        number = 77,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "packedUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_uint64",
-                        number = 78,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
-                        jsonName = "packedUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sint32",
-                        number = 79,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
-                        jsonName = "packedSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sint64",
-                        number = 80,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
-                        jsonName = "packedSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_fixed32",
-                        number = 81,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
-                        jsonName = "packedFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_fixed64",
-                        number = 82,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
-                        jsonName = "packedFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sfixed32",
-                        number = 83,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
-                        jsonName = "packedSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sfixed64",
-                        number = 84,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
-                        jsonName = "packedSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_float",
-                        number = 85,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
-                        jsonName = "packedFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_double",
-                        number = 86,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
-                        jsonName = "packedDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_bool",
-                        number = 87,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
-                        jsonName = "packedBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_nested_enum",
-                        number = 88,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
-                        jsonName = "packedNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::packedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_int32",
-                        number = 89,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
-                        jsonName = "unpackedInt32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_int64",
-                        number = 90,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
-                        jsonName = "unpackedInt64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_uint32",
-                        number = 91,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
-                        jsonName = "unpackedUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_uint64",
-                        number = 92,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
-                        jsonName = "unpackedUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sint32",
-                        number = 93,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
-                        jsonName = "unpackedSint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sint64",
-                        number = 94,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
-                        jsonName = "unpackedSint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_fixed32",
-                        number = 95,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
-                        jsonName = "unpackedFixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_fixed64",
-                        number = 96,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
-                        jsonName = "unpackedFixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sfixed32",
-                        number = 97,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
-                        jsonName = "unpackedSfixed32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sfixed64",
-                        number = 98,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
-                        jsonName = "unpackedSfixed64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_float",
-                        number = 99,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
-                        jsonName = "unpackedFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_double",
-                        number = 100,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
-                        jsonName = "unpackedDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_bool",
-                        number = 101,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
-                        jsonName = "unpackedBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_nested_enum",
-                        number = 102,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion)),
-                        jsonName = "unpackedNestedEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::unpackedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_uint32",
-                        number = 111,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofUint32",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_nested_message",
-                        number = 112,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion),
-                        oneofMember = true,
-                        jsonName = "oneofNestedMessage",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_string",
-                        number = 113,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofString",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_bytes",
-                        number = 114,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofBytes",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_bool",
-                        number = 115,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofBool",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_uint64",
-                        number = 116,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofUint64",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_float",
-                        number = 117,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofFloat",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_double",
-                        number = 118,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofDouble",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_enum",
-                        number = 119,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion, hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofEnum",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::oneofEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bool_wrapper",
-                        number = 201,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion),
-                        jsonName = "optionalBoolWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalBoolWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int32_wrapper",
-                        number = 202,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion),
-                        jsonName = "optionalInt32Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int64_wrapper",
-                        number = 203,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion),
-                        jsonName = "optionalInt64Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint32_wrapper",
-                        number = 204,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion),
-                        jsonName = "optionalUint32Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint64_wrapper",
-                        number = 205,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion),
-                        jsonName = "optionalUint64Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_float_wrapper",
-                        number = 206,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion),
-                        jsonName = "optionalFloatWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalFloatWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_double_wrapper",
-                        number = 207,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion),
-                        jsonName = "optionalDoubleWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalDoubleWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string_wrapper",
-                        number = 208,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion),
-                        jsonName = "optionalStringWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalStringWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bytes_wrapper",
-                        number = 209,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion),
-                        jsonName = "optionalBytesWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalBytesWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bool_wrapper",
-                        number = 211,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion)),
-                        jsonName = "repeatedBoolWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBoolWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int32_wrapper",
-                        number = 212,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion)),
-                        jsonName = "repeatedInt32Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int64_wrapper",
-                        number = 213,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion)),
-                        jsonName = "repeatedInt64Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint32_wrapper",
-                        number = 214,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion)),
-                        jsonName = "repeatedUint32Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint64_wrapper",
-                        number = 215,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion)),
-                        jsonName = "repeatedUint64Wrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_float_wrapper",
-                        number = 216,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion)),
-                        jsonName = "repeatedFloatWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFloatWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_double_wrapper",
-                        number = 217,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion)),
-                        jsonName = "repeatedDoubleWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedDoubleWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string_wrapper",
-                        number = 218,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion)),
-                        jsonName = "repeatedStringWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedStringWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bytes_wrapper",
-                        number = 219,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion)),
-                        jsonName = "repeatedBytesWrapper",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBytesWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_duration",
-                        number = 301,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion),
-                        jsonName = "optionalDuration",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalDuration
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_timestamp",
-                        number = 302,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion),
-                        jsonName = "optionalTimestamp",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalTimestamp
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_field_mask",
-                        number = 303,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion),
-                        jsonName = "optionalFieldMask",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalFieldMask
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_struct",
-                        number = 304,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion),
-                        jsonName = "optionalStruct",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalStruct
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_any",
-                        number = 305,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion),
-                        jsonName = "optionalAny",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalAny
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_value",
-                        number = 306,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion),
-                        jsonName = "optionalValue",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::optionalValue
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_duration",
-                        number = 311,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Duration>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion)),
-                        jsonName = "repeatedDuration",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedDuration
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_timestamp",
-                        number = 312,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Timestamp>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion)),
-                        jsonName = "repeatedTimestamp",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedTimestamp
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fieldmask",
-                        number = 313,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.FieldMask>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion)),
-                        jsonName = "repeatedFieldmask",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFieldmask
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_any",
-                        number = 315,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Any>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion)),
-                        jsonName = "repeatedAny",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedAny
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_value",
-                        number = 316,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Value>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion)),
-                        jsonName = "repeatedValue",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedValue
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_list_value",
-                        number = 317,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.ListValue>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.ListValue.Companion)),
-                        jsonName = "repeatedListValue",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedListValue
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_struct",
-                        number = 324,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Struct>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion)),
-                        jsonName = "repeatedStruct",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::repeatedStruct
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "fieldname1",
-                        number = 401,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldname1",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldname1
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_name2",
-                        number = 402,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName2",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName2
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "_field_name3",
-                        number = 403,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName3",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName3
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__name4_",
-                        number = 404,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName4",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::field_name4
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field0name5",
-                        number = 405,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "field0name5",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::field0name5
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_0_name6",
-                        number = 406,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "field0Name6",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::field0Name6
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "fieldName7",
-                        number = 407,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName7",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName7
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FieldName8",
-                        number = 408,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName8",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName8
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_Name9",
-                        number = 409,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName9",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName9
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "Field_Name10",
-                        number = 410,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName10",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName10
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FIELD_NAME11",
-                        number = 411,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FIELDNAME11",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fIELDNAME11
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FIELD_name12",
-                        number = 412,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FIELDName12",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fIELDName12
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "__field_name13",
-                        number = 413,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName13",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::_fieldName13
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "__Field_name14",
-                        number = 414,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName14",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::_FieldName14
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__name15",
-                        number = 415,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName15",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::field_name15
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__Name16",
-                        number = 416,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName16",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::field_Name16
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_name17__",
-                        number = 417,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName17",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName17_
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "Field_name18__",
-                        number = 418,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName18",
-                        value = pbandk.conformance.pb.TestAllTypesProto3::fieldName18_
-                    )
-                )
+                addFields0()
+                addFields1()
             }
         )
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.conformance.pb.TestAllTypesProto3, *>>.addFields0() {
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int32",
+                    number = 1,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "optionalInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int64",
+                    number = 2,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int64(),
+                    jsonName = "optionalInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint32",
+                    number = 3,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt32(),
+                    jsonName = "optionalUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint64",
+                    number = 4,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt64(),
+                    jsonName = "optionalUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sint32",
+                    number = 5,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SInt32(),
+                    jsonName = "optionalSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sint64",
+                    number = 6,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SInt64(),
+                    jsonName = "optionalSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_fixed32",
+                    number = 7,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Fixed32(),
+                    jsonName = "optionalFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_fixed64",
+                    number = 8,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Fixed64(),
+                    jsonName = "optionalFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sfixed32",
+                    number = 9,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SFixed32(),
+                    jsonName = "optionalSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sfixed64",
+                    number = 10,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SFixed64(),
+                    jsonName = "optionalSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_float",
+                    number = 11,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Float(),
+                    jsonName = "optionalFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_double",
+                    number = 12,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Double(),
+                    jsonName = "optionalDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bool",
+                    number = 13,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
+                    jsonName = "optionalBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string",
+                    number = 14,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                    jsonName = "optionalString",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bytes",
+                    number = 15,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bytes(),
+                    jsonName = "optionalBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_nested_message",
+                    number = 18,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion),
+                    jsonName = "optionalNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_foreign_message",
+                    number = 19,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessage.Companion),
+                    jsonName = "optionalForeignMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_nested_enum",
+                    number = 21,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion),
+                    jsonName = "optionalNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_foreign_enum",
+                    number = 22,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnum.Companion),
+                    jsonName = "optionalForeignEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_aliased_enum",
+                    number = 23,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.AliasedEnum.Companion),
+                    jsonName = "optionalAliasedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalAliasedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string_piece",
+                    number = 24,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                    jsonName = "optionalStringPiece",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalStringPiece
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_cord",
+                    number = 25,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                    jsonName = "optionalCord",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalCord
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "recursive_message",
+                    number = 27,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.Companion),
+                    jsonName = "recursiveMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::recursiveMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int32",
+                    number = 31,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
+                    jsonName = "repeatedInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int64",
+                    number = 32,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
+                    jsonName = "repeatedInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint32",
+                    number = 33,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
+                    jsonName = "repeatedUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint64",
+                    number = 34,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
+                    jsonName = "repeatedUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sint32",
+                    number = 35,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
+                    jsonName = "repeatedSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sint64",
+                    number = 36,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
+                    jsonName = "repeatedSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fixed32",
+                    number = 37,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
+                    jsonName = "repeatedFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fixed64",
+                    number = 38,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
+                    jsonName = "repeatedFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sfixed32",
+                    number = 39,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
+                    jsonName = "repeatedSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sfixed64",
+                    number = 40,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
+                    jsonName = "repeatedSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_float",
+                    number = 41,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
+                    jsonName = "repeatedFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_double",
+                    number = 42,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
+                    jsonName = "repeatedDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bool",
+                    number = 43,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
+                    jsonName = "repeatedBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string",
+                    number = 44,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedString",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bytes",
+                    number = 45,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
+                    jsonName = "repeatedBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_nested_message",
+                    number = 48,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion)),
+                    jsonName = "repeatedNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_foreign_message",
+                    number = 49,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessage.Companion)),
+                    jsonName = "repeatedForeignMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_nested_enum",
+                    number = 51,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
+                    jsonName = "repeatedNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_foreign_enum",
+                    number = 52,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.ForeignEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnum.Companion), packed = true),
+                    jsonName = "repeatedForeignEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string_piece",
+                    number = 54,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedStringPiece",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedStringPiece
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_cord",
+                    number = 55,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedCord",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedCord
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_int32",
+                    number = 56,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
+                    jsonName = "mapInt32Int32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapInt32Int32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int64_int64",
+                    number = 57,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
+                    jsonName = "mapInt64Int64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapInt64Int64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_uint32_uint32",
+                    number = 58,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
+                    jsonName = "mapUint32Uint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapUint32Uint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_uint64_uint64",
+                    number = 59,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
+                    jsonName = "mapUint64Uint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapUint64Uint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sint32_sint32",
+                    number = 60,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
+                    jsonName = "mapSint32Sint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapSint32Sint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sint64_sint64",
+                    number = 61,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
+                    jsonName = "mapSint64Sint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapSint64Sint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_fixed32_fixed32",
+                    number = 62,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
+                    jsonName = "mapFixed32Fixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapFixed32Fixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_fixed64_fixed64",
+                    number = 63,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
+                    jsonName = "mapFixed64Fixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapFixed64Fixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sfixed32_sfixed32",
+                    number = 64,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
+                    jsonName = "mapSfixed32Sfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapSfixed32Sfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sfixed64_sfixed64",
+                    number = 65,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
+                    jsonName = "mapSfixed64Sfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapSfixed64Sfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_float",
+                    number = 66,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Float>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
+                    jsonName = "mapInt32Float",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapInt32Float
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_double",
+                    number = 67,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Double>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
+                    jsonName = "mapInt32Double",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapInt32Double
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_bool_bool",
+                    number = 68,
+                    type = pbandk.FieldDescriptor.Type.Map<Boolean, Boolean>(keyType = pbandk.FieldDescriptor.Type.Primitive.Bool(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
+                    jsonName = "mapBoolBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapBoolBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_string",
+                    number = 69,
+                    type = pbandk.FieldDescriptor.Type.Map<String, String>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "mapStringString",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapStringString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_bytes",
+                    number = 70,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.ByteArr>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
+                    jsonName = "mapStringBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapStringBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_nested_message",
+                    number = 71,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.TestAllTypesProto3.NestedMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion)),
+                    jsonName = "mapStringNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapStringNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_foreign_message",
+                    number = 72,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.ForeignMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.ForeignMessage.Companion)),
+                    jsonName = "mapStringForeignMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapStringForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_nested_enum",
+                    number = 73,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion)),
+                    jsonName = "mapStringNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapStringNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_foreign_enum",
+                    number = 74,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.conformance.pb.ForeignEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.ForeignEnum.Companion)),
+                    jsonName = "mapStringForeignEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::mapStringForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_int32",
+                    number = 75,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
+                    jsonName = "packedInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_int64",
+                    number = 76,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
+                    jsonName = "packedInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_uint32",
+                    number = 77,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
+                    jsonName = "packedUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_uint64",
+                    number = 78,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
+                    jsonName = "packedUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sint32",
+                    number = 79,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
+                    jsonName = "packedSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sint64",
+                    number = 80,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
+                    jsonName = "packedSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_fixed32",
+                    number = 81,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
+                    jsonName = "packedFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_fixed64",
+                    number = 82,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
+                    jsonName = "packedFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sfixed32",
+                    number = 83,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
+                    jsonName = "packedSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sfixed64",
+                    number = 84,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
+                    jsonName = "packedSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_float",
+                    number = 85,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
+                    jsonName = "packedFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_double",
+                    number = 86,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
+                    jsonName = "packedDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_bool",
+                    number = 87,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
+                    jsonName = "packedBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_nested_enum",
+                    number = 88,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
+                    jsonName = "packedNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::packedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_int32",
+                    number = 89,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
+                    jsonName = "unpackedInt32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_int64",
+                    number = 90,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
+                    jsonName = "unpackedInt64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_uint32",
+                    number = 91,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
+                    jsonName = "unpackedUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_uint64",
+                    number = 92,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
+                    jsonName = "unpackedUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sint32",
+                    number = 93,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
+                    jsonName = "unpackedSint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sint64",
+                    number = 94,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
+                    jsonName = "unpackedSint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_fixed32",
+                    number = 95,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
+                    jsonName = "unpackedFixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_fixed64",
+                    number = 96,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
+                    jsonName = "unpackedFixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sfixed32",
+                    number = 97,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
+                    jsonName = "unpackedSfixed32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sfixed64",
+                    number = 98,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
+                    jsonName = "unpackedSfixed64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_float",
+                    number = 99,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
+                    jsonName = "unpackedFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_double",
+                    number = 100,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
+                    jsonName = "unpackedDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_bool",
+                    number = 101,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
+                    jsonName = "unpackedBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_nested_enum",
+                    number = 102,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.conformance.pb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion)),
+                    jsonName = "unpackedNestedEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::unpackedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_uint32",
+                    number = 111,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofUint32",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_nested_message",
+                    number = 112,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedMessage.Companion),
+                    oneofMember = true,
+                    jsonName = "oneofNestedMessage",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_string",
+                    number = 113,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofString",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_bytes",
+                    number = 114,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofBytes",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_bool",
+                    number = 115,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofBool",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_uint64",
+                    number = 116,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofUint64",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_float",
+                    number = 117,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofFloat",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_double",
+                    number = 118,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofDouble",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_enum",
+                    number = 119,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.conformance.pb.TestAllTypesProto3.NestedEnum.Companion, hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofEnum",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::oneofEnum
+                )
+            )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.conformance.pb.TestAllTypesProto3, *>>.addFields1() {
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bool_wrapper",
+                    number = 201,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion),
+                    jsonName = "optionalBoolWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalBoolWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int32_wrapper",
+                    number = 202,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion),
+                    jsonName = "optionalInt32Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int64_wrapper",
+                    number = 203,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion),
+                    jsonName = "optionalInt64Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalInt64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint32_wrapper",
+                    number = 204,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion),
+                    jsonName = "optionalUint32Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint64_wrapper",
+                    number = 205,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion),
+                    jsonName = "optionalUint64Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalUint64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_float_wrapper",
+                    number = 206,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion),
+                    jsonName = "optionalFloatWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalFloatWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_double_wrapper",
+                    number = 207,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion),
+                    jsonName = "optionalDoubleWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalDoubleWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string_wrapper",
+                    number = 208,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion),
+                    jsonName = "optionalStringWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalStringWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bytes_wrapper",
+                    number = 209,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion),
+                    jsonName = "optionalBytesWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalBytesWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bool_wrapper",
+                    number = 211,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion)),
+                    jsonName = "repeatedBoolWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBoolWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int32_wrapper",
+                    number = 212,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion)),
+                    jsonName = "repeatedInt32Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int64_wrapper",
+                    number = 213,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion)),
+                    jsonName = "repeatedInt64Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedInt64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint32_wrapper",
+                    number = 214,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion)),
+                    jsonName = "repeatedUint32Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint64_wrapper",
+                    number = 215,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion)),
+                    jsonName = "repeatedUint64Wrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedUint64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_float_wrapper",
+                    number = 216,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion)),
+                    jsonName = "repeatedFloatWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFloatWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_double_wrapper",
+                    number = 217,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion)),
+                    jsonName = "repeatedDoubleWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedDoubleWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string_wrapper",
+                    number = 218,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion)),
+                    jsonName = "repeatedStringWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedStringWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bytes_wrapper",
+                    number = 219,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion)),
+                    jsonName = "repeatedBytesWrapper",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedBytesWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_duration",
+                    number = 301,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion),
+                    jsonName = "optionalDuration",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalDuration
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_timestamp",
+                    number = 302,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion),
+                    jsonName = "optionalTimestamp",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalTimestamp
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_field_mask",
+                    number = 303,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion),
+                    jsonName = "optionalFieldMask",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalFieldMask
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_struct",
+                    number = 304,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion),
+                    jsonName = "optionalStruct",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalStruct
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_any",
+                    number = 305,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion),
+                    jsonName = "optionalAny",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalAny
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_value",
+                    number = 306,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion),
+                    jsonName = "optionalValue",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::optionalValue
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_duration",
+                    number = 311,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Duration>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion)),
+                    jsonName = "repeatedDuration",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedDuration
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_timestamp",
+                    number = 312,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Timestamp>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion)),
+                    jsonName = "repeatedTimestamp",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedTimestamp
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fieldmask",
+                    number = 313,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.FieldMask>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion)),
+                    jsonName = "repeatedFieldmask",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedFieldmask
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_any",
+                    number = 315,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Any>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion)),
+                    jsonName = "repeatedAny",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedAny
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_value",
+                    number = 316,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Value>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion)),
+                    jsonName = "repeatedValue",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedValue
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_list_value",
+                    number = 317,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.ListValue>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.ListValue.Companion)),
+                    jsonName = "repeatedListValue",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedListValue
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_struct",
+                    number = 324,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Struct>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion)),
+                    jsonName = "repeatedStruct",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::repeatedStruct
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "fieldname1",
+                    number = 401,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldname1",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldname1
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_name2",
+                    number = 402,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName2",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName2
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "_field_name3",
+                    number = 403,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName3",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName3
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__name4_",
+                    number = 404,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName4",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::field_name4
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field0name5",
+                    number = 405,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "field0name5",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::field0name5
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_0_name6",
+                    number = 406,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "field0Name6",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::field0Name6
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "fieldName7",
+                    number = 407,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName7",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName7
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FieldName8",
+                    number = 408,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName8",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName8
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_Name9",
+                    number = 409,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName9",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName9
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "Field_Name10",
+                    number = 410,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName10",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName10
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FIELD_NAME11",
+                    number = 411,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FIELDNAME11",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fIELDNAME11
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FIELD_name12",
+                    number = 412,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FIELDName12",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fIELDName12
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "__field_name13",
+                    number = 413,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName13",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::_fieldName13
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "__Field_name14",
+                    number = 414,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName14",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::_FieldName14
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__name15",
+                    number = 415,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName15",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::field_name15
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__Name16",
+                    number = 416,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName16",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::field_Name16
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_name17__",
+                    number = 417,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName17",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName17_
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "Field_name18__",
+                    number = 418,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName18",
+                    value = pbandk.conformance.pb.TestAllTypesProto3::fieldName18_
+                )
+            )
+        }
     }
 
     public sealed class NestedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {

--- a/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
+++ b/protoc-gen-pbandk/lib/src/commonMain/kotlin/pbandk/gen/CodeGenerator.kt
@@ -181,7 +181,7 @@ public open class CodeGenerator(
 
     protected fun writeMessageDescriptor(type: File.Type.Message) {
         val allFields = type.sortedStandardFieldsWithOneOfs()
-        val chunkSize = 200
+        val chunkSize = 100
         val needToChunk = allFields.size > chunkSize
 
         line("override val descriptor: pbandk.MessageDescriptor<${type.kotlinTypeNameWithPackage}> = pbandk.MessageDescriptor(").indented {

--- a/test-types/src/commonMain/kotlin/pbandk/testpb/test_compiler_limits.kt
+++ b/test-types/src/commonMain/kotlin/pbandk/testpb/test_compiler_limits.kt
@@ -2039,6 +2039,11 @@ public data class MessageWithLotsOfFields(
                 addFields2()
                 addFields3()
                 addFields4()
+                addFields5()
+                addFields6()
+                addFields7()
+                addFields8()
+                addFields9()
             }
         )
 
@@ -3043,6 +3048,9 @@ public data class MessageWithLotsOfFields(
                     value = pbandk.testpb.MessageWithLotsOfFields::field1099
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields1() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -4045,7 +4053,7 @@ public data class MessageWithLotsOfFields(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields1() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields2() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -5046,6 +5054,9 @@ public data class MessageWithLotsOfFields(
                     value = pbandk.testpb.MessageWithLotsOfFields::field1299
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields3() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -6048,7 +6059,7 @@ public data class MessageWithLotsOfFields(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields2() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields4() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -7049,6 +7060,9 @@ public data class MessageWithLotsOfFields(
                     value = pbandk.testpb.MessageWithLotsOfFields::field1499
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields5() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -8051,7 +8065,7 @@ public data class MessageWithLotsOfFields(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields3() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields6() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -9052,6 +9066,9 @@ public data class MessageWithLotsOfFields(
                     value = pbandk.testpb.MessageWithLotsOfFields::field1699
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields7() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -10054,7 +10071,7 @@ public data class MessageWithLotsOfFields(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields4() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields8() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -11055,6 +11072,9 @@ public data class MessageWithLotsOfFields(
                     value = pbandk.testpb.MessageWithLotsOfFields::field1899
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithLotsOfFields, *>>.addFields9() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -18090,6 +18110,16 @@ public data class MessageWithHugeOneof(
                 addFields7()
                 addFields8()
                 addFields9()
+                addFields10()
+                addFields11()
+                addFields12()
+                addFields13()
+                addFields14()
+                addFields15()
+                addFields16()
+                addFields17()
+                addFields18()
+                addFields19()
             }
         )
 
@@ -19194,6 +19224,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof1099
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields1() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -20296,7 +20329,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields1() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields2() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -21397,6 +21430,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof1299
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields3() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -22499,7 +22535,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields2() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields4() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -23600,6 +23636,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof1499
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields5() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -24702,7 +24741,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields3() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields6() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -25803,6 +25842,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof1699
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields7() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -26905,7 +26947,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields4() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields8() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -28006,6 +28048,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof1899
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields9() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -29108,7 +29153,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields5() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields10() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -30209,6 +30254,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof2099
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields11() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -31311,7 +31359,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields6() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields12() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -32412,6 +32460,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof2299
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields13() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -33514,7 +33565,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields7() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields14() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -34615,6 +34666,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof2499
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields15() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -35717,7 +35771,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields8() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields16() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -36818,6 +36872,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof2699
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields17() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -37920,7 +37977,7 @@ public data class MessageWithHugeOneof(
             )
         }
 
-        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields9() {
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields18() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,
@@ -39021,6 +39078,9 @@ public data class MessageWithHugeOneof(
                     value = pbandk.testpb.MessageWithHugeOneof::oneof2899
                 )
             )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.MessageWithHugeOneof, *>>.addFields19() {
             add(
                 pbandk.FieldDescriptor(
                     messageDescriptor = this@Companion::descriptor,

--- a/test-types/src/commonMain/kotlin/pbandk/testpb/test_messages_proto3.kt
+++ b/test-types/src/commonMain/kotlin/pbandk/testpb/test_messages_proto3.kt
@@ -208,1507 +208,1515 @@ public data class TestAllTypesProto3(
             messageClass = pbandk.testpb.TestAllTypesProto3::class,
             messageCompanion = this,
             fields = buildList(149) {
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int32",
-                        number = 1,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "optionalInt32",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int64",
-                        number = 2,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int64(),
-                        jsonName = "optionalInt64",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint32",
-                        number = 3,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt32(),
-                        jsonName = "optionalUint32",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint64",
-                        number = 4,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt64(),
-                        jsonName = "optionalUint64",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sint32",
-                        number = 5,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SInt32(),
-                        jsonName = "optionalSint32",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sint64",
-                        number = 6,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SInt64(),
-                        jsonName = "optionalSint64",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_fixed32",
-                        number = 7,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Fixed32(),
-                        jsonName = "optionalFixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_fixed64",
-                        number = 8,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Fixed64(),
-                        jsonName = "optionalFixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sfixed32",
-                        number = 9,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SFixed32(),
-                        jsonName = "optionalSfixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_sfixed64",
-                        number = 10,
-                        type = pbandk.FieldDescriptor.Type.Primitive.SFixed64(),
-                        jsonName = "optionalSfixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_float",
-                        number = 11,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Float(),
-                        jsonName = "optionalFloat",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_double",
-                        number = 12,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(),
-                        jsonName = "optionalDouble",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bool",
-                        number = 13,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
-                        jsonName = "optionalBool",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string",
-                        number = 14,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "optionalString",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bytes",
-                        number = 15,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(),
-                        jsonName = "optionalBytes",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_nested_message",
-                        number = 18,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion),
-                        jsonName = "optionalNestedMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_foreign_message",
-                        number = 19,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.ForeignMessage.Companion),
-                        jsonName = "optionalForeignMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_nested_enum",
-                        number = 21,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion),
-                        jsonName = "optionalNestedEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_foreign_enum",
-                        number = 22,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.ForeignEnum.Companion),
-                        jsonName = "optionalForeignEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_aliased_enum",
-                        number = 23,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.AliasedEnum.Companion),
-                        jsonName = "optionalAliasedEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalAliasedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string_piece",
-                        number = 24,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "optionalStringPiece",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalStringPiece
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_cord",
-                        number = 25,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(),
-                        jsonName = "optionalCord",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalCord
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "recursive_message",
-                        number = 27,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.Companion),
-                        jsonName = "recursiveMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::recursiveMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int32",
-                        number = 31,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
-                        jsonName = "repeatedInt32",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int64",
-                        number = 32,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
-                        jsonName = "repeatedInt64",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint32",
-                        number = 33,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "repeatedUint32",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint64",
-                        number = 34,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
-                        jsonName = "repeatedUint64",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sint32",
-                        number = 35,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
-                        jsonName = "repeatedSint32",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sint64",
-                        number = 36,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
-                        jsonName = "repeatedSint64",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fixed32",
-                        number = 37,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
-                        jsonName = "repeatedFixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fixed64",
-                        number = 38,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
-                        jsonName = "repeatedFixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sfixed32",
-                        number = 39,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
-                        jsonName = "repeatedSfixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_sfixed64",
-                        number = 40,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
-                        jsonName = "repeatedSfixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_float",
-                        number = 41,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
-                        jsonName = "repeatedFloat",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_double",
-                        number = 42,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
-                        jsonName = "repeatedDouble",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bool",
-                        number = 43,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
-                        jsonName = "repeatedBool",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string",
-                        number = 44,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedString",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bytes",
-                        number = 45,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
-                        jsonName = "repeatedBytes",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_nested_message",
-                        number = 48,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion)),
-                        jsonName = "repeatedNestedMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_foreign_message",
-                        number = 49,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.ForeignMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.ForeignMessage.Companion)),
-                        jsonName = "repeatedForeignMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_nested_enum",
-                        number = 51,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
-                        jsonName = "repeatedNestedEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_foreign_enum",
-                        number = 52,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.ForeignEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.ForeignEnum.Companion), packed = true),
-                        jsonName = "repeatedForeignEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string_piece",
-                        number = 54,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedStringPiece",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedStringPiece
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_cord",
-                        number = 55,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "repeatedCord",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedCord
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_int32",
-                        number = 56,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
-                        jsonName = "mapInt32Int32",
-                        value = pbandk.testpb.TestAllTypesProto3::mapInt32Int32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int64_int64",
-                        number = 57,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
-                        jsonName = "mapInt64Int64",
-                        value = pbandk.testpb.TestAllTypesProto3::mapInt64Int64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_uint32_uint32",
-                        number = 58,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
-                        jsonName = "mapUint32Uint32",
-                        value = pbandk.testpb.TestAllTypesProto3::mapUint32Uint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_uint64_uint64",
-                        number = 59,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
-                        jsonName = "mapUint64Uint64",
-                        value = pbandk.testpb.TestAllTypesProto3::mapUint64Uint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sint32_sint32",
-                        number = 60,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
-                        jsonName = "mapSint32Sint32",
-                        value = pbandk.testpb.TestAllTypesProto3::mapSint32Sint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sint64_sint64",
-                        number = 61,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
-                        jsonName = "mapSint64Sint64",
-                        value = pbandk.testpb.TestAllTypesProto3::mapSint64Sint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_fixed32_fixed32",
-                        number = 62,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
-                        jsonName = "mapFixed32Fixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::mapFixed32Fixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_fixed64_fixed64",
-                        number = 63,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
-                        jsonName = "mapFixed64Fixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::mapFixed64Fixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sfixed32_sfixed32",
-                        number = 64,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
-                        jsonName = "mapSfixed32Sfixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::mapSfixed32Sfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_sfixed64_sfixed64",
-                        number = 65,
-                        type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
-                        jsonName = "mapSfixed64Sfixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::mapSfixed64Sfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_float",
-                        number = 66,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Float>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
-                        jsonName = "mapInt32Float",
-                        value = pbandk.testpb.TestAllTypesProto3::mapInt32Float
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_int32_double",
-                        number = 67,
-                        type = pbandk.FieldDescriptor.Type.Map<Int, Double>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
-                        jsonName = "mapInt32Double",
-                        value = pbandk.testpb.TestAllTypesProto3::mapInt32Double
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_bool_bool",
-                        number = 68,
-                        type = pbandk.FieldDescriptor.Type.Map<Boolean, Boolean>(keyType = pbandk.FieldDescriptor.Type.Primitive.Bool(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
-                        jsonName = "mapBoolBool",
-                        value = pbandk.testpb.TestAllTypesProto3::mapBoolBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_string",
-                        number = 69,
-                        type = pbandk.FieldDescriptor.Type.Map<String, String>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
-                        jsonName = "mapStringString",
-                        value = pbandk.testpb.TestAllTypesProto3::mapStringString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_bytes",
-                        number = 70,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.ByteArr>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
-                        jsonName = "mapStringBytes",
-                        value = pbandk.testpb.TestAllTypesProto3::mapStringBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_nested_message",
-                        number = 71,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.TestAllTypesProto3.NestedMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion)),
-                        jsonName = "mapStringNestedMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::mapStringNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_foreign_message",
-                        number = 72,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.ForeignMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.ForeignMessage.Companion)),
-                        jsonName = "mapStringForeignMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::mapStringForeignMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_nested_enum",
-                        number = 73,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.TestAllTypesProto3.NestedEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion)),
-                        jsonName = "mapStringNestedEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::mapStringNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "map_string_foreign_enum",
-                        number = 74,
-                        type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.ForeignEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.ForeignEnum.Companion)),
-                        jsonName = "mapStringForeignEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::mapStringForeignEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_int32",
-                        number = 75,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
-                        jsonName = "packedInt32",
-                        value = pbandk.testpb.TestAllTypesProto3::packedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_int64",
-                        number = 76,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
-                        jsonName = "packedInt64",
-                        value = pbandk.testpb.TestAllTypesProto3::packedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_uint32",
-                        number = 77,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
-                        jsonName = "packedUint32",
-                        value = pbandk.testpb.TestAllTypesProto3::packedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_uint64",
-                        number = 78,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
-                        jsonName = "packedUint64",
-                        value = pbandk.testpb.TestAllTypesProto3::packedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sint32",
-                        number = 79,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
-                        jsonName = "packedSint32",
-                        value = pbandk.testpb.TestAllTypesProto3::packedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sint64",
-                        number = 80,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
-                        jsonName = "packedSint64",
-                        value = pbandk.testpb.TestAllTypesProto3::packedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_fixed32",
-                        number = 81,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
-                        jsonName = "packedFixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::packedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_fixed64",
-                        number = 82,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
-                        jsonName = "packedFixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::packedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sfixed32",
-                        number = 83,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
-                        jsonName = "packedSfixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::packedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_sfixed64",
-                        number = 84,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
-                        jsonName = "packedSfixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::packedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_float",
-                        number = 85,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
-                        jsonName = "packedFloat",
-                        value = pbandk.testpb.TestAllTypesProto3::packedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_double",
-                        number = 86,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
-                        jsonName = "packedDouble",
-                        value = pbandk.testpb.TestAllTypesProto3::packedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_bool",
-                        number = 87,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
-                        jsonName = "packedBool",
-                        value = pbandk.testpb.TestAllTypesProto3::packedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "packed_nested_enum",
-                        number = 88,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
-                        jsonName = "packedNestedEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::packedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_int32",
-                        number = 89,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
-                        jsonName = "unpackedInt32",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedInt32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_int64",
-                        number = 90,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
-                        jsonName = "unpackedInt64",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedInt64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_uint32",
-                        number = 91,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
-                        jsonName = "unpackedUint32",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_uint64",
-                        number = 92,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
-                        jsonName = "unpackedUint64",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sint32",
-                        number = 93,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
-                        jsonName = "unpackedSint32",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedSint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sint64",
-                        number = 94,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
-                        jsonName = "unpackedSint64",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedSint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_fixed32",
-                        number = 95,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
-                        jsonName = "unpackedFixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedFixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_fixed64",
-                        number = 96,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
-                        jsonName = "unpackedFixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedFixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sfixed32",
-                        number = 97,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
-                        jsonName = "unpackedSfixed32",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedSfixed32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_sfixed64",
-                        number = 98,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
-                        jsonName = "unpackedSfixed64",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedSfixed64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_float",
-                        number = 99,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
-                        jsonName = "unpackedFloat",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_double",
-                        number = 100,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
-                        jsonName = "unpackedDouble",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_bool",
-                        number = 101,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
-                        jsonName = "unpackedBool",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "unpacked_nested_enum",
-                        number = 102,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion)),
-                        jsonName = "unpackedNestedEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::unpackedNestedEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_uint32",
-                        number = 111,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofUint32",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofUint32
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_nested_message",
-                        number = 112,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion),
-                        oneofMember = true,
-                        jsonName = "oneofNestedMessage",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofNestedMessage
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_string",
-                        number = 113,
-                        type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofString",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofString
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_bytes",
-                        number = 114,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofBytes",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofBytes
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_bool",
-                        number = 115,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofBool",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofBool
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_uint64",
-                        number = 116,
-                        type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofUint64",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofUint64
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_float",
-                        number = 117,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofFloat",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofFloat
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_double",
-                        number = 118,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofDouble",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofDouble
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "oneof_enum",
-                        number = 119,
-                        type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion, hasPresence = true),
-                        oneofMember = true,
-                        jsonName = "oneofEnum",
-                        value = pbandk.testpb.TestAllTypesProto3::oneofEnum
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bool_wrapper",
-                        number = 201,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion),
-                        jsonName = "optionalBoolWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalBoolWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int32_wrapper",
-                        number = 202,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion),
-                        jsonName = "optionalInt32Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalInt32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_int64_wrapper",
-                        number = 203,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion),
-                        jsonName = "optionalInt64Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalInt64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint32_wrapper",
-                        number = 204,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion),
-                        jsonName = "optionalUint32Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalUint32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_uint64_wrapper",
-                        number = 205,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion),
-                        jsonName = "optionalUint64Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalUint64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_float_wrapper",
-                        number = 206,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion),
-                        jsonName = "optionalFloatWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalFloatWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_double_wrapper",
-                        number = 207,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion),
-                        jsonName = "optionalDoubleWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalDoubleWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_string_wrapper",
-                        number = 208,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion),
-                        jsonName = "optionalStringWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalStringWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_bytes_wrapper",
-                        number = 209,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion),
-                        jsonName = "optionalBytesWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalBytesWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bool_wrapper",
-                        number = 211,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion)),
-                        jsonName = "repeatedBoolWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedBoolWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int32_wrapper",
-                        number = 212,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion)),
-                        jsonName = "repeatedInt32Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedInt32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_int64_wrapper",
-                        number = 213,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion)),
-                        jsonName = "repeatedInt64Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedInt64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint32_wrapper",
-                        number = 214,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion)),
-                        jsonName = "repeatedUint32Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedUint32Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_uint64_wrapper",
-                        number = 215,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion)),
-                        jsonName = "repeatedUint64Wrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedUint64Wrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_float_wrapper",
-                        number = 216,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion)),
-                        jsonName = "repeatedFloatWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedFloatWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_double_wrapper",
-                        number = 217,
-                        type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion)),
-                        jsonName = "repeatedDoubleWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedDoubleWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_string_wrapper",
-                        number = 218,
-                        type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion)),
-                        jsonName = "repeatedStringWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedStringWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_bytes_wrapper",
-                        number = 219,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion)),
-                        jsonName = "repeatedBytesWrapper",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedBytesWrapper
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_duration",
-                        number = 301,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion),
-                        jsonName = "optionalDuration",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalDuration
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_timestamp",
-                        number = 302,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion),
-                        jsonName = "optionalTimestamp",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalTimestamp
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_field_mask",
-                        number = 303,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion),
-                        jsonName = "optionalFieldMask",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalFieldMask
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_struct",
-                        number = 304,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion),
-                        jsonName = "optionalStruct",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalStruct
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_any",
-                        number = 305,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion),
-                        jsonName = "optionalAny",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalAny
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "optional_value",
-                        number = 306,
-                        type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion),
-                        jsonName = "optionalValue",
-                        value = pbandk.testpb.TestAllTypesProto3::optionalValue
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_duration",
-                        number = 311,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Duration>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion)),
-                        jsonName = "repeatedDuration",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedDuration
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_timestamp",
-                        number = 312,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Timestamp>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion)),
-                        jsonName = "repeatedTimestamp",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedTimestamp
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_fieldmask",
-                        number = 313,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.FieldMask>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion)),
-                        jsonName = "repeatedFieldmask",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedFieldmask
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_any",
-                        number = 315,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Any>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion)),
-                        jsonName = "repeatedAny",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedAny
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_value",
-                        number = 316,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Value>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion)),
-                        jsonName = "repeatedValue",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedValue
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_list_value",
-                        number = 317,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.ListValue>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.ListValue.Companion)),
-                        jsonName = "repeatedListValue",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedListValue
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "repeated_struct",
-                        number = 324,
-                        type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Struct>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion)),
-                        jsonName = "repeatedStruct",
-                        value = pbandk.testpb.TestAllTypesProto3::repeatedStruct
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "fieldname1",
-                        number = 401,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldname1",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldname1
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_name2",
-                        number = 402,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName2",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName2
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "_field_name3",
-                        number = 403,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName3",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName3
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__name4_",
-                        number = 404,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName4",
-                        value = pbandk.testpb.TestAllTypesProto3::field_name4
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field0name5",
-                        number = 405,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "field0name5",
-                        value = pbandk.testpb.TestAllTypesProto3::field0name5
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_0_name6",
-                        number = 406,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "field0Name6",
-                        value = pbandk.testpb.TestAllTypesProto3::field0Name6
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "fieldName7",
-                        number = 407,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName7",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName7
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FieldName8",
-                        number = 408,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName8",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName8
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_Name9",
-                        number = 409,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName9",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName9
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "Field_Name10",
-                        number = 410,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName10",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName10
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FIELD_NAME11",
-                        number = 411,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FIELDNAME11",
-                        value = pbandk.testpb.TestAllTypesProto3::fIELDNAME11
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "FIELD_name12",
-                        number = 412,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FIELDName12",
-                        value = pbandk.testpb.TestAllTypesProto3::fIELDName12
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "__field_name13",
-                        number = 413,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName13",
-                        value = pbandk.testpb.TestAllTypesProto3::_fieldName13
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "__Field_name14",
-                        number = 414,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName14",
-                        value = pbandk.testpb.TestAllTypesProto3::_FieldName14
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__name15",
-                        number = 415,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName15",
-                        value = pbandk.testpb.TestAllTypesProto3::field_name15
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field__Name16",
-                        number = 416,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName16",
-                        value = pbandk.testpb.TestAllTypesProto3::field_Name16
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "field_name17__",
-                        number = 417,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "fieldName17",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName17_
-                    )
-                )
-                add(
-                    pbandk.FieldDescriptor(
-                        messageDescriptor = this@Companion::descriptor,
-                        name = "Field_name18__",
-                        number = 418,
-                        type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
-                        jsonName = "FieldName18",
-                        value = pbandk.testpb.TestAllTypesProto3::fieldName18_
-                    )
-                )
+                addFields0()
+                addFields1()
             }
         )
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.TestAllTypesProto3, *>>.addFields0() {
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int32",
+                    number = 1,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "optionalInt32",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int64",
+                    number = 2,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int64(),
+                    jsonName = "optionalInt64",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint32",
+                    number = 3,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt32(),
+                    jsonName = "optionalUint32",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint64",
+                    number = 4,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt64(),
+                    jsonName = "optionalUint64",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sint32",
+                    number = 5,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SInt32(),
+                    jsonName = "optionalSint32",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sint64",
+                    number = 6,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SInt64(),
+                    jsonName = "optionalSint64",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_fixed32",
+                    number = 7,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Fixed32(),
+                    jsonName = "optionalFixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_fixed64",
+                    number = 8,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Fixed64(),
+                    jsonName = "optionalFixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sfixed32",
+                    number = 9,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SFixed32(),
+                    jsonName = "optionalSfixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_sfixed64",
+                    number = 10,
+                    type = pbandk.FieldDescriptor.Type.Primitive.SFixed64(),
+                    jsonName = "optionalSfixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_float",
+                    number = 11,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Float(),
+                    jsonName = "optionalFloat",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_double",
+                    number = 12,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Double(),
+                    jsonName = "optionalDouble",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bool",
+                    number = 13,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bool(),
+                    jsonName = "optionalBool",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string",
+                    number = 14,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                    jsonName = "optionalString",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bytes",
+                    number = 15,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bytes(),
+                    jsonName = "optionalBytes",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_nested_message",
+                    number = 18,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion),
+                    jsonName = "optionalNestedMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_foreign_message",
+                    number = 19,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.ForeignMessage.Companion),
+                    jsonName = "optionalForeignMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_nested_enum",
+                    number = 21,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion),
+                    jsonName = "optionalNestedEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_foreign_enum",
+                    number = 22,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.ForeignEnum.Companion),
+                    jsonName = "optionalForeignEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_aliased_enum",
+                    number = 23,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.AliasedEnum.Companion),
+                    jsonName = "optionalAliasedEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalAliasedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string_piece",
+                    number = 24,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                    jsonName = "optionalStringPiece",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalStringPiece
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_cord",
+                    number = 25,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(),
+                    jsonName = "optionalCord",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalCord
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "recursive_message",
+                    number = 27,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.Companion),
+                    jsonName = "recursiveMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::recursiveMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int32",
+                    number = 31,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
+                    jsonName = "repeatedInt32",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int64",
+                    number = 32,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
+                    jsonName = "repeatedInt64",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint32",
+                    number = 33,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
+                    jsonName = "repeatedUint32",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint64",
+                    number = 34,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
+                    jsonName = "repeatedUint64",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sint32",
+                    number = 35,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
+                    jsonName = "repeatedSint32",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sint64",
+                    number = 36,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
+                    jsonName = "repeatedSint64",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fixed32",
+                    number = 37,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
+                    jsonName = "repeatedFixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fixed64",
+                    number = 38,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
+                    jsonName = "repeatedFixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sfixed32",
+                    number = 39,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
+                    jsonName = "repeatedSfixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_sfixed64",
+                    number = 40,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
+                    jsonName = "repeatedSfixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_float",
+                    number = 41,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
+                    jsonName = "repeatedFloat",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_double",
+                    number = 42,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
+                    jsonName = "repeatedDouble",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bool",
+                    number = 43,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
+                    jsonName = "repeatedBool",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string",
+                    number = 44,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedString",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bytes",
+                    number = 45,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
+                    jsonName = "repeatedBytes",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_nested_message",
+                    number = 48,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion)),
+                    jsonName = "repeatedNestedMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_foreign_message",
+                    number = 49,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.ForeignMessage>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.ForeignMessage.Companion)),
+                    jsonName = "repeatedForeignMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_nested_enum",
+                    number = 51,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
+                    jsonName = "repeatedNestedEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_foreign_enum",
+                    number = 52,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.ForeignEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.ForeignEnum.Companion), packed = true),
+                    jsonName = "repeatedForeignEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string_piece",
+                    number = 54,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedStringPiece",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedStringPiece
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_cord",
+                    number = 55,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "repeatedCord",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedCord
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_int32",
+                    number = 56,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
+                    jsonName = "mapInt32Int32",
+                    value = pbandk.testpb.TestAllTypesProto3::mapInt32Int32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int64_int64",
+                    number = 57,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
+                    jsonName = "mapInt64Int64",
+                    value = pbandk.testpb.TestAllTypesProto3::mapInt64Int64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_uint32_uint32",
+                    number = 58,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
+                    jsonName = "mapUint32Uint32",
+                    value = pbandk.testpb.TestAllTypesProto3::mapUint32Uint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_uint64_uint64",
+                    number = 59,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
+                    jsonName = "mapUint64Uint64",
+                    value = pbandk.testpb.TestAllTypesProto3::mapUint64Uint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sint32_sint32",
+                    number = 60,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
+                    jsonName = "mapSint32Sint32",
+                    value = pbandk.testpb.TestAllTypesProto3::mapSint32Sint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sint64_sint64",
+                    number = 61,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
+                    jsonName = "mapSint64Sint64",
+                    value = pbandk.testpb.TestAllTypesProto3::mapSint64Sint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_fixed32_fixed32",
+                    number = 62,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
+                    jsonName = "mapFixed32Fixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::mapFixed32Fixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_fixed64_fixed64",
+                    number = 63,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
+                    jsonName = "mapFixed64Fixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::mapFixed64Fixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sfixed32_sfixed32",
+                    number = 64,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Int>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
+                    jsonName = "mapSfixed32Sfixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::mapSfixed32Sfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_sfixed64_sfixed64",
+                    number = 65,
+                    type = pbandk.FieldDescriptor.Type.Map<Long, Long>(keyType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
+                    jsonName = "mapSfixed64Sfixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::mapSfixed64Sfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_float",
+                    number = 66,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Float>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
+                    jsonName = "mapInt32Float",
+                    value = pbandk.testpb.TestAllTypesProto3::mapInt32Float
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_int32_double",
+                    number = 67,
+                    type = pbandk.FieldDescriptor.Type.Map<Int, Double>(keyType = pbandk.FieldDescriptor.Type.Primitive.Int32(), valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
+                    jsonName = "mapInt32Double",
+                    value = pbandk.testpb.TestAllTypesProto3::mapInt32Double
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_bool_bool",
+                    number = 68,
+                    type = pbandk.FieldDescriptor.Type.Map<Boolean, Boolean>(keyType = pbandk.FieldDescriptor.Type.Primitive.Bool(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
+                    jsonName = "mapBoolBool",
+                    value = pbandk.testpb.TestAllTypesProto3::mapBoolBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_string",
+                    number = 69,
+                    type = pbandk.FieldDescriptor.Type.Map<String, String>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.String()),
+                    jsonName = "mapStringString",
+                    value = pbandk.testpb.TestAllTypesProto3::mapStringString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_bytes",
+                    number = 70,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.ByteArr>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Primitive.Bytes()),
+                    jsonName = "mapStringBytes",
+                    value = pbandk.testpb.TestAllTypesProto3::mapStringBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_nested_message",
+                    number = 71,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.TestAllTypesProto3.NestedMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion)),
+                    jsonName = "mapStringNestedMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::mapStringNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_foreign_message",
+                    number = 72,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.ForeignMessage?>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.ForeignMessage.Companion)),
+                    jsonName = "mapStringForeignMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::mapStringForeignMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_nested_enum",
+                    number = 73,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.TestAllTypesProto3.NestedEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion)),
+                    jsonName = "mapStringNestedEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::mapStringNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "map_string_foreign_enum",
+                    number = 74,
+                    type = pbandk.FieldDescriptor.Type.Map<String, pbandk.testpb.ForeignEnum>(keyType = pbandk.FieldDescriptor.Type.Primitive.String(), valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.ForeignEnum.Companion)),
+                    jsonName = "mapStringForeignEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::mapStringForeignEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_int32",
+                    number = 75,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32(), packed = true),
+                    jsonName = "packedInt32",
+                    value = pbandk.testpb.TestAllTypesProto3::packedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_int64",
+                    number = 76,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64(), packed = true),
+                    jsonName = "packedInt64",
+                    value = pbandk.testpb.TestAllTypesProto3::packedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_uint32",
+                    number = 77,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32(), packed = true),
+                    jsonName = "packedUint32",
+                    value = pbandk.testpb.TestAllTypesProto3::packedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_uint64",
+                    number = 78,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64(), packed = true),
+                    jsonName = "packedUint64",
+                    value = pbandk.testpb.TestAllTypesProto3::packedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sint32",
+                    number = 79,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32(), packed = true),
+                    jsonName = "packedSint32",
+                    value = pbandk.testpb.TestAllTypesProto3::packedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sint64",
+                    number = 80,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64(), packed = true),
+                    jsonName = "packedSint64",
+                    value = pbandk.testpb.TestAllTypesProto3::packedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_fixed32",
+                    number = 81,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32(), packed = true),
+                    jsonName = "packedFixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::packedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_fixed64",
+                    number = 82,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64(), packed = true),
+                    jsonName = "packedFixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::packedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sfixed32",
+                    number = 83,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32(), packed = true),
+                    jsonName = "packedSfixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::packedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_sfixed64",
+                    number = 84,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64(), packed = true),
+                    jsonName = "packedSfixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::packedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_float",
+                    number = 85,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float(), packed = true),
+                    jsonName = "packedFloat",
+                    value = pbandk.testpb.TestAllTypesProto3::packedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_double",
+                    number = 86,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double(), packed = true),
+                    jsonName = "packedDouble",
+                    value = pbandk.testpb.TestAllTypesProto3::packedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_bool",
+                    number = 87,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool(), packed = true),
+                    jsonName = "packedBool",
+                    value = pbandk.testpb.TestAllTypesProto3::packedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "packed_nested_enum",
+                    number = 88,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion), packed = true),
+                    jsonName = "packedNestedEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::packedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_int32",
+                    number = 89,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int32()),
+                    jsonName = "unpackedInt32",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedInt32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_int64",
+                    number = 90,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Int64()),
+                    jsonName = "unpackedInt64",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedInt64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_uint32",
+                    number = 91,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt32()),
+                    jsonName = "unpackedUint32",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_uint64",
+                    number = 92,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.UInt64()),
+                    jsonName = "unpackedUint64",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sint32",
+                    number = 93,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt32()),
+                    jsonName = "unpackedSint32",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedSint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sint64",
+                    number = 94,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SInt64()),
+                    jsonName = "unpackedSint64",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedSint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_fixed32",
+                    number = 95,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed32()),
+                    jsonName = "unpackedFixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedFixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_fixed64",
+                    number = 96,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.Fixed64()),
+                    jsonName = "unpackedFixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedFixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sfixed32",
+                    number = 97,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed32()),
+                    jsonName = "unpackedSfixed32",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedSfixed32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_sfixed64",
+                    number = 98,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Primitive.SFixed64()),
+                    jsonName = "unpackedSfixed64",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedSfixed64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_float",
+                    number = 99,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Primitive.Float()),
+                    jsonName = "unpackedFloat",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_double",
+                    number = 100,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Primitive.Double()),
+                    jsonName = "unpackedDouble",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_bool",
+                    number = 101,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Primitive.Bool()),
+                    jsonName = "unpackedBool",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "unpacked_nested_enum",
+                    number = 102,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.testpb.TestAllTypesProto3.NestedEnum>(valueType = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion)),
+                    jsonName = "unpackedNestedEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::unpackedNestedEnum
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_uint32",
+                    number = 111,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt32(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofUint32",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofUint32
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_nested_message",
+                    number = 112,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.testpb.TestAllTypesProto3.NestedMessage.Companion),
+                    oneofMember = true,
+                    jsonName = "oneofNestedMessage",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofNestedMessage
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_string",
+                    number = 113,
+                    type = pbandk.FieldDescriptor.Type.Primitive.String(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofString",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofString
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_bytes",
+                    number = 114,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bytes(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofBytes",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofBytes
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_bool",
+                    number = 115,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Bool(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofBool",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofBool
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_uint64",
+                    number = 116,
+                    type = pbandk.FieldDescriptor.Type.Primitive.UInt64(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofUint64",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofUint64
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_float",
+                    number = 117,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Float(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofFloat",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofFloat
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_double",
+                    number = 118,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Double(hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofDouble",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofDouble
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "oneof_enum",
+                    number = 119,
+                    type = pbandk.FieldDescriptor.Type.Enum(enumCompanion = pbandk.testpb.TestAllTypesProto3.NestedEnum.Companion, hasPresence = true),
+                    oneofMember = true,
+                    jsonName = "oneofEnum",
+                    value = pbandk.testpb.TestAllTypesProto3::oneofEnum
+                )
+            )
+        }
+
+        private fun MutableList<pbandk.FieldDescriptor<pbandk.testpb.TestAllTypesProto3, *>>.addFields1() {
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bool_wrapper",
+                    number = 201,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion),
+                    jsonName = "optionalBoolWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalBoolWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int32_wrapper",
+                    number = 202,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion),
+                    jsonName = "optionalInt32Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalInt32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_int64_wrapper",
+                    number = 203,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion),
+                    jsonName = "optionalInt64Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalInt64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint32_wrapper",
+                    number = 204,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion),
+                    jsonName = "optionalUint32Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalUint32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_uint64_wrapper",
+                    number = 205,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion),
+                    jsonName = "optionalUint64Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalUint64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_float_wrapper",
+                    number = 206,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion),
+                    jsonName = "optionalFloatWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalFloatWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_double_wrapper",
+                    number = 207,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion),
+                    jsonName = "optionalDoubleWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalDoubleWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_string_wrapper",
+                    number = 208,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion),
+                    jsonName = "optionalStringWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalStringWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_bytes_wrapper",
+                    number = 209,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion),
+                    jsonName = "optionalBytesWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalBytesWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bool_wrapper",
+                    number = 211,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Boolean>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BoolValue.Companion)),
+                    jsonName = "repeatedBoolWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedBoolWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int32_wrapper",
+                    number = 212,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int32Value.Companion)),
+                    jsonName = "repeatedInt32Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedInt32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_int64_wrapper",
+                    number = 213,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Int64Value.Companion)),
+                    jsonName = "repeatedInt64Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedInt64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint32_wrapper",
+                    number = 214,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Int>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt32Value.Companion)),
+                    jsonName = "repeatedUint32Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedUint32Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_uint64_wrapper",
+                    number = 215,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Long>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.UInt64Value.Companion)),
+                    jsonName = "repeatedUint64Wrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedUint64Wrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_float_wrapper",
+                    number = 216,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Float>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FloatValue.Companion)),
+                    jsonName = "repeatedFloatWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedFloatWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_double_wrapper",
+                    number = 217,
+                    type = pbandk.FieldDescriptor.Type.Repeated<Double>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.DoubleValue.Companion)),
+                    jsonName = "repeatedDoubleWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedDoubleWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_string_wrapper",
+                    number = 218,
+                    type = pbandk.FieldDescriptor.Type.Repeated<String>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.StringValue.Companion)),
+                    jsonName = "repeatedStringWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedStringWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_bytes_wrapper",
+                    number = 219,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.ByteArr>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.BytesValue.Companion)),
+                    jsonName = "repeatedBytesWrapper",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedBytesWrapper
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_duration",
+                    number = 301,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion),
+                    jsonName = "optionalDuration",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalDuration
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_timestamp",
+                    number = 302,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion),
+                    jsonName = "optionalTimestamp",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalTimestamp
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_field_mask",
+                    number = 303,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion),
+                    jsonName = "optionalFieldMask",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalFieldMask
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_struct",
+                    number = 304,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion),
+                    jsonName = "optionalStruct",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalStruct
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_any",
+                    number = 305,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion),
+                    jsonName = "optionalAny",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalAny
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "optional_value",
+                    number = 306,
+                    type = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion),
+                    jsonName = "optionalValue",
+                    value = pbandk.testpb.TestAllTypesProto3::optionalValue
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_duration",
+                    number = 311,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Duration>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Duration.Companion)),
+                    jsonName = "repeatedDuration",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedDuration
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_timestamp",
+                    number = 312,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Timestamp>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Timestamp.Companion)),
+                    jsonName = "repeatedTimestamp",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedTimestamp
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_fieldmask",
+                    number = 313,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.FieldMask>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.FieldMask.Companion)),
+                    jsonName = "repeatedFieldmask",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedFieldmask
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_any",
+                    number = 315,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Any>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Any.Companion)),
+                    jsonName = "repeatedAny",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedAny
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_value",
+                    number = 316,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Value>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Value.Companion)),
+                    jsonName = "repeatedValue",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedValue
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_list_value",
+                    number = 317,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.ListValue>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.ListValue.Companion)),
+                    jsonName = "repeatedListValue",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedListValue
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "repeated_struct",
+                    number = 324,
+                    type = pbandk.FieldDescriptor.Type.Repeated<pbandk.wkt.Struct>(valueType = pbandk.FieldDescriptor.Type.Message(messageCompanion = pbandk.wkt.Struct.Companion)),
+                    jsonName = "repeatedStruct",
+                    value = pbandk.testpb.TestAllTypesProto3::repeatedStruct
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "fieldname1",
+                    number = 401,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldname1",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldname1
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_name2",
+                    number = 402,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName2",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName2
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "_field_name3",
+                    number = 403,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName3",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName3
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__name4_",
+                    number = 404,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName4",
+                    value = pbandk.testpb.TestAllTypesProto3::field_name4
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field0name5",
+                    number = 405,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "field0name5",
+                    value = pbandk.testpb.TestAllTypesProto3::field0name5
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_0_name6",
+                    number = 406,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "field0Name6",
+                    value = pbandk.testpb.TestAllTypesProto3::field0Name6
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "fieldName7",
+                    number = 407,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName7",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName7
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FieldName8",
+                    number = 408,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName8",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName8
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_Name9",
+                    number = 409,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName9",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName9
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "Field_Name10",
+                    number = 410,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName10",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName10
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FIELD_NAME11",
+                    number = 411,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FIELDNAME11",
+                    value = pbandk.testpb.TestAllTypesProto3::fIELDNAME11
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "FIELD_name12",
+                    number = 412,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FIELDName12",
+                    value = pbandk.testpb.TestAllTypesProto3::fIELDName12
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "__field_name13",
+                    number = 413,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName13",
+                    value = pbandk.testpb.TestAllTypesProto3::_fieldName13
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "__Field_name14",
+                    number = 414,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName14",
+                    value = pbandk.testpb.TestAllTypesProto3::_FieldName14
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__name15",
+                    number = 415,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName15",
+                    value = pbandk.testpb.TestAllTypesProto3::field_name15
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field__Name16",
+                    number = 416,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName16",
+                    value = pbandk.testpb.TestAllTypesProto3::field_Name16
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "field_name17__",
+                    number = 417,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "fieldName17",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName17_
+                )
+            )
+            add(
+                pbandk.FieldDescriptor(
+                    messageDescriptor = this@Companion::descriptor,
+                    name = "Field_name18__",
+                    number = 418,
+                    type = pbandk.FieldDescriptor.Type.Primitive.Int32(),
+                    jsonName = "FieldName18",
+                    value = pbandk.testpb.TestAllTypesProto3::fieldName18_
+                )
+            )
+        }
     }
 
     public sealed class NestedEnum(override val value: Int, override val name: String? = null) : pbandk.Message.Enum {


### PR DESCRIPTION
The previous size of 200 worked fine when a message contained lots of fields without any custom options. But custom options on a field increase the size of the code that is generated for the field's field descriptor.  Which means we can fit fewer field descriptor constructor calls in a single method before the method's bytecode becomes too big and generates a `MethodTooLargeException`.

For now we'll just reduce the chunking size from 200 to 100 to give us some more breathing room. Sufficiently large and complex protobuf message definitions can still lead to an exception though. If that happens often then we can implement further improvements to the chunking.

Fixes #252 