### PR TITLE
Added support for the android native platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 
+* Added support for the `androidNativeArm32` and `androidNativeArm64` platforms (PR [#293])
+
 ### Changed
 
 ### Fixed
@@ -19,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 [#73]: https://github.com/streem/pbandk/issues/73
 [#248]: https://github.com/streem/pbandk/pull/248
+[#293]: https://github.com/streem/pbandk/pull/293
 
 
 ## [0.16.0] - 2024-09-03

--- a/runtime/api/pbandk-runtime.klib.api
+++ b/runtime/api/pbandk-runtime.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs]
-// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64]
+// Targets: [androidNativeArm32, androidNativeArm64, iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs]
+// Alias: native => [androidNativeArm32, androidNativeArm64, iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, mingwX64, tvosArm64, tvosSimulatorArm64, tvosX64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -63,8 +63,8 @@ kotlin {
     tvosArm64()
     iosArm64()
     // Tier 3
-    //androidNativeArm32()
-    //androidNativeArm64()
+    androidNativeArm32()
+    androidNativeArm64()
     //androidNativeX86()
     //androidNativeX64()
     mingwX64()

--- a/test-types/build.gradle.kts
+++ b/test-types/build.gradle.kts
@@ -48,8 +48,8 @@ kotlin {
     tvosArm64()
     iosArm64()
     // Tier 3
-    //androidNativeArm32()
-    //androidNativeArm64()
+    androidNativeArm32()
+    androidNativeArm64()
     //androidNativeX86()
     //androidNativeX64()
     mingwX64()


### PR DESCRIPTION
Added support for the following platforms:
- `androidNativeArm64`
- `androidNativeArm32`

Taken inspiration from [the PR that added support for mingwX64](https://github.com/streem/pbandk/pull/276)


Ran the conformance tests for both platforms locally on an android device.
But didn't upload the modifications required to do so (modifications in the test script to also run on a connected android device using adb when a flag is passed & changes to conformance-native to support 32bit).
Tell me if I should :)