### PR TITLE
Update to latest version of actions/cache

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Cache gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - name: Cache protobuf conformance-test-runner ${{ env.PROTOBUF_CONFORMANCE_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-protobuf
         with:
           path: |
@@ -233,7 +233,7 @@ jobs:
           node-version: ${{ env.NODEJS_VERSION }}
 
       - name: Cache protobuf conformance-test-runner ${{ env.PROTOBUF_CONFORMANCE_VERSION }}
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             conformance-test-runner/conformance_test_runner
@@ -272,7 +272,7 @@ jobs:
           path: ~/.m2/repository
 
       - name: Cache gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,7 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: Cache gradle
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches


### PR DESCRIPTION
`actions/cache@v2` has been deprecated by GitHub and will be removed in a couple months.