### PR TITLE
Update to the latest macos runner for GitHub Actions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -15,7 +15,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             os-type: linux
-          - os: macos-12
+          - os: macos-14
             os-type: macos
       fail-fast: false
     name: Build (${{ matrix.os-type }})
@@ -161,7 +161,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             os-type: linux
-          - os: macos-12
+          - os: macos-14
             os-type: macos
       fail-fast: false
     name: Build conformance test runner (${{ matrix.os-type }})
@@ -212,7 +212,7 @@ jobs:
           - os: ubuntu-22.04
             build-os-type: linux
             platform: linux
-          - os: macos-12
+          - os: macos-14
             build-os-type: macos
             platform: macos
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -48,7 +48,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             os-type: linux
-          - os: macos-12
+          - os: macos-14
             os-type: macos
       fail-fast: false
     name: Publish (${{ matrix.os-type }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 
+* `protoc-gen-kotlin` can now be run by the `root` user. (PR [#248], fixes [#73]) (thanks @strophy)
+
+[#73]: https://github.com/streem/pbandk/issues/73
+[#248]: https://github.com/streem/pbandk/pull/248
+
 
 ## [0.16.0] - 2024-09-03
 


### PR DESCRIPTION
GitHub has removed support for the `macos-12` runner.
